### PR TITLE
Fixes #180: Images are not showing in the comparison tool

### DIFF
--- a/assets/js/jquery.twentytwenty.js
+++ b/assets/js/jquery.twentytwenty.js
@@ -1,65 +1,52 @@
-/* eslint-disable */
-(function($, d, w, undefined) {
+(function($, d, w, undefined) { // eslint-disable-line no-unused-vars, no-shadow, no-shadow-restricted-names
 
-	$.fn.twentytwenty = function(options, callback) {
-		options = $.extend({
+	$.fn.twentytwenty = function( options, callback ) {
+		options = $.extend( {
 			handlePosition: 0.5,
 			orientation:    'horizontal',
 			labelBefore:    'Before',
 			labelAfter:     'After'
-		}, options);
+		}, options );
 
-		return this.each(function() {
+		return this.each( function() {
 			var sliderPct         = options.handlePosition,
-				$container        = $(this),
+				$container        = $( this ),
 				sliderOrientation = options.orientation,
-				beforeDirection   = (sliderOrientation === 'vertical') ? 'down' : 'left',
-				afterDirection    = (sliderOrientation === 'vertical') ? 'up' : 'right',
-				$beforeImg        = $container.find('img:first'),
-				$afterImg         = $container.find('img:last');
+				beforeDirection   = ( 'vertical' === sliderOrientation ) ? 'down' : 'left',
+				afterDirection    = ( 'vertical' === sliderOrientation ) ? 'up'   : 'right',
+				$beforeImg        = $container.find( 'img:first' ),
+				$afterImg         = $container.find( 'img:last' ),
+				offsetX           = 0,
+				offsetY           = 0,
+				imgWidth          = 0,
+				imgHeight         = 0,
+				$slider, $overlay,
+				calcOffset = function( dimensionPct ) {
+					var width  = parseInt( $beforeImg.attr( 'width' ), 10 ),
+						height = parseInt( $beforeImg.attr( 'height' ), 10 );
 
+					if ( ! width || ! height ) {
+						width  = parseInt( $beforeImg.width(), 10 );
+						height = parseInt( $beforeImg.height(), 10 );
+					}
 
-			$container.wrap('<div class="twentytwenty-wrapper twentytwenty-' + sliderOrientation + '"></div>');
-			$container.append('<div class="twentytwenty-overlay"></div>');
-			$container.append('<div class="twentytwenty-handle"></div>');
-
-			var $slider = $container.find('.twentytwenty-handle');
-
-			$slider.append('<span class="twentytwenty-' + beforeDirection + '-arrow"></span>');
-			$slider.append('<span class="twentytwenty-' + afterDirection + '-arrow"></span>');
-			$container.addClass('twentytwenty-container');
-			$beforeImg.addClass('twentytwenty-before');
-			$afterImg.addClass('twentytwenty-after');
-
-			var $overlay = $container.find('.twentytwenty-overlay');
-
-			$overlay.append('<div class="twentytwenty-labels twentytwenty-before-label"><span class="twentytwenty-label-content">' + options.labelBefore + '</span></div>');
-			$overlay.append('<div class="twentytwenty-labels twentytwenty-after-label"><span class="twentytwenty-label-content">' + options.labelAfter + '</span></div>');
-
-
-			// some usefull function and vars declarations
-
-			var calcOffset = function(dimensionPct) {
-					var w = $beforeImg.width();
-					var h = $beforeImg.height();
 					return {
-						w: w+"px",
-						h: h+"px",
-						cw: (dimensionPct*w)+"px",
-						ch: (dimensionPct*h)+"px"
+						w:  width  + "px",
+						h:  height + "px",
+						cw: ( dimensionPct * width )  + "px",
+						ch: ( dimensionPct * height ) + "px"
 					};
 				},
-
 				adjustContainer = function( offset ) {
-					// make it dynamic, in case "before" image change
-					var $beforeImg = $container.find('.twentytwenty-before');
+					// Make it dynamic, in case the "before" image changes.
+					var $beforeImage = $container.find( '.twentytwenty-before' );
 
-					if ( sliderOrientation === 'vertical' ) {
-						$beforeImg.css( 'clip', 'rect(0,' + offset.w + ',' + offset.ch + ',0)' );
+					if ( 'vertical' === sliderOrientation ) {
+						$beforeImage.css( 'clip', 'rect(0,' + offset.w + ',' + offset.ch + ',0)' );
+					} else {
+						$beforeImage.css( 'clip', 'rect(0,' + offset.cw + ',' + offset.h + ',0)' );
 					}
-					else {
-						$beforeImg.css( 'clip', 'rect(0,' + offset.cw + ',' + offset.h + ',0)' );
-					}
+
 					$container.css( 'height', offset.h );
 
 					if ( typeof callback === 'function' ) {
@@ -67,62 +54,81 @@
 					}
 				},
 				adjustSlider = function( pct ) {
-					var offset = calcOffset(pct);
-					$slider.css( ( sliderOrientation === 'vertical' ) ? 'top' : 'left', ( sliderOrientation === 'vertical' ) ? offset.ch : offset.cw );
+					var offset = calcOffset( pct );
+
+					if ( 'vertical' === sliderOrientation ) {
+						$slider.css( 'top', offset.ch );
+					} else {
+						$slider.css( 'left', offset.cw );
+					}
+
 					adjustContainer( offset );
-				},
-				offsetX = 0,
-				offsetY = 0,
-				imgWidth = 0,
-				imgHeight = 0;
+				};
 
-			$( w ).on('resize.twentytwenty', function() {
+
+			$container.wrap( '<div class="twentytwenty-wrapper twentytwenty-' + sliderOrientation + '"></div>' );
+			$container.append( '<div class="twentytwenty-overlay"></div>' );
+			$container.append( '<div class="twentytwenty-handle"></div>' );
+
+			$slider = $container.find( '.twentytwenty-handle' );
+
+			$slider.append( '<span class="twentytwenty-' + beforeDirection + '-arrow"></span>' );
+			$slider.append( '<span class="twentytwenty-' + afterDirection + '-arrow"></span>' );
+			$container.addClass( 'twentytwenty-container' );
+			$beforeImg.addClass( 'twentytwenty-before' );
+			$afterImg.addClass( 'twentytwenty-after' );
+
+			$overlay = $container.find( '.twentytwenty-overlay' );
+
+			$overlay.append( '<div class="twentytwenty-labels twentytwenty-before-label"><span class="twentytwenty-label-content">' + options.labelBefore + '</span></div>' );
+			$overlay.append( '<div class="twentytwenty-labels twentytwenty-after-label"><span class="twentytwenty-label-content">' + options.labelAfter + '</span></div>' );
+
+			$( w ).on( 'resize.twentytwenty', function() {
 				adjustSlider( sliderPct );
-			});
+			} );
 
-			$slider.on('movestart', function(e) {
-				if ( ( ( e.distX > e.distY && e.distX < -e.distY ) || ( e.distX < e.distY && e.distX > -e.distY ) ) && sliderOrientation !== 'vertical' ) {
+			$slider.on( 'movestart', function( e ) {
+				if ( 'vertical' !== sliderOrientation && ( ( e.distX > e.distY && e.distX < -e.distY ) || ( e.distX < e.distY && e.distX > -e.distY ) ) ) {
+					e.preventDefault();
+				} else if ( 'vertical' === sliderOrientation && ( ( e.distX < e.distY && e.distX < -e.distY ) || ( e.distX > e.distY && e.distX > -e.distY ) ) ) {
 					e.preventDefault();
 				}
-				else if ( ( ( e.distX < e.distY && e.distX < -e.distY ) || ( e.distX > e.distY && e.distX > -e.distY ) ) && sliderOrientation === 'vertical' ) {
-					e.preventDefault();
-				}
-				$container.addClass('active');
-				offsetX 	= $container.offset().left;
-				offsetY 	= $container.offset().top;
-				imgWidth 	= $beforeImg.width();
-				imgHeight 	= $beforeImg.height();
-			});
 
-			$slider.on('moveend', function() {
-				$container.removeClass('active');
-			});
+				$container.addClass( 'active' );
 
-			$slider.on('move', function(e) {
+				offsetX   = $container.offset().left;
+				offsetY   = $container.offset().top;
+				imgWidth  = $beforeImg.width();
+				imgHeight = $beforeImg.height();
+			} );
+
+			$slider.on( 'moveend', function() {
+				$container.removeClass( 'active' );
+			} );
+
+			$slider.on( 'move', function( e ) {
 				if ( $container.hasClass('active') ) {
-
-					sliderPct = ( sliderOrientation === 'vertical' ) ? ( e.pageY-offsetY )/imgHeight : ( e.pageX-offsetX )/imgWidth;
+					sliderPct = 'vertical' === sliderOrientation ? ( e.pageY - offsetY ) / imgHeight : ( e.pageX - offsetX ) / imgWidth;
 
 					if ( sliderPct < 0 ) {
 						sliderPct = 0;
-					}
-					if ( sliderPct > 1 ) {
+					} else if ( sliderPct > 1 ) {
 						sliderPct = 1;
 					}
+
 					adjustSlider( sliderPct );
 				}
-			});
+			} );
 
-			$container.find('img').on('mousedown', function(event) {
-				event.preventDefault();
-			});
+			$container.find( 'img' ).on( 'mousedown', function( e ) {
+				e.preventDefault();
+			} );
 
-			$( w ).trigger('resize.twentytwenty');
-		});
+			$( w ).trigger( 'resize.twentytwenty' );
+		} );
 	};
 
 } )(jQuery, document, window);
-/* eslint-enable */
 
 /**
  * Twentytwenty Imagify Init

--- a/assets/js/jquery.twentytwenty.min.js
+++ b/assets/js/jquery.twentytwenty.min.js
@@ -1,1 +1,652 @@
-!function(a,b,c,d){a.fn.twentytwenty=function(b,d){return b=a.extend({handlePosition:.5,orientation:"horizontal",labelBefore:"Before",labelAfter:"After"},b),this.each(function(){var e=b.handlePosition,f=a(this),g=b.orientation,h="vertical"===g?"down":"left",i="vertical"===g?"up":"right",j=f.find("img:first"),k=f.find("img:last");f.wrap('<div class="twentytwenty-wrapper twentytwenty-'+g+'"></div>'),f.append('<div class="twentytwenty-overlay"></div>'),f.append('<div class="twentytwenty-handle"></div>');var l=f.find(".twentytwenty-handle");l.append('<span class="twentytwenty-'+h+'-arrow"></span>'),l.append('<span class="twentytwenty-'+i+'-arrow"></span>'),f.addClass("twentytwenty-container"),j.addClass("twentytwenty-before"),k.addClass("twentytwenty-after");var m=f.find(".twentytwenty-overlay");m.append('<div class="twentytwenty-labels twentytwenty-before-label"><span class="twentytwenty-label-content">'+b.labelBefore+"</span></div>"),m.append('<div class="twentytwenty-labels twentytwenty-after-label"><span class="twentytwenty-label-content">'+b.labelAfter+"</span></div>");var n=function(a){var b=j.width(),c=j.height();return{w:b+"px",h:c+"px",cw:a*b+"px",ch:a*c+"px"}},o=function(a){var b=f.find(".twentytwenty-before");"vertical"===g?b.css("clip","rect(0,"+a.w+","+a.ch+",0)"):b.css("clip","rect(0,"+a.cw+","+a.h+",0)"),f.css("height",a.h),"function"==typeof d&&d()},p=function(a){var b=n(a);l.css("vertical"===g?"top":"left","vertical"===g?b.ch:b.cw),o(b)},q=0,r=0,s=0,t=0;a(c).on("resize.twentytwenty",function(){p(e)}),l.on("movestart",function(a){(a.distX>a.distY&&a.distX<-a.distY||a.distX<a.distY&&a.distX>-a.distY)&&"vertical"!==g?a.preventDefault():(a.distX<a.distY&&a.distX<-a.distY||a.distX>a.distY&&a.distX>-a.distY)&&"vertical"===g&&a.preventDefault(),f.addClass("active"),q=f.offset().left,r=f.offset().top,s=j.width(),t=j.height()}),l.on("moveend",function(){f.removeClass("active")}),l.on("move",function(a){f.hasClass("active")&&(e="vertical"===g?(a.pageY-r)/t:(a.pageX-q)/s,e<0&&(e=0),e>1&&(e=1),p(e))}),f.find("img").on("mousedown",function(a){a.preventDefault()}),a(c).trigger("resize.twentytwenty")})}}(jQuery,document,window),function(a,b,c,d){var e=function(b){b.each(function(){var b=a(this),c=parseInt(b.closest(".imagify-chart").next(".imagify-chart-value").text(),10),d=[{value:c,color:"#00B3D3"},{value:100-c,color:"#D8D8D8"}];new Chart(b[0].getContext("2d")).Doughnut(d,{segmentStrokeColor:"#2A2E3C",segmentStrokeWidth:1,animateRotate:!0,percentageInnerCutout:60,tooltipEvents:[]})})},f=function(b){var d,f={width:0,height:0,originalUrl:"",optimizedUrl:"",originalSize:0,optimizedSize:0,saving:0,modalAppendTo:a("body"),trigger:a('[data-target="imagify-visual-comparison"]'),modalId:"imagify-visual-comparison",openModal:!1},g=a.extend({},f,b);if(0===g.width||0===g.height||""===g.originalUrl||""===g.optimizedUrl||0===g.originalSize||0===g.optimizedSize||0===g.saving)return"error";d='<div id="'+g.modalId+'" class="imagify-modal imagify-visual-comparison" aria-hidden="true">',d+='<div class="imagify-modal-content loading">',d+='<div class="twentytwenty-container">',d+='<img class="imagify-img-before" alt="" width="'+g.width+'" height="'+g.height+'">',d+='<img class="imagify-img-after" alt="" width="'+g.width+'" height="'+g.height+'">',d+="</div>",d+='<div class="imagify-comparison-levels">',d+='<div class="imagify-c-level imagify-level-original go-left">',d+='<p class="imagify-c-level-row">',d+='<span class="label">'+imagifyTTT.labels.filesize+"</span>",d+='<span class="value level">'+g.originalSize+"</span>",d+="</p>",d+="</div>",d+='<div class="imagify-c-level imagify-level-optimized go-right">',d+='<p class="imagify-c-level-row">',d+='<span class="label">'+imagifyTTT.labels.filesize+"</span>",d+='<span class="value level">'+g.optimizedSize+"</span>",d+="</p>",d+='<p class="imagify-c-level-row">',d+='<span class="label">'+imagifyTTT.labels.saving+"</span>",d+='<span class="value"><span class="imagify-chart"><span class="imagify-chart-container"><canvas id="imagify-consumption-chart-normal" width="15" height="15"></canvas></span></span><span class="imagify-chart-value">'+g.saving+"</span>%</span>",d+="</p>",d+="</div>",d+="</div>",d+='<button class="close-btn absolute" type="button"><i aria-hidden="true" class="dashicons dashicons-no-alt"></i><span class="screen-reader-text">'+imagifyTTT.labels.close+"</span></button>",d+="</div>",d+="</div>",g.modalAppendTo.append(d),g.trigger.on("click.imagify",function(b){var d,f,h=a(a(this).data("target")),i=0;b.preventDefault(),g.openModal&&c.imagify.openModal(a(this)),h.find(".imagify-modal-content").css({width:.85*a(c).outerWidth()+"px","max-width":g.width}),h.find(".imagify-img-before").on("load",function(){i++}).attr("src",g.originalUrl),h.find(".imagify-img-after").on("load",function(){i++}).attr("src",g.optimizedUrl+(g.optimizedUrl.indexOf("?")>0?"&":"?")+"v="+Date.now()),d=h.find(".twentytwenty-container"),f=setInterval(function(){if(2===i)return d.twentytwenty({handlePosition:.3,orientation:"horizontal",labelBefore:imagifyTTT.labels.originalL,labelAfter:imagifyTTT.labels.optimizedL},function(){var b,f,g,i,j,k,l=a(c).height(),m=h.find(".twentytwenty-container").height(),n=h.find(".twentytwenty-wrapper").position().top;d.closest(".imagify-modal-content").hasClass("loaded")||(d.closest(".imagify-modal-content").removeClass("loading").addClass("loaded"),e(h.find(".imagify-level-optimized .imagify-chart canvas"))),l<m&&!h.hasClass("modal-is-too-high")&&(h.addClass("modal-is-too-high"),b=h.find(".twentytwenty-handle"),f=h.find(".twentytwenty-label-content"),g=h.find(".imagify-comparison-levels"),i=g.outerHeight(),j=(l-n-b.height())/2,k=l-3*n-i,b.css({top:j}),f.css({top:k,bottom:"auto"}),h.find(".twentytwenty-wrapper").css({paddingBottom:i}),h.find(".imagify-modal-content").on("scroll.imagify",function(){var c=a(this).scrollTop();b.css({top:j+c}),f.css({top:k+c}),g.css({bottom:-c})}))}),clearInterval(f),f=null,"done"},75)})};if(a(".imagify-visual-comparison-btn").on("click",function(){var b,d,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,A,B;1!==a(".twentytwenty-wrapper").length&&(a(a(this).data("target")).find(".imagify-modal-content").css("width",.95*a(c).outerWidth()+"px"),a(".twentytwenty-container").length>0&&a(c).outerWidth()<=800||(b=a(".twentytwenty-container"),d=0,f=b.data("loader"),g=b.data("label-original"),h=b.data("label-normal"),i=b.data("label-aggressive"),j=b.data("label-ultra"),k=b.data("original-label").replace(/\*\*/,"<strong>").replace(/\*\*/,"</strong>"),l=b.data("original-alt"),m=b.data("original-img"),n=b.data("original-dim").split("x"),o=b.data("normal-alt"),p=b.data("normal-img"),q=b.data("normal-dim").split("x"),r=b.data("aggressive-alt"),s=b.data("aggressive-img"),t=b.data("aggressive-dim").split("x"),u=b.data("ultra-label").replace(/\*\*/,"<strong>").replace(/\*\*/,"</strong>"),v=b.data("ultra-alt"),w=b.data("ultra-img"),x=b.data("ultra-dim").split("x"),y='<span class="twentytwenty-duo-buttons twentytwenty-duo-left">',y+='<button type="button" class="imagify-comparison-original selected" data-img="original">'+g+"</button>",y+='<button type="button" class="imagify-comparison-normal" data-img="normal">'+h+"</button>",y+='<button type="button" class="imagify-comparison-aggressive" data-img="aggressive">'+i+"</button>",y+="</span>",z='<span class="twentytwenty-duo-buttons twentytwenty-duo-right">',z+='<button type="button" class="imagify-comparison-normal" data-img="normal">'+h+"</button>",z+='<button type="button" class="imagify-comparison-aggressive" data-img="aggressive">'+i+"</button>",z+='<button type="button" class="imagify-comparison-ultra selected" data-img="ultra">'+j+"</button>",z+="</span>",b.before('<img class="loader" src="'+f+'" alt="Loading…" width="64" height="64">'),a(".twentytwenty-left-buttons").append(y),a(".twentytwenty-right-buttons").append(z),A='<img class="img-original" alt="'+l+'" width="'+n[0]+'" height="'+n[1]+'">',A+='<img class="img-normal" alt="'+o+'" width="'+q[0]+'" height="'+q[1]+'">',A+='<img class="img-aggressive" alt="'+r+'" width="'+t[0]+'" height="'+t[1]+'">',A+='<img class="img-ultra" alt="'+v+'" width="'+x[0]+'" height="'+x[1]+'">',A+=a(".twentytwenty-left-buttons").lenght?y+z:"",b.closest(".imagify-modal-content").addClass("loading").find(".twentytwenty-container").append(A),a(".img-original").on("load",function(){d++}).attr("src",m),a(".img-normal").on("load",function(){d++}).attr("src",p),a(".img-aggressive").on("load",function(){d++}).attr("src",s),a(".img-ultra").on("load",function(){d++}).attr("src",w),B=setInterval(function(){4===d&&(b.twentytwenty({handlePosition:.6,orientation:"horizontal",labelBefore:k,labelAfter:u},function(){b.closest(".imagify-modal-content").hasClass("loaded")||(b.closest(".imagify-modal-content").removeClass("loading").addClass("loaded"),e(a(".imagify-level-ultra .imagify-chart canvas")))}),clearInterval(B),B=null)},75),a(".imagify-comparison-title").on("click",".twentytwenty-duo-buttons button:not(.selected)",function(b){var c,d=a(this),f=d.closest(".imagify-comparison-title").nextAll(".twentytwenty-wrapper").find(".twentytwenty-container"),g=d.closest(".twentytwenty-duo-buttons").hasClass("twentytwenty-duo-left")?"left":"right",h="left"===g?d.closest(".imagify-comparison-title").find(".twentytwenty-duo-right"):d.closest(".imagify-comparison-title").find(".twentytwenty-duo-left"),i=d.closest(".twentytwenty-duo-buttons").find("button"),j=f.find(".twentytwenty-before"),k=f.find(".twentytwenty-after"),l=d.data("img");b.stopPropagation(),b.preventDefault(),i.removeClass("selected"),d.addClass("selected"),h.find(".selected").data("img")===l&&h.find("button:not(.selected)").eq(0).trigger("click"),"left"===g&&(c=j.css("clip"),j.attr("style",""),j.removeClass("twentytwenty-before"),f.find(".img-"+l).addClass("twentytwenty-before").css("clip",c),a(".twentytwenty-before-label .twentytwenty-label-content").text(f.data(l+"-label")),a(".imagify-c-level.go-left").attr("aria-hidden","true").removeClass("go-left go-right"),a(".imagify-level-"+l).attr("aria-hidden","false").addClass("go-left")),"right"===g&&(k.removeClass("twentytwenty-after"),f.find(".img-"+l).addClass("twentytwenty-after"),a(".twentytwenty-after-label .twentytwenty-label-content").text(f.data(l+"-label")),a(".imagify-c-level.go-right").attr("aria-hidden","true").removeClass("go-left go-right"),a(".imagify-level-"+l).attr("aria-hidden","false").addClass("go-right")),e(a(".imagify-level-"+l+" .imagify-chart canvas"))})))}),imagifyTTT.imageWidth&&a(".post-php .wp_attachment_image .thumbnail").length>0){var g,h,i=a(".post-php .wp_attachment_image"),j={src:a("#imagify-full-original").val(),size:a("#imagify-full-original-size").val()},k=a("#misc-publishing-actions").find(".misc-pub-imagify .button-primary");imagifyTTT.widthLimit=parseInt(imagifyTTT.widthLimit,10),imagifyTTT.imageWidth>imagifyTTT.widthLimit&&j.src?(g=a(".misc-pub-filesize strong").text(),h=a(".imagify-data-item .imagify-chart-value").text(),a('[id^="imgedit-open-btn-"]').before('<button type="button" class="imagify-button-primary button-primary imagify-modal-trigger" data-target="#imagify-visual-comparison" id="imagify-start-comparison">'+imagifyTTT.labels.compare+"</button>"),f({width:parseInt(imagifyTTT.imageWidth,10),height:parseInt(imagifyTTT.imageHeight,10),originalUrl:j.src,optimizedUrl:imagifyTTT.imageSrc,originalSize:j.size,optimizedSize:g,saving:h,modalAppendTo:i,trigger:a("#imagify-start-comparison"),modalId:"imagify-visual-comparison"})):imagifyTTT.imageWidth<imagifyTTT.widthLimit&&j.src||a("#imagify-full-original").length>0&&""===j.src||1===a("#misc-publishing-actions").find(".misc-pub-imagify .button-primary").length&&(a('[id^="imgedit-open-btn-"]').before('<span class="spinner imagify-hidden"></span><a class="imagify-button-primary button-primary imagify-optimize-trigger" id="imagify-optimize-trigger" href="'+k.attr("href")+'">'+imagifyTTT.labels.optimize+"</a>"),a("#imagify-optimize-trigger").on("click",function(){a(this).prev(".spinner").removeClass("imagify-hidden").addClass("is-active")}))}if(a(".upload-php .imagify-compare-images").length>0&&a(".imagify-compare-images").each(function(){var b=a(this),c=b.data("id"),d=b.closest("#post-"+c).find(".column-imagify_optimized_file");f({width:parseInt(b.data("full-width"),10),height:parseInt(b.data("full-height"),10),originalUrl:b.data("backup-src"),optimizedUrl:b.data("full-src"),originalSize:d.find(".original").text(),optimizedSize:d.find(".imagify-data-item .big").text(),saving:d.find(".imagify-chart-value").text(),modalAppendTo:b.closest(".column-primary"),trigger:b,modalId:"imagify-comparison-"+c})}),a(".upload-php").length>0)var l=function(a){var b={};return c.location.href.replace(/[?&]+([^=&]+)=?([^&]*)?/gi,function(a,c,d){b[c]=void 0!==d?d:""}),a?b[a]?b[a]:null:b},m=function(){var b=setInterval(function(){var c,d;a(".media-modal .imagify-datas-details").length&&(d=a("#imagify-original-src").val(),d&&(a(".media-frame-content .attachment-actions").prepend('<button type="button" class="imagify-button-primary button-primary imagify-modal-trigger" data-target="#imagify-comparison-modal" id="imagify-media-frame-comparison-btn">'+imagifyTTT.labels.compare+"</button>"),c=a(".media-frame-content .compat-field-imagify"),f({width:parseInt(a("#imagify-full-width").val(),10),height:parseInt(a("#imagify-full-height").val(),10),originalUrl:d,optimizedUrl:a("#imagify-full-src").val(),originalSize:a("#imagify-original-size").val(),optimizedSize:c.find(".imagify-data-item .big").text(),saving:c.find(".imagify-chart-value").text(),modalAppendTo:a(".media-frame-content .thumbnail-image"),trigger:a("#imagify-media-frame-comparison-btn"),modalId:"imagify-comparison-modal",openModal:!0})),clearInterval(b),b=null)},20)},n=setInterval(function(){a(".upload-php .media-frame.mode-grid .attachments").length&&(a(".upload-php .media-frame.mode-grid").on("click",".attachment",function(){m()}),l("item")&&m(),clearInterval(n),n=null)},100)}(jQuery,document,window);
+(function($, d, w, undefined) { // eslint-disable-line no-unused-vars, no-shadow, no-shadow-restricted-names
+
+	$.fn.twentytwenty = function( options, callback ) {
+		options = $.extend( {
+			handlePosition: 0.5,
+			orientation:    'horizontal',
+			labelBefore:    'Before',
+			labelAfter:     'After'
+		}, options );
+
+		return this.each( function() {
+			var sliderPct         = options.handlePosition,
+				$container        = $( this ),
+				sliderOrientation = options.orientation,
+				beforeDirection   = ( 'vertical' === sliderOrientation ) ? 'down' : 'left',
+				afterDirection    = ( 'vertical' === sliderOrientation ) ? 'up'   : 'right',
+				$beforeImg        = $container.find( 'img:first' ),
+				$afterImg         = $container.find( 'img:last' ),
+				offsetX           = 0,
+				offsetY           = 0,
+				imgWidth          = 0,
+				imgHeight         = 0,
+				$slider, $overlay,
+				calcOffset = function( dimensionPct ) {
+					var width  = parseInt( $beforeImg.attr( 'width' ), 10 ),
+						height = parseInt( $beforeImg.attr( 'height' ), 10 );
+
+					if ( ! width || ! height ) {
+						width  = parseInt( $beforeImg.width(), 10 );
+						height = parseInt( $beforeImg.height(), 10 );
+					}
+
+					return {
+						w:  width  + "px",
+						h:  height + "px",
+						cw: ( dimensionPct * width )  + "px",
+						ch: ( dimensionPct * height ) + "px"
+					};
+				},
+				adjustContainer = function( offset ) {
+					// Make it dynamic, in case the "before" image changes.
+					var $beforeImage = $container.find( '.twentytwenty-before' );
+
+					if ( 'vertical' === sliderOrientation ) {
+						$beforeImage.css( 'clip', 'rect(0,' + offset.w + ',' + offset.ch + ',0)' );
+					} else {
+						$beforeImage.css( 'clip', 'rect(0,' + offset.cw + ',' + offset.h + ',0)' );
+					}
+
+					$container.css( 'height', offset.h );
+
+					if ( typeof callback === 'function' ) {
+						callback();
+					}
+				},
+				adjustSlider = function( pct ) {
+					var offset = calcOffset( pct );
+
+					if ( 'vertical' === sliderOrientation ) {
+						$slider.css( 'top', offset.ch );
+					} else {
+						$slider.css( 'left', offset.cw );
+					}
+
+					adjustContainer( offset );
+				};
+
+
+			$container.wrap( '<div class="twentytwenty-wrapper twentytwenty-' + sliderOrientation + '"></div>' );
+			$container.append( '<div class="twentytwenty-overlay"></div>' );
+			$container.append( '<div class="twentytwenty-handle"></div>' );
+
+			$slider = $container.find( '.twentytwenty-handle' );
+
+			$slider.append( '<span class="twentytwenty-' + beforeDirection + '-arrow"></span>' );
+			$slider.append( '<span class="twentytwenty-' + afterDirection + '-arrow"></span>' );
+			$container.addClass( 'twentytwenty-container' );
+			$beforeImg.addClass( 'twentytwenty-before' );
+			$afterImg.addClass( 'twentytwenty-after' );
+
+			$overlay = $container.find( '.twentytwenty-overlay' );
+
+			$overlay.append( '<div class="twentytwenty-labels twentytwenty-before-label"><span class="twentytwenty-label-content">' + options.labelBefore + '</span></div>' );
+			$overlay.append( '<div class="twentytwenty-labels twentytwenty-after-label"><span class="twentytwenty-label-content">' + options.labelAfter + '</span></div>' );
+
+			$( w ).on( 'resize.twentytwenty', function() {
+				adjustSlider( sliderPct );
+			} );
+
+			$slider.on( 'movestart', function( e ) {
+				if ( 'vertical' !== sliderOrientation && ( ( e.distX > e.distY && e.distX < -e.distY ) || ( e.distX < e.distY && e.distX > -e.distY ) ) ) {
+					e.preventDefault();
+				} else if ( 'vertical' === sliderOrientation && ( ( e.distX < e.distY && e.distX < -e.distY ) || ( e.distX > e.distY && e.distX > -e.distY ) ) ) {
+					e.preventDefault();
+				}
+
+				$container.addClass( 'active' );
+
+				offsetX   = $container.offset().left;
+				offsetY   = $container.offset().top;
+				imgWidth  = $beforeImg.width();
+				imgHeight = $beforeImg.height();
+			} );
+
+			$slider.on( 'moveend', function() {
+				$container.removeClass( 'active' );
+			} );
+
+			$slider.on( 'move', function( e ) {
+				if ( $container.hasClass('active') ) {
+					sliderPct = 'vertical' === sliderOrientation ? ( e.pageY - offsetY ) / imgHeight : ( e.pageX - offsetX ) / imgWidth;
+
+					if ( sliderPct < 0 ) {
+						sliderPct = 0;
+					} else if ( sliderPct > 1 ) {
+						sliderPct = 1;
+					}
+
+					adjustSlider( sliderPct );
+				}
+			} );
+
+			$container.find( 'img' ).on( 'mousedown', function( e ) {
+				e.preventDefault();
+			} );
+
+			$( w ).trigger( 'resize.twentytwenty' );
+		} );
+	};
+
+} )(jQuery, document, window);
+
+/**
+ * Twentytwenty Imagify Init
+ */
+(function($, d, w, undefined) { // eslint-disable-line no-unused-vars, no-shadow, no-shadow-restricted-names
+
+	/*
+	 * Mini chart
+	 *
+	 * @param {element} canvas
+	 */
+	var drawMeAChart = function ( canvas ) {
+			canvas.each( function() {
+				var $this        = $( this ),
+					theValue     = parseInt( $this.closest( '.imagify-chart' ).next( '.imagify-chart-value' ).text(), 10 ),
+					overviewData = [
+						{
+							value: theValue,
+							color: '#00B3D3'
+						},
+						{
+							value: 100 - theValue,
+							color: '#D8D8D8'
+						}
+					];
+
+				new Chart( $this[0].getContext( '2d' ) ).Doughnut( overviewData, { // eslint-disable-line new-cap
+					segmentStrokeColor:    '#2A2E3C',
+					segmentStrokeWidth:    1,
+					animateRotate:         true,
+					percentageInnerCutout: 60,
+					tooltipEvents:         []
+				} );
+			} );
+		},
+		/**
+		 * Dynamic modal
+		 *
+		 * @param {object} Parameters to build modal with datas
+		 */
+		imagifyTwentyModal = function( options ) {
+			var defaults = {
+					width:         0, //px
+					height:        0, //px
+					originalUrl:   '', //url
+					optimizedUrl:  '', //url
+					originalSize:  0, //mb
+					optimizedSize: 0, // mb
+					saving:        0, //percent
+					modalAppendTo: $( 'body' ), // jQuery element
+					trigger:       $( '[data-target="imagify-visual-comparison"]' ), // jQuery element (button, link) with data-target="modalId"
+					modalId:       'imagify-visual-comparison', // should be dynamic if multiple modals
+					openModal:     false
+				},
+				settings = $.extend( {}, defaults, options ),
+				modalHtml;
+
+			if ( 0 === settings.width || 0 === settings.height || '' === settings.originalUrl || '' === settings.optimizedUrl || 0 === settings.originalSize || 0 === settings.optimizedSize || 0 === settings.saving ) {
+				return 'error';
+			}
+
+			// create modal box
+			modalHtml  = '<div id="' + settings.modalId + '" class="imagify-modal imagify-visual-comparison" aria-hidden="true">';
+			/* eslint-disable indent */
+				modalHtml += '<div class="imagify-modal-content loading">';
+					modalHtml += '<div class="twentytwenty-container">';
+						modalHtml += '<img class="imagify-img-before" alt="" width="' + settings.width + '" height="' + settings.height + '">';
+						modalHtml += '<img class="imagify-img-after" alt="" width="' + settings.width + '" height="' + settings.height + '">';
+					modalHtml += '</div>';
+					modalHtml += '<div class="imagify-comparison-levels">';
+						modalHtml += '<div class="imagify-c-level imagify-level-original go-left">';
+							modalHtml += '<p class="imagify-c-level-row">';
+								modalHtml += '<span class="label">' + imagifyTTT.labels.filesize + '</span>';
+								modalHtml += '<span class="value level">' + settings.originalSize + '</span>';
+							modalHtml += '</p>';
+						modalHtml += '</div>';
+						modalHtml += '<div class="imagify-c-level imagify-level-optimized go-right">';
+							modalHtml += '<p class="imagify-c-level-row">';
+								modalHtml += '<span class="label">' + imagifyTTT.labels.filesize + '</span>';
+								modalHtml += '<span class="value level">' + settings.optimizedSize + '</span>';
+							modalHtml += '</p>';
+							modalHtml += '<p class="imagify-c-level-row">';
+								modalHtml += '<span class="label">' + imagifyTTT.labels.saving + '</span>';
+								modalHtml += '<span class="value"><span class="imagify-chart"><span class="imagify-chart-container"><canvas id="imagify-consumption-chart-normal" width="15" height="15"></canvas></span></span><span class="imagify-chart-value">' + settings.saving + '</span>%</span>';
+							modalHtml += '</p>';
+						modalHtml += '</div>';
+					modalHtml += '</div>';
+					modalHtml += '<button class="close-btn absolute" type="button"><i aria-hidden="true" class="dashicons dashicons-no-alt"></i><span class="screen-reader-text">' + imagifyTTT.labels.close + '</span></button>';
+				modalHtml += '</div>';
+				/* eslint-enable indent */
+			modalHtml += '</div>';
+
+			settings.modalAppendTo.append( modalHtml );
+
+			settings.trigger.on( 'click.imagify', function( e ) {
+				var $modal     = $( $( this ).data( 'target' ) ),
+					imgsLoaded = 0,
+					$tt, checkLoad;
+
+				e.preventDefault();
+
+				if ( settings.openModal ) {
+					w.imagify.openModal( $( this ) );
+				}
+
+				$modal.find( '.imagify-modal-content').css( {
+					'width':     ( $( w ).outerWidth() * 0.85 ) + 'px',
+					'max-width': settings.width
+				} );
+
+				// Load before img.
+				$modal.find( '.imagify-img-before').on( 'load', function() {
+					imgsLoaded++;
+				} ).attr( 'src', settings.originalUrl );
+
+				// Load after img.
+				$modal.find( '.imagify-img-after' ).on( 'load', function() {
+					imgsLoaded++;
+				} ).attr( 'src', settings.optimizedUrl + ( settings.optimizedUrl.indexOf( '?' ) > 0 ? '&' : '?' ) + 'v=' + Date.now() );
+
+				$tt       = $modal.find( '.twentytwenty-container' );
+				checkLoad = setInterval( function() {
+					if ( 2 !== imgsLoaded ) {
+						return;
+					}
+
+					$tt.twentytwenty( {
+						handlePosition: 0.3,
+						orientation:    'horizontal',
+						labelBefore:    imagifyTTT.labels.originalL,
+						labelAfter:     imagifyTTT.labels.optimizedL
+					}, function() {
+						var windowH = $( w ).height(),
+							ttH     = $modal.find( '.twentytwenty-container' ).height(),
+							ttTop   = $modal.find( '.twentytwenty-wrapper' ).position().top,
+							$handle, $labels, $datas, datasH, handlePos, labelsPos;
+
+						if ( ! $tt.closest( '.imagify-modal-content' ).hasClass( 'loaded' ) ) {
+							$tt.closest( '.imagify-modal-content' ).removeClass( 'loading' ).addClass( 'loaded' );
+							drawMeAChart( $modal.find( '.imagify-level-optimized .imagify-chart canvas' ) );
+						}
+
+						// Check if image height is to big.
+						if ( windowH < ttH && ! $modal.hasClass( 'modal-is-too-high' ) ) {
+							$modal.addClass( 'modal-is-too-high' );
+
+							$handle   = $modal.find( '.twentytwenty-handle' );
+							$labels   = $modal.find( '.twentytwenty-label-content' );
+							$datas    = $modal.find( '.imagify-comparison-levels' );
+							datasH    = $datas.outerHeight();
+							handlePos = ( windowH - ttTop - $handle.height() ) / 2;
+							labelsPos = ( windowH - ttTop * 3 - datasH );
+
+							$handle.css( {
+								top: handlePos
+							} );
+							$labels.css( {
+								top:    labelsPos,
+								bottom: 'auto'
+							} );
+							$modal.find( '.twentytwenty-wrapper' ).css( {
+								paddingBottom: datasH
+							} );
+							$modal.find( '.imagify-modal-content' ).on( 'scroll.imagify', function() {
+								var scrollTop = $( this ).scrollTop();
+
+								$handle.css( {
+									top: handlePos + scrollTop
+								} );
+								$labels.css( {
+									top: labelsPos + scrollTop
+								} );
+								$datas.css( {
+									bottom: -scrollTop
+								} );
+							} );
+						}
+					} );
+
+					clearInterval( checkLoad );
+					checkLoad = null;
+					return 'done';
+				}, 75 );
+			} );
+		}; // imagifyTwentyModal( options );
+
+
+	/**
+	 * The complexe visual comparison
+	 */
+	$( '.imagify-visual-comparison-btn' ).on( 'click', function() {
+		var $tt, imgsLoaded, loader,
+			labelOriginal, labelNormal, labelAggressive, labelUltra,
+			originalLabel, originalAlt, originalSrc, originalDim,
+			normalAlt, normalSrc, normalDim,
+			aggressiveAlt, aggressiveSrc, aggressiveDim,
+			ultraLabel, ultraAlt, ultraSrc, ultraDim,
+			ttBeforeButtons, ttAfterButtons, image50, twentyMe;
+
+		if ( $( '.twentytwenty-wrapper' ).length === 1 ) {
+			return;
+		}
+
+		$( $( this ).data( 'target' ) ).find( '.imagify-modal-content' ).css( 'width', ( $( w ).outerWidth() * 0.95 ) + 'px' );
+
+		if ( $( '.twentytwenty-container' ).length > 0 && $( w ).outerWidth() <= 800 ) {
+			return;
+		}
+
+		$tt              = $( '.twentytwenty-container' );
+		imgsLoaded       = 0;
+		loader           = $tt.data( 'loader' );
+		labelOriginal    = $tt.data( 'label-original' );
+		labelNormal      = $tt.data( 'label-normal' );
+		labelAggressive  = $tt.data( 'label-aggressive' );
+		labelUltra       = $tt.data( 'label-ultra' );
+
+		originalLabel    = $tt.data( 'original-label' ).replace( /\*\*/, '<strong>' ).replace( /\*\*/, '</strong>' );
+		originalAlt      = $tt.data( 'original-alt' );
+		originalSrc      = $tt.data( 'original-img' );
+		originalDim      = $tt.data( 'original-dim' ).split( 'x' );
+
+		normalAlt        = $tt.data( 'normal-alt' );
+		normalSrc        = $tt.data( 'normal-img' );
+		normalDim        = $tt.data( 'normal-dim' ).split( 'x' );
+
+		aggressiveAlt    = $tt.data( 'aggressive-alt' );
+		aggressiveSrc    = $tt.data( 'aggressive-img' );
+		aggressiveDim    = $tt.data( 'aggressive-dim' ).split( 'x' );
+
+		ultraLabel       = $tt.data( 'ultra-label' ).replace( /\*\*/, '<strong>' ).replace( /\*\*/, '</strong>' );
+		ultraAlt         = $tt.data( 'ultra-alt' );
+		ultraSrc         = $tt.data( 'ultra-img' );
+		ultraDim         = $tt.data( 'ultra-dim' ).split( 'x' );
+
+		ttBeforeButtons  = '<span class="twentytwenty-duo-buttons twentytwenty-duo-left">';
+		/* eslint-disable indent */
+			ttBeforeButtons += '<button type="button" class="imagify-comparison-original selected" data-img="original">' + labelOriginal + '</button>';
+			ttBeforeButtons += '<button type="button" class="imagify-comparison-normal" data-img="normal">' + labelNormal + '</button>';
+			ttBeforeButtons += '<button type="button" class="imagify-comparison-aggressive" data-img="aggressive">' + labelAggressive + '</button>';
+			/* eslint-enable indent */
+		ttBeforeButtons += '</span>';
+		ttAfterButtons   = '<span class="twentytwenty-duo-buttons twentytwenty-duo-right">';
+		/* eslint-disable indent */
+			ttAfterButtons  += '<button type="button" class="imagify-comparison-normal" data-img="normal">' + labelNormal + '</button>';
+			ttAfterButtons  += '<button type="button" class="imagify-comparison-aggressive" data-img="aggressive">' + labelAggressive + '</button>';
+			ttAfterButtons  += '<button type="button" class="imagify-comparison-ultra selected" data-img="ultra">' + labelUltra + '</button>';
+			/* eslint-enable indent */
+		ttAfterButtons  += '</span>';
+
+		// Loader.
+		$tt.before( '<img class="loader" src="' + loader + '" alt="Loading…" width="64" height="64">' );
+
+		// Should be more locally integrated...
+		$( '.twentytwenty-left-buttons' ).append( ttBeforeButtons );
+		$( '.twentytwenty-right-buttons' ).append( ttAfterButtons );
+
+		image50    = '<img class="img-original" alt="' + originalAlt + '" width="' + originalDim[0] + '" height="' + originalDim[1] + '">';
+		image50   += '<img class="img-normal" alt="' + normalAlt + '" width="' + normalDim[0] + '" height="' + normalDim[1] + '">';
+		image50   += '<img class="img-aggressive" alt="' + aggressiveAlt + '" width="' + aggressiveDim[0] + '" height="' + aggressiveDim[1] + '">';
+		image50   += '<img class="img-ultra" alt="' + ultraAlt + '" width="' + ultraDim[0] + '" height="' + ultraDim[1] + '">';
+		// Add switchers button only if needed.
+		// Should be more locally integrated...
+		image50   += $( '.twentytwenty-left-buttons' ).lenght ? ttBeforeButtons + ttAfterButtons : '';
+
+		// Add images to 50/50 area.
+		$tt.closest( '.imagify-modal-content' ).addClass( 'loading' ).find( '.twentytwenty-container' ).append( image50 );
+
+		// Load image original.
+		$( '.img-original' ).on( 'load', function() {
+			imgsLoaded++;
+		} ).attr( 'src', originalSrc );
+
+		// Load image normal.
+		$( '.img-normal' ).on( 'load', function() {
+			imgsLoaded++;
+		} ).attr( 'src', normalSrc );
+
+		// Load image aggressive.
+		$( '.img-aggressive' ).on( 'load', function() {
+			imgsLoaded++;
+		} ).attr( 'src', aggressiveSrc );
+
+		// Load image ultra.
+		$( '.img-ultra' ).on( 'load', function() {
+			imgsLoaded++;
+		} ).attr( 'src', ultraSrc );
+
+		twentyMe = setInterval( function() {
+			if ( 4 !== imgsLoaded ) {
+				return;
+			}
+
+			$tt.twentytwenty({
+				handlePosition: 0.6,
+				orientation:    'horizontal',
+				labelBefore:    originalLabel,
+				labelAfter:     ultraLabel
+			}, function() {
+				// Fires on initialisation & each time the handle is moving.
+				if ( ! $tt.closest( '.imagify-modal-content' ).hasClass( 'loaded' ) ) {
+					$tt.closest( '.imagify-modal-content' ).removeClass( 'loading' ).addClass( 'loaded' );
+					drawMeAChart( $( '.imagify-level-ultra .imagify-chart canvas' ) );
+				}
+			} );
+
+			clearInterval( twentyMe );
+			twentyMe = null;
+		}, 75);
+
+		// On click on button choices.
+		$( '.imagify-comparison-title' ).on( 'click', '.twentytwenty-duo-buttons button:not(.selected)', function( e ) {
+			var $this      = $( this ),
+				$container = $this.closest( '.imagify-comparison-title' ).nextAll( '.twentytwenty-wrapper' ).find( '.twentytwenty-container' ),
+				side       = $this.closest( '.twentytwenty-duo-buttons' ).hasClass( 'twentytwenty-duo-left' ) ? 'left' : 'right',
+				$otherSide = 'left' === side ? $this.closest( '.imagify-comparison-title' ).find( '.twentytwenty-duo-right' ) : $this.closest( '.imagify-comparison-title' ).find( '.twentytwenty-duo-left' ),
+				$duo       = $this.closest( '.twentytwenty-duo-buttons' ).find( 'button' ),
+				$imgBefore = $container.find( '.twentytwenty-before' ),
+				$imgAfter  = $container.find( '.twentytwenty-after' ),
+				image      = $this.data( 'img' ),
+				clipStyles;
+
+			e.stopPropagation();
+			e.preventDefault();
+
+			// Button coloration.
+			$duo.removeClass( 'selected' );
+			$this.addClass( 'selected' );
+
+			// Other side action (to not compare same images).
+			if ( $otherSide.find( '.selected' ).data( 'img' ) === image ) {
+				$otherSide.find( 'button:not(.selected)' ).eq( 0 ).trigger( 'click' );
+			}
+
+			// Left buttons.
+			if ( 'left' === side ) {
+				clipStyles = $imgBefore.css( 'clip' );
+				$imgBefore.attr( 'style', '' );
+				$imgBefore.removeClass( 'twentytwenty-before' );
+				$container.find( '.img-' + image ).addClass( 'twentytwenty-before' ).css( 'clip', clipStyles );
+				$( '.twentytwenty-before-label .twentytwenty-label-content' ).text( $container.data( image + '-label' ) );
+				$( '.imagify-c-level.go-left' ).attr( 'aria-hidden', 'true' ).removeClass( 'go-left go-right' );
+				$( '.imagify-level-' + image ).attr( 'aria-hidden', 'false' ).addClass( 'go-left' );
+			}
+
+			// Right buttons.
+			if ( 'right' === side ) {
+				$imgAfter.removeClass( 'twentytwenty-after' );
+				$container.find( '.img-' + image ).addClass( 'twentytwenty-after' );
+				$( '.twentytwenty-after-label .twentytwenty-label-content' ).text( $container.data( image + '-label' ) );
+				$( '.imagify-c-level.go-right' ).attr( 'aria-hidden', 'true' ).removeClass( 'go-left go-right' );
+				$( '.imagify-level-' + image ).attr( 'aria-hidden', 'false' ).addClass( 'go-right' );
+			}
+
+			drawMeAChart( $( '.imagify-level-' + image + ' .imagify-chart canvas' ) );
+		} );
+	} );
+
+
+	/**
+	 * Imagify comparison inside Media post edition.
+	 */
+	if ( imagifyTTT.imageWidth && $( '.post-php .wp_attachment_image .thumbnail' ).length > 0 ) {
+
+		var $oriParent   = $( '.post-php .wp_attachment_image' ),
+			oriSource    = { src: $( '#imagify-full-original' ).val(), size: $( '#imagify-full-original-size' ).val() },
+			$optimizeBtn = $( '#misc-publishing-actions' ).find( '.misc-pub-imagify .button-primary' ),
+			filesize, saving;
+
+		imagifyTTT.widthLimit = parseInt( imagifyTTT.widthLimit, 10 );
+
+		// If shown image > 360, use twentytwenty.
+		if ( imagifyTTT.imageWidth > imagifyTTT.widthLimit && oriSource.src ) {
+
+			filesize = $( '.misc-pub-filesize strong' ).text();
+			saving   = $( '.imagify-data-item .imagify-chart-value' ).text();
+
+			// Create button to trigger.
+			$( '[id^="imgedit-open-btn-"]' ).before( '<button type="button" class="imagify-button-primary button-primary imagify-modal-trigger" data-target="#imagify-visual-comparison" id="imagify-start-comparison">' + imagifyTTT.labels.compare + '</button>' );
+
+			// Modal and trigger event creation.
+			imagifyTwentyModal( {
+				width:         parseInt( imagifyTTT.imageWidth, 10 ),
+				height:        parseInt( imagifyTTT.imageHeight, 10 ),
+				originalUrl:   oriSource.src,
+				optimizedUrl:  imagifyTTT.imageSrc,
+				originalSize:  oriSource.size,
+				optimizedSize: filesize,
+				saving:        saving,
+				modalAppendTo: $oriParent,
+				trigger:       $( '#imagify-start-comparison' ),
+				modalId:       'imagify-visual-comparison'
+			} );
+		}
+		// Else put images next to next.
+		else if ( imagifyTTT.imageWidth < imagifyTTT.widthLimit && oriSource.src ) {
+			// TODO
+		}
+		// If image has no backup.
+		else if ( $( '#imagify-full-original' ).length > 0 && '' === oriSource.src ) {
+			// do nothing ?
+		}
+		// In case image is not optimized.
+		else {
+			// If is not in optimizing process, propose the Optimize button trigger.
+			if ( $( '#misc-publishing-actions' ).find( '.misc-pub-imagify .button-primary' ).length === 1 ) {
+				$( '[id^="imgedit-open-btn-"]' ).before( '<span class="spinner imagify-hidden"></span><a class="imagify-button-primary button-primary imagify-optimize-trigger" id="imagify-optimize-trigger" href="' + $optimizeBtn.attr( 'href' ) + '">' + imagifyTTT.labels.optimize + '</a>' );
+
+				$( '#imagify-optimize-trigger' ).on( 'click', function() {
+					$( this ).prev( '.spinner' ).removeClass( 'imagify-hidden' ).addClass( 'is-active' );
+				} );
+			}
+		}
+
+	}
+
+	/**
+	 * Images comparison in attachments list page (upload.php).
+	 */
+	if ( $( '.upload-php .imagify-compare-images' ).length > 0 ) {
+
+		$( '.imagify-compare-images' ).each( function() {
+			var $this  = $( this ),
+				id     = $this.data( 'id' ),
+				$datas = $this.closest( '#post-' + id ).find( '.column-imagify_optimized_file' );
+
+			// Modal and trigger event creation.
+			imagifyTwentyModal( {
+				width:         parseInt( $this.data( 'full-width' ), 10 ),
+				height:        parseInt( $this.data( 'full-height' ), 10 ),
+				originalUrl:   $this.data( 'backup-src' ),
+				optimizedUrl:  $this.data( 'full-src' ),
+				originalSize:  $datas.find( '.original' ).text(),
+				optimizedSize: $datas.find( '.imagify-data-item .big' ).text(),
+				saving:        $datas.find( '.imagify-chart-value' ).text(),
+				modalAppendTo: $this.closest( '.column-primary' ),
+				trigger:       $this,
+				modalId:       'imagify-comparison-' + id
+			} );
+		} );
+	}
+
+	/**
+	 * Images Comparison in Grid View modal.
+	 */
+	if ( $( '.upload-php' ).length > 0 ) {
+
+		var getVar = function ( param ) {
+				var vars = {};
+
+				w.location.href.replace(
+					/[?&]+([^=&]+)=?([^&]*)?/gi,//
+					function( m, key, value ) {
+						vars[ key ] = undefined !== value ? value : '';
+					}
+				);
+
+				if ( param ) {
+					return vars[ param ] ? vars[ param ] : null;
+				}
+				return vars;
+			},
+			imagifyContentInModal = function() {
+				var tempTimer = setInterval( function() {
+					var $datas, originalSrc;
+
+					if ( ! $( '.media-modal .imagify-datas-details' ).length ) {
+						return;
+					}
+
+					originalSrc = $( '#imagify-original-src' ).val();
+
+					if ( originalSrc ) {
+						// Trigger creation.
+						$( '.media-frame-content .attachment-actions' ).prepend( '<button type="button" class="imagify-button-primary button-primary imagify-modal-trigger" data-target="#imagify-comparison-modal" id="imagify-media-frame-comparison-btn">' + imagifyTTT.labels.compare + '</button>' );
+
+						// Get datas.
+						$datas = $( '.media-frame-content .compat-field-imagify' );
+
+						// Modal and trigger event creation.
+						imagifyTwentyModal( {
+							width:         parseInt( $( '#imagify-full-width' ).val(), 10 ),
+							height:        parseInt( $( '#imagify-full-height' ).val(), 10 ),
+							originalUrl:   originalSrc,
+							optimizedUrl:  $( '#imagify-full-src' ).val(),
+							originalSize:  $( '#imagify-original-size' ).val(),
+							optimizedSize: $datas.find( '.imagify-data-item .big' ).text(),
+							saving:        $datas.find( '.imagify-chart-value' ).text(),
+							modalAppendTo: $( '.media-frame-content .thumbnail-image' ),
+							trigger:       $( '#imagify-media-frame-comparison-btn' ),
+							modalId:       'imagify-comparison-modal',
+							openModal:     true
+						} );
+					}
+
+					clearInterval( tempTimer );
+					tempTimer = null;
+				}, 20 );
+			},
+			waitContent = setInterval( function() {
+				if ( ! $( '.upload-php .media-frame.mode-grid .attachments' ).length ) {
+					return;
+				}
+
+				// If attachment is clicked, build the modal inside the modal.
+				$( '.upload-php .media-frame.mode-grid' ).on( 'click', '.attachment', function() {
+					imagifyContentInModal();
+				} );
+
+				// If attachment is mentionned in URL, build the modal inside the modal.
+				if ( getVar( 'item' ) ) {
+					imagifyContentInModal();
+				}
+
+				clearInterval( waitContent );
+				waitContent = null;
+			}, 100 );
+		// If URL contain item, that will open the WP Modal View.
+	}
+
+} )(jQuery, document, window);

