### PR TITLE
Fixes #152: compatibility with WP Real Media Library plugin

### DIFF
--- a/inc/3rd-party/3rd-party.php
+++ b/inc/3rd-party/3rd-party.php
@@ -1,13 +1,19 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin\' uh?' );
 
+/**
+ * Plugins.
+ */
 require( IMAGIFY_3RD_PARTY_PATH . 'amazon-s3-and-cloudfront/amazon-s3-and-cloudfront.php' );
 require( IMAGIFY_3RD_PARTY_PATH . 'enable-media-replace/enable-media-replace.php' );
 require( IMAGIFY_3RD_PARTY_PATH . 'nextgen-gallery/nextgen-gallery.php' );
 require( IMAGIFY_3RD_PARTY_PATH . 'screets-lc.php' );
+require( IMAGIFY_3RD_PARTY_PATH . 'wp-real-media-library.php' );
 require( IMAGIFY_3RD_PARTY_PATH . 'wp-retina-2x.php' );
 require( IMAGIFY_3RD_PARTY_PATH . 'wp-rocket.php' );
 require( IMAGIFY_3RD_PARTY_PATH . 'yoast-seo.php' );
 
-// Hosting.
+/**
+ * Hosting.
+ */
 require( IMAGIFY_3RD_PARTY_PATH . 'hosting/wpengine.php' );

