### PR TITLE
Improves lang detection

### DIFF
--- a/inc/classes/class-imagify-admin-ajax-post.php
+++ b/inc/classes/class-imagify-admin-ajax-post.php
@@ -645,7 +645,7 @@ class Imagify_Admin_Ajax_Post {
 		$data = array(
 			'email'    => $_GET['email'],
 			'password' => wp_generate_password( 12, false ),
-			'lang'     => get_locale(),
+			'lang'     => imagify_get_locale(),
 		);
 
 		$response = add_imagify_user( $data );

--- a/inc/functions/admin.php
+++ b/inc/functions/admin.php
@@ -201,27 +201,21 @@ function get_imagify_bulk_buffer_size() {
 function imagify_get_wp_rocket_url( $path = false, $query = array() ) {
 	$wprocket_url = 'https://wp-rocket.me/';
 
-	// Locale.
-	$locale       = function_exists( 'get_user_locale' ) ? get_user_locale() : get_locale();
-	$suffixes     = array(
-		'fr_FR' => 'fr',
-		'es_ES' => 'es',
-		'it_IT' => 'it',
-		'de_DE' => 'de',
-	);
+	// Current lang.
+	$lang = imagify_get_current_lang_in( array( 'de', 'es', 'fr', 'it' ) );
 
-	if ( isset( $suffixes[ $locale ] ) ) {
-		$wprocket_url .= $suffixes[ $locale ] . '/';
+	if ( 'en' !== $lang ) {
+		$wprocket_url .= $lang . '/';
 	}
 
 	// URI.
 	$paths = array(
 		'pricing' => array(
-			'default' => 'pricing',
-			'fr_FR'   => 'offres',
-			'es_ES'   => 'precios',
-			'it_IT'   => 'offerte',
-			'de_DE'   => 'preise',
+			'de' => 'preise',
+			'en' => 'pricing',
+			'es' => 'precios',
+			'fr' => 'offres',
+			'it' => 'offerte',
 		),
 	);
 
@@ -229,11 +223,7 @@ function imagify_get_wp_rocket_url( $path = false, $query = array() ) {
 		$path = trim( $path, '/' );
 
 		if ( isset( $paths[ $path ] ) ) {
-			if ( isset( $paths[ $path ][ $locale ] ) ) {
-				$wprocket_url .= $paths[ $path ][ $locale ] . '/';
-			} else {
-				$wprocket_url .= $paths[ $path ]['default'] . '/';
-			}
+			$wprocket_url .= $paths[ $path ][ $lang ] . '/';
 		} else {
 			$wprocket_url .= $path . '/';
 		}

--- a/inc/functions/common.php
+++ b/inc/functions/common.php
@@ -212,14 +212,13 @@ function imagify_get_external_url( $target, $query_args = array() ) {
 			break;
 
 		case 'contact':
-			$locale = function_exists( 'get_user_locale' ) ? get_user_locale() : get_locale();
-			$paths  = array(
-				'default' => 'contact',
-				'fr_FR'   => 'fr/contact',
+			$lang  = imagify_get_current_lang_in( 'fr' );
+			$paths = array(
+				'en' => 'contact',
+				'fr' => 'fr/contact',
 			);
 
-			$url = isset( $paths[ $locale ] ) ? $paths[ $locale ] : $paths['default'];
-			$url = $site_url . $url . '/';
+			$url = $site_url . $paths[ $lang ] . '/';
 			break;
 
 		case 'documentation':
@@ -258,4 +257,51 @@ function imagify_get_external_url( $target, $query_args = array() ) {
 	}
 
 	return $url;
+}
+
+/**
+ * Get the current lang ('fr', 'en', 'de'...), limited to a given list.
+ *
+ * @since  1.6.14
+ * @author Grégory Viguier
+ *
+ * @param  array $langs An array of langs, like array( 'de', 'es', 'fr', 'it' ).
+ * @return string The current lang. Default is 'en'.
+ */
+function imagify_get_current_lang_in( $langs ) {
+	static $locale;
+
+	if ( ! isset( $locale ) ) {
+		$locale = imagify_get_locale();
+		$locale = explode( '_', strtolower( $locale . '_' ) ); // Trailing underscore is to make sure $locale[1] is set.
+	}
+
+	foreach ( (array) $langs as $lang ) {
+		if ( $lang === $locale[0] || $lang === $locale[1] ) {
+			return $lang;
+		}
+	}
+
+	return 'en';
+}
+
+/**
+ * Get the current locale.
+ *
+ * @since  1.6.14
+ * @author Grégory Viguier
+ *
+ * @return string The current locale.
+ */
+function imagify_get_locale() {
+	$locale = function_exists( 'get_user_locale' ) ? get_user_locale() : get_locale();
+	/**
+	 * Filter the locale used by Imagify.
+	 *
+	 * @since  1.6.14
+	 * @author Grégory Viguier
+	 *
+	 * @param string $locale The current locale.
+	 */
+	return apply_filters( 'imagify_locale', $locale );
 }


### PR DESCRIPTION
Improved lang detection in `imagify_get_wp_rocket_url()` and `imagify_get_external_url()`.
Instead of focusing on "sub-language" (the locale, like 'fr_FR'), use the "language family" (like 'fr', that regroups 'fr_FR' and 'fr_BE'). This way works in most cases, and at least for the languages we use.
Introduced `imagify_get_current_lang_in()` and `imagify_get_locale()`.