### PR TITLE
Fixes #163: compatibility with Heartbeat Control

### DIFF
--- a/inc/classes/class-imagify-assets.php
+++ b/inc/classes/class-imagify-assets.php
@@ -123,7 +123,7 @@ class Imagify_Assets {
 			return;
 		}
 
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles_and_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles_and_scripts' ), IMAGIFY_INT_MAX );
 		add_action( 'wp_enqueue_media',      array( $this, 'enqueue_media_modal' ) );
 
 		add_action( 'admin_footer-media_page_imagify-bulk-optimization', array( $this, 'print_support_script' ) );


### PR DESCRIPTION
Use a very low hook priority to enqueue Imagify styles and scripts: this allows to re-register heartbeat after Heartbeat Control plugin unregistered it.