### PR TITLE
Large library transient

### DIFF
--- a/inc/3rd-party/nextgen-gallery/inc/admin/ajax.php
+++ b/inc/3rd-party/nextgen-gallery/inc/admin/ajax.php
@@ -80,9 +80,8 @@ function _do_wp_ajax_imagify_ngg_get_unoptimized_attachment_ids() {
 
 	@set_time_limit( 0 );
 
-	$optimization_level           = (int) $_GET['optimization_level'];
-	$optimization_level           = -1 !== $optimization_level ? $optimization_level : (int) get_imagify_option( 'optimization_level', 1 );
-	$unoptimized_attachment_limit = imagify_get_unoptimized_attachment_limit();
+	$optimization_level = (int) $_GET['optimization_level'];
+	$optimization_level = -1 !== $optimization_level ? $optimization_level : (int) get_imagify_option( 'optimization_level', 1 );
 
 	$storage   = C_Gallery_Storage::get_instance();
 	$ngg_table = $wpdb->prefix . 'ngg_pictures';
@@ -97,7 +96,7 @@ function _do_wp_ajax_imagify_ngg_get_unoptimized_attachment_ids() {
 			OR idata.status = 'error'
 		LIMIT %d",
 		$optimization_level,
-		$unoptimized_attachment_limit
+		imagify_get_unoptimized_attachment_limit()
 	), ARRAY_A );
 
 	// Save the optimization level in a transient to retrieve it later during the process.

