### PR TITLE
Fixes #134: Disable auto optimization for specific file formats

### DIFF
--- a/inc/3rd-party/amazon-s3-and-cloudfront/inc/classes/class-imagify-as3cf.php
+++ b/inc/3rd-party/amazon-s3-and-cloudfront/inc/classes/class-imagify-as3cf.php
@@ -338,9 +338,19 @@ class Imagify_AS3CF {
 			$auto_optimize = imagify_valid_key() && get_imagify_option( 'auto_optimize' );
 		}
 
-		if ( $is_new_upload && ! $auto_optimize ) {
-			// It's a new upload and auto-optimization is disabled.
-			return $metadata;
+		if ( $is_new_upload ) {
+			// It's a new upload.
+			if ( ! $auto_optimize ) {
+				// Auto-optimization is disabled.
+				return $metadata;
+			}
+
+			/** This filter is documented in inc/common/attachments.php. */
+			$optimize = apply_filters( 'imagify_auto_optimize_attachment', true, $attachment_id, $metadata );
+
+			if ( ! $optimize ) {
+				return $metadata;
+			}
 		}
 
 		if ( ! $is_new_upload && ! get_post_meta( $attachment_id, '_imagify_data', true ) ) {

--- a/inc/common/attachments.php
+++ b/inc/common/attachments.php
@@ -19,6 +19,22 @@ function _imagify_optimize_attachment( $metadata, $attachment_id ) {
 		return $metadata;
 	}
 
+	/**
+	 * Allow to prevent automatic optimization for a specific attachment.
+	 *
+	 * @since  1.6.12
+	 * @author Grégory Viguier
+	 *
+	 * @param bool  $optimize      True to optimize, false otherwise.
+	 * @param int   $attachment_id Attachment ID.
+	 * @param array $metadata      An array of attachment meta data.
+	 */
+	$optimize = apply_filters( 'imagify_auto_optimize_attachment', true, $attachment_id, $metadata );
+
+	if ( ! $optimize ) {
+		return $metadata;
+	}
+
 	$context     = 'wp';
 	$action      = 'imagify_async_optimize_upload_new_media';
 	$_ajax_nonce = wp_create_nonce( 'new_media-' . $attachment_id );


### PR DESCRIPTION
Introduced the filter `imagify_auto_optimize_attachment` allowing to prevent automatic optimization for a specific attachment.