### PR TITLE
Fixes #166: compatibility Formidable Forms Pro

### DIFF
--- a/inc/3rd-party/3rd-party.php
+++ b/inc/3rd-party/3rd-party.php
@@ -3,6 +3,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin\' uh?' );
 
 require( IMAGIFY_3RD_PARTY_PATH . 'amazon-s3-and-cloudfront/amazon-s3-and-cloudfront.php' );
 require( IMAGIFY_3RD_PARTY_PATH . 'enable-media-replace/enable-media-replace.php' );
+require( IMAGIFY_3RD_PARTY_PATH . 'formidable-pro/formidable-pro.php' );
 require( IMAGIFY_3RD_PARTY_PATH . 'nextgen-gallery/nextgen-gallery.php' );
 require( IMAGIFY_3RD_PARTY_PATH . 'screets-lc.php' );
 require( IMAGIFY_3RD_PARTY_PATH . 'wp-retina-2x.php' );

--- a/inc/3rd-party/formidable-pro/formidable-pro.php
+++ b/inc/3rd-party/formidable-pro/formidable-pro.php
@@ -1,0 +1,8 @@
+<?php
+defined( 'ABSPATH' ) || die( 'Cheatin\' uh?' );
+
+if ( class_exists( 'FrmProEddController' ) ) :
+
+	Imagify_Formidable_Pro::get_instance()->init();
+
+endif;

--- a/inc/3rd-party/formidable-pro/inc/classes/class-imagify-formidable-pro.php
+++ b/inc/3rd-party/formidable-pro/inc/classes/class-imagify-formidable-pro.php
@@ -1,0 +1,99 @@
+<?php
+defined( 'ABSPATH' ) || die( 'Cheatin\' uh?' );
+
+/**
+ * Compat class for Formidable Forms Pro plugin.
+ * Each call to `new WP_Query()` made by Imagify must have a `'is_imagify' => true` argument.
+ *
+ * @since  1.6.13
+ * @author Grégory Viguier
+ */
+class Imagify_Formidable_Pro {
+
+	/**
+	 * Class version.
+	 *
+	 * @var string
+	 */
+	const VERSION = '1.0';
+
+	/**
+	 * Set to true when the current query comes from Imagify.
+	 *
+	 * @var int
+	 */
+	protected $is_imagify;
+
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var object
+	 */
+	protected static $_instance;
+
+	/**
+	 * Get the main instance.
+	 *
+	 * Ensures only one instance of class is loaded or can be loaded.
+	 *
+	 * @since  1.6.13
+	 * @author Grégory Viguier
+	 *
+	 * @return object Main instance.
+	 */
+	public static function get_instance() {
+		if ( ! isset( self::$_instance ) ) {
+			self::$_instance = new self();
+		}
+
+		return self::$_instance;
+	}
+
+	/**
+	 * The class constructor.
+	 *
+	 * @since  1.6.13
+	 * @author Grégory Viguier
+	 */
+	protected function __construct() {}
+
+	/**
+	 * Launch the hooks.
+	 *
+	 * @since  1.6.13
+	 * @author Grégory Viguier
+	 */
+	public function init() {
+		add_action( 'parse_query',     array( $this, 'maybe_remove_media_library_filter' ) );
+		add_action( 'posts_selection', array( $this, 'maybe_put_media_library_filter_back' ) );
+	}
+
+	/**
+	 * Fires before the 'pre_get_posts' hook.
+	 *
+	 * @since  1.6.13
+	 * @author Grégory Viguier
+	 *
+	 * @param object $wp_query The WP_Query instance (passed by reference).
+	 */
+	public function maybe_remove_media_library_filter( $wp_query ) {
+		if ( ! empty( $wp_query->query_vars['is_imagify'] ) && class_exists( 'FrmProFileField' ) ) {
+			$this->is_imagify = true;
+			remove_action( 'pre_get_posts', 'FrmProFileField::filter_media_library', 99 );
+		} else {
+			$this->is_imagify = false;
+		}
+	}
+
+	/**
+	 * Fires after the 'pre_get_posts' hook.
+	 *
+	 * @since  1.6.13
+	 * @author Grégory Viguier
+	 */
+	public function maybe_put_media_library_filter_back() {
+		if ( $this->is_imagify ) {
+			add_action( 'pre_get_posts', 'FrmProFileField::filter_media_library', 99 );
+		}
+	}
+}

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -69,6 +69,7 @@ function _imagify_new_upgrade( $imagify_version, $current_version ) {
 	if ( version_compare( $current_version, '1.2' ) < 0 ) {
 		// Update all already optimized images status from 'error' to 'already_optimized'.
 		$query = new WP_Query( array(
+			'is_imagify'             => true,
 			'post_type'              => 'attachment',
 			'post_status'            => 'inherit',
 			'post_mime_type'         => 'image',
@@ -102,6 +103,7 @@ function _imagify_new_upgrade( $imagify_version, $current_version ) {
 	if ( version_compare( $current_version, '1.3.2' ) < 0 ) {
 		// Update all already optimized images status from 'error' to 'already_optimized'.
 		$query = new WP_Query( array(
+			'is_imagify'             => true,
 			'post_type'              => 'attachment',
 			'post_status'            => 'inherit',
 			'post_mime_type'         => 'image',

--- a/inc/functions/admin-stats.php
+++ b/inc/functions/admin-stats.php
@@ -445,6 +445,7 @@ function imagify_calculate_total_size_images_library() {
  */
 function imagify_calculate_average_size_images_per_month() {
 	$query = array(
+		'is_imagify'     => true,
 		'post_type'      => 'attachment',
 		'post_status'    => 'inherit',
 		'post_mime_type' => get_imagify_mime_type(),

--- a/inc/functions/common.php
+++ b/inc/functions/common.php
@@ -157,6 +157,7 @@ function imagify_autoload( $class ) {
 		'Imagify_AS3CF_Attachment'     => 'amazon-s3-and-cloudfront',
 		'Imagify_AS3CF'                => 'amazon-s3-and-cloudfront',
 		'Imagify_Enable_Media_Replace' => 'enable-media-replace',
+		'Imagify_Formidable_Pro'       => 'formidable-pro',
 		'Imagify_NGG_Attachment'       => 'nextgen-gallery',
 		'Imagify_NGG_DB'               => 'nextgen-gallery',
 		'Imagify_NGG_Storage'          => 'nextgen-gallery',


### PR DESCRIPTION
When a query is made by Imagify, the `pre_get_posts` hook from FFP is removed (and put back later).