--- a/inc/3rd-party/nextgen-gallery/inc/admin/enqueue.php
+++ b/inc/3rd-party/nextgen-gallery/inc/admin/enqueue.php
@@ -11,7 +11,6 @@ add_action( 'imagify_assets_enqueued', '_imagify_ngg_admin_print_styles' );
  * @author Grégory Viguier
  */
 function _imagify_ngg_admin_print_styles() {
-	global $admin_page_hooks;
 	$assets = Imagify_Assets::get_instance();
 
 	/**
@@ -25,10 +24,7 @@ function _imagify_ngg_admin_print_styles() {
 	/**
 	 * NGG Bulk Optimization.
 	 */
-	// Because WP nonsense, the screen ID depends on the menu title, which is translated. So the screen ID changes depending on the administration locale.
-	$ngg_menu_slug  = defined( 'NGGFOLDER' ) ? plugin_basename( NGGFOLDER ) : 'nextgen-gallery';
-	$ngg_menu_slug  = isset( $admin_page_hooks[ $ngg_menu_slug ] ) ? $admin_page_hooks[ $ngg_menu_slug ] : 'gallery';
-	$bulk_screen_id = $ngg_menu_slug . '_page_' . IMAGIFY_SLUG . '-ngg-bulk-optimization';
+	$bulk_screen_id = imagify_get_ngg_bulk_screen_id();
 
 	if ( ! imagify_is_screen( $bulk_screen_id ) ) {
 		return;

--- a/inc/3rd-party/nextgen-gallery/inc/functions/common.php
+++ b/inc/3rd-party/nextgen-gallery/inc/functions/common.php
@@ -19,3 +19,21 @@ function imagify_get_ngg_capacity( $capacity = 'edit_post', $describer = 'manual
 
 	return $capacity;
 }
+
+/**
+ * Get NGG Bulk Optimization screen ID.
+ * Because WP nonsense, the screen ID depends on the menu title, which is translated. So the screen ID changes depending on the administration locale.
+ *
+ * @since  1.6.13
+ * @author Grégory Viguier
+ *
+ * @return string
+ */
+function imagify_get_ngg_bulk_screen_id() {
+	global $admin_page_hooks;
+
+	$ngg_menu_slug  = defined( 'NGGFOLDER' ) ? plugin_basename( NGGFOLDER ) : 'nextgen-gallery';
+	$ngg_menu_slug  = isset( $admin_page_hooks[ $ngg_menu_slug ] ) ? $admin_page_hooks[ $ngg_menu_slug ] : 'gallery';
+
+	return $ngg_menu_slug . '_page_' . IMAGIFY_SLUG . '-ngg-bulk-optimization';
+}

--- a/inc/3rd-party/wp-real-media-library.php
+++ b/inc/3rd-party/wp-real-media-library.php
@@ -1,0 +1,61 @@
+<?php
+defined( 'ABSPATH' ) || die( 'Cheatin\' uh?' );
+
+if ( defined( 'RML_FILE' ) ) :
+
+	/**
+	 * Prevent WP Real Media Library to use its outdated version of SweetAlert where we need ours.
+	 */
+	add_action( 'current_screen', 'imagify_wprml_init' );
+	/**
+	 * Dequeue WP Real Media Library's version of SweetAlert when we need ours.
+	 *
+	 * @since  1.6.13
+	 * @author Grégory Viguier
+	 */
+	function imagify_wprml_init() {
+		static $done = false;
+
+		if ( $done ) {
+			return;
+		}
+		$done = true;
+
+		if ( ! class_exists( 'MatthiasWeb\RealMediaLibrary\general\Backend' ) ) {
+			return;
+		}
+
+		$notices = Imagify_Notices::get_instance();
+
+		if ( $notices->has_notices() && ( $notices->display_welcome_steps() || $notices->display_wrong_api_key() ) ) {
+			// We display a notice that uses SweetAlert.
+			imgfyrml_dequeue();
+			return;
+		}
+
+		if ( imagify_is_screen( 'bulk' ) || imagify_is_screen( 'imagify-settings' ) ) {
+			// We display a page that uses SweetAlert.
+			imgfyrml_dequeue();
+			return;
+		}
+
+		if ( function_exists( 'imagify_get_ngg_bulk_screen_id' ) && imagify_is_screen( imagify_get_ngg_bulk_screen_id() ) ) {
+			// We display the NGG Bulk Optimization page.
+			imgfyrml_dequeue();
+		}
+	}
+
+	/**
+	 * Prevent WP Real Media Library to enqueue its version of SweetAlert.
+	 *
+	 * @since  1.6.13
+	 * @author Grégory Viguier
+	 */
+	function imgfyrml_dequeue() {
+		$instance = MatthiasWeb\RealMediaLibrary\general\Backend::getInstance();
+
+		remove_action( 'admin_enqueue_scripts', array( $instance, 'admin_enqueue_scripts' ), 0 );
+		remove_action( 'admin_footer',          array( $instance, 'admin_footer' ) );
+	}
+
+endif;

--- a/inc/3rd-party/wp-real-media-library.php
+++ b/inc/3rd-party/wp-real-media-library.php
@@ -29,19 +29,19 @@ if ( defined( 'RML_FILE' ) ) :
 
 		if ( $notices->has_notices() && ( $notices->display_welcome_steps() || $notices->display_wrong_api_key() ) ) {
 			// We display a notice that uses SweetAlert.
-			imgfyrml_dequeue();
+			imagify_wprml_dequeue();
 			return;
 		}
 
 		if ( imagify_is_screen( 'bulk' ) || imagify_is_screen( 'imagify-settings' ) ) {
 			// We display a page that uses SweetAlert.
-			imgfyrml_dequeue();
+			imagify_wprml_dequeue();
 			return;
 		}
 
 		if ( function_exists( 'imagify_get_ngg_bulk_screen_id' ) && imagify_is_screen( imagify_get_ngg_bulk_screen_id() ) ) {
 			// We display the NGG Bulk Optimization page.
-			imgfyrml_dequeue();
+			imagify_wprml_dequeue();
 		}
 	}
 
@@ -51,7 +51,7 @@ if ( defined( 'RML_FILE' ) ) :
 	 * @since  1.6.13
 	 * @author Grégory Viguier
 	 */
-	function imgfyrml_dequeue() {
+	function imagify_wprml_dequeue() {
 		$instance = MatthiasWeb\RealMediaLibrary\general\Backend::getInstance();
 
 		remove_action( 'admin_enqueue_scripts', array( $instance, 'admin_enqueue_scripts' ), 0 );


### PR DESCRIPTION
This prevents this plugin to enqueue its outdated version of SweetAlert on the screens we use ours: some of our notices, bulk optimization page, settings page, NGG bulk optimization page.