--- a/inc/3rd-party/nextgen-gallery/inc/admin/ajax.php
+++ b/inc/3rd-party/nextgen-gallery/inc/admin/ajax.php
@@ -80,18 +80,9 @@ function _do_wp_ajax_imagify_ngg_get_unoptimized_attachment_ids() {
 
 	@set_time_limit( 0 );
 
-	$optimization_level = (int) $_GET['optimization_level'];
-	$optimization_level = ( -1 !== $optimization_level ) ? $optimization_level : get_imagify_option( 'optimization_level', 1 );
-	$optimization_level = (int) $optimization_level;
-
-	/**
-	 * Filter the unoptimized attachments limit query.
-	 *
-	 * @since 1.4.4
-	 *
-	 * @param int The limit (-1 for unlimited).
-	 */
-	$unoptimized_attachment_limit = apply_filters( 'imagify_unoptimized_attachment_limit', 10000 );
+	$optimization_level           = (int) $_GET['optimization_level'];
+	$optimization_level           = -1 !== $optimization_level ? $optimization_level : (int) get_imagify_option( 'optimization_level', 1 );
+	$unoptimized_attachment_limit = imagify_get_unoptimized_attachment_limit();
 
 	$storage   = C_Gallery_Storage::get_instance();
 	$ngg_table = $wpdb->prefix . 'ngg_pictures';

--- a/inc/admin/ui/bulk.php
+++ b/inc/admin/ui/bulk.php
@@ -182,7 +182,7 @@ function _imagify_display_bulk_page() {
 							<?php
 							esc_html_e( 'Please be aware that optimizing a large number of images can take a while depending on your server and network speed.', 'imagify' );
 
-							if ( get_transient( IMAGIFY_SLUG . '_large_library' ) ) {
+							if ( get_transient( 'imagify_large_library' ) ) {
 								printf(
 									/* translators: %s is a formatted number. Don't use %d. */
 									__( 'If you have more than %s images, you will need to launch the bulk optimization several times.' , 'imagify' ),

--- a/inc/admin/ui/bulk.php
+++ b/inc/admin/ui/bulk.php
@@ -186,12 +186,7 @@ function _imagify_display_bulk_page() {
 								printf(
 									/* translators: %s is a formatted number. Don't use %d. */
 									__( 'If you have more than %s images, you will need to launch the bulk optimization several times.' , 'imagify' ),
-									/**
-									 * Filter the unoptimized attachments limit.
-									 *
-									 * @param int Default is 10000.
-									 */
-									number_format_i18n( apply_filters( 'imagify_unoptimized_attachment_limit', 10000 ) )
+									number_format_i18n( imagify_get_unoptimized_attachment_limit() )
 								);
 							}
 							?>

--- a/inc/classes/class-imagify-admin-ajax-post.php
+++ b/inc/classes/class-imagify-admin-ajax-post.php
@@ -401,18 +401,9 @@ class Imagify_Admin_Ajax_Post {
 		@set_time_limit( 0 );
 
 		// Get (ordered) IDs.
-		$optimization_level = (int) $_GET['optimization_level'];
-		$optimization_level = ( -1 !== $optimization_level ) ? $optimization_level : (int) get_imagify_option( 'optimization_level', 1 );
-
-		/**
-		 * Filter the unoptimized attachments limit query.
-		 *
-		 * @since 1.4.4
-		 *
-		 * @param int The limit (-1 for unlimited).
-		 */
-		$unoptimized_attachment_limit = (int) apply_filters( 'imagify_unoptimized_attachment_limit', 10000 );
-		$unoptimized_attachment_limit = -1 === $unoptimized_attachment_limit ? PHP_INT_MAX : $unoptimized_attachment_limit;
+		$optimization_level           = (int) $_GET['optimization_level'];
+		$optimization_level           = -1 !== $optimization_level ? $optimization_level : (int) get_imagify_option( 'optimization_level', 1 );
+		$unoptimized_attachment_limit = imagify_get_unoptimized_attachment_limit();
 
 		Imagify_DB::unlimit_joins();
 

--- a/inc/classes/class-imagify-admin-ajax-post.php
+++ b/inc/classes/class-imagify-admin-ajax-post.php
@@ -401,9 +401,8 @@ class Imagify_Admin_Ajax_Post {
 		@set_time_limit( 0 );
 
 		// Get (ordered) IDs.
-		$optimization_level           = (int) $_GET['optimization_level'];
-		$optimization_level           = -1 !== $optimization_level ? $optimization_level : (int) get_imagify_option( 'optimization_level', 1 );
-		$unoptimized_attachment_limit = imagify_get_unoptimized_attachment_limit();
+		$optimization_level = (int) $_GET['optimization_level'];
+		$optimization_level = -1 !== $optimization_level ? $optimization_level : (int) get_imagify_option( 'optimization_level', 1 );
 
 		Imagify_DB::unlimit_joins();
 
@@ -439,11 +438,11 @@ class Imagify_Admin_Ajax_Post {
 				$wpdb->posts.ID DESC
 			LIMIT 0, %d",
 			$optimization_level,
-			$unoptimized_attachment_limit
+			imagify_get_unoptimized_attachment_limit()
 		) );
 
 		$wpdb->flush();
-		unset( $unoptimized_attachment_limit, $mime_types );
+		unset( $mime_types );
 		$ids = array_filter( array_map( 'absint', $ids ) );
 
 		if ( ! $ids ) {

--- a/inc/functions/admin-stats.php
+++ b/inc/functions/admin-stats.php
@@ -45,12 +45,7 @@ function imagify_count_attachments() {
 			AND $wpdb->posts.post_status = 'inherit'"
 	);
 
-	/**
-	 * Filter the limit from which the library is considered large.
-	 *
-	 * @param int $limit Number of attachments.
-	 */
-	if ( $count > apply_filters( 'imagify_unoptimized_attachment_limit', 10000 ) ) {
+	if ( $count > imagify_get_unoptimized_attachment_limit() ) {
 		set_transient( 'imagify_large_library', 1 );
 	} elseif ( get_transient( 'imagify_large_library' ) ) {
 		// In case the number is decreasing under our limit.

--- a/inc/functions/attachments.php
+++ b/inc/functions/attachments.php
@@ -337,3 +337,24 @@ function get_imagify_upload_baseurl() {
 
 	return $upload_baseurl;
 }
+
+/**
+ * Get the maximal number of unoptimized attachments to fetch.
+ *
+ * @since  1.6.14
+ * @author Grégory Viguier
+ *
+ * @return int
+ */
+function imagify_get_unoptimized_attachment_limit() {
+	/**
+	 * Filter the unoptimized attachments limit query.
+	 *
+	 * @since 1.4.4
+	 *
+	 * @param int $limit The limit (-1 for unlimited).
+	 */
+	$limit = (int) apply_filters( 'imagify_unoptimized_attachment_limit', 10000 );
+
+	return -1 === $limit ? PHP_INT_MAX : abs( $limit );
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -8,13 +8,9 @@ delete_site_option( 'imagify_settings' );
 
 // Delete all transients.
 delete_site_transient( 'imagify_check_licence_1' );
-delete_site_transient( 'imagify_bulk_optimization_level' );
-delete_site_transient( 'imagify_large_library' );
-delete_site_transient( 'imagify_max_image_size' );
-
-// Clear scheduled hooks.
-wp_clear_scheduled_hook( 'imagify_rating_event' );
-wp_clear_scheduled_hook( 'imagify_update_library_size_calculations_event' );
+delete_transient( 'imagify_bulk_optimization_level' );
+delete_transient( 'imagify_large_library' );
+delete_transient( 'imagify_max_image_size' );
 
 // Delete transients.
 $transients = implode( '" OR option_name LIKE "', array(
@@ -24,8 +20,12 @@ $transients = implode( '" OR option_name LIKE "', array(
 ) );
 $wpdb->query( 'DELETE from ' . $wpdb->options . ' WHERE option_name LIKE "' . $transients . '"' ); // WPCS: unprepared SQL ok.
 
+// Clear scheduled hooks.
+wp_clear_scheduled_hook( 'imagify_rating_event' );
+wp_clear_scheduled_hook( 'imagify_update_library_size_calculations_event' );
+
 // Delete all user meta related to Imagify.
 delete_metadata( 'user', '', '_imagify_ignore_notices', '', true );
 
 // Drop the tables.
-$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->ngg_imagify_data );
+$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'ngg_imagify_data' );


### PR DESCRIPTION
Thinking it wasn't used, the first idea was to remove the `imagify_large_library` transient.
But in fact it is used, it's just a bit messed up.

TL;DR: consistency, small fixes, new helper function.