### PR TITLE
Fixes #162: release the JOIN kraken

### DIFF
--- a/inc/classes/class-imagify-admin-ajax-post.php
+++ b/inc/classes/class-imagify-admin-ajax-post.php
@@ -418,6 +418,8 @@ class Imagify_Admin_Ajax_Post {
 		$mime_types = esc_sql( $mime_types );
 		$mime_types = "'" . implode( "','", $mime_types ) . "'";
 
+		imagify_unlimit_sql_joins();
+
 		$ids = $wpdb->get_col( $wpdb->prepare( // WPCS: unprepared SQL ok.
 			"SELECT $wpdb->posts.ID
 			FROM $wpdb->posts

--- a/inc/functions/admin-stats.php
+++ b/inc/functions/admin-stats.php
@@ -97,6 +97,8 @@ function imagify_count_error_attachments() {
 	$mime_types = esc_sql( $mime_types );
 	$mime_types = "'" . implode( "','", $mime_types ) . "'";
 
+	imagify_unlimit_sql_joins();
+
 	$count = (int) $wpdb->get_var( // WPCS: unprepared SQL ok.
 		"
 		SELECT COUNT( $wpdb->posts.ID )
@@ -149,6 +151,8 @@ function imagify_count_optimized_attachments() {
 	$mime_types = get_imagify_mime_type();
 	$mime_types = esc_sql( $mime_types );
 	$mime_types = "'" . implode( "','", $mime_types ) . "'";
+
+	imagify_unlimit_sql_joins();
 
 	$count = (int) $wpdb->get_var( // WPCS: unprepared SQL ok.
 		"

--- a/inc/functions/common.php
+++ b/inc/functions/common.php
@@ -247,3 +247,35 @@ function imagify_get_external_url( $target, $query_args = array() ) {
 
 	return $url;
 }
+
+/**
+ * Some hosts limit the number of JOINs in SQL queries, but we need them.
+ *
+ * @since  1.6.13
+ * @author Grégory Viguier
+ */
+function imagify_unlimit_sql_joins() {
+	global $wpdb;
+	static $done = false;
+
+	if ( $done ) {
+		return;
+	}
+
+	$done  = true;
+	$query = 'SET SQL_BIG_SELECTS=1';
+
+	/**
+	 * Filter the SQL query allowing to remove the limit on JOINs.
+	 *
+	 * @since  1.6.13
+	 * @author Grégory Viguier
+	 *
+	 * @param string|bool $query The query. False to prevent any query.
+	 */
+	$query = apply_filters( 'imagify_unlimit_sql_joins_query', $query );
+
+	if ( $query && is_string( $query ) ) {
+		$wpdb->query( $query ); // WPCS: unprepared SQL ok.
+	}
+}


### PR DESCRIPTION
Introduced `imagify_unlimit_sql_joins()` to prevent hosts to limit the number of `JOIN`s in SQL queries.