--- a/inc/admin/meta-boxes.php
+++ b/inc/admin/meta-boxes.php
@@ -55,6 +55,6 @@ function _imagify_attachment_submitbox_misc_actions() {
 
 	if ( $attachment->is_optimized() ) {
 		echo '<input id="imagify-full-original" type="hidden" value="' . esc_url( $attachment->get_backup_url() ) . '">';
-		echo '<input id="imagify-full-original-size" type="hidden" value="' . esc_attr( $attachment->get_original_size() ) . '">';
+		echo '<input id="imagify-full-original-size" type="hidden" value="' . esc_attr( $attachment->get_original_size( true, 0 ) ) . '">';
 	}
 }

--- a/inc/classes/class-imagify-abstract-attachment.php
+++ b/inc/classes/class-imagify-abstract-attachment.php
@@ -257,15 +257,16 @@ abstract class Imagify_Abstract_Attachment {
 	 * @access public
 	 *
 	 * @param  bool $human_format True to display the image human format size (1Mb).
+	 * @param  int  $decimals     Precision of number of decimal places.
 	 * @return string
 	 */
-	public function get_original_size( $human_format = true ) {
+	public function get_original_size( $human_format = true, $decimals = 2 ) {
 		$filesystem    = imagify_get_filesystem();
 		$original_size = $this->get_size_data( 'full', 'original_size' );
 		$original_size = empty( $original_size ) ? $filesystem->size( $this->get_original_path() ) : (int) $original_size;
 
 		if ( true === $human_format ) {
-			$original_size = @size_format( $original_size, 2 );
+			$original_size = @size_format( $original_size, $decimals );
 		}
 
 		return $original_size;


### PR DESCRIPTION
In TwentyTwenty, try first to grab the image `width` and `height` attributes to get its dimensions. If it fails, then use the computed styles. This is to prevent to have an image with a height and width of 0. Also, improved a bit the whole code and enabled the linter in this section.