### PR TITLE
Fixes #233

### DIFF
--- a/assets/js/bulk.js
+++ b/assets/js/bulk.js
@@ -166,9 +166,16 @@
 				.on( 'queueEmpty.imagify', this.queueEmpty );
 
 			// Heartbeat.
-			$( d )
-				.on( 'heartbeat-send', this.addHeartbeat )
-				.on( 'heartbeat-tick', this.processHeartbeat );
+			if ( imagifyBulk.ajaxActions.getStats && $( '.imagify-bulk-table [data-group-id="library"][data-context="wp"]' ).length ) {
+				// If large library.
+				imagifyBulk.heartbeatId = false;
+			}
+
+			if ( imagifyBulk.heartbeatId ) {
+				$( d )
+					.on( 'heartbeat-send', this.addHeartbeat )
+					.on( 'heartbeat-tick', this.processHeartbeat );
+			}
 		},
 
 		/**
@@ -373,6 +380,28 @@
 			return ajaxurl + w.imagify.concat + '_wpnonce=' + imagifyBulk.ajaxNonce + '&optimization_level=' + item.level + '&action=' + action + '&folder_type=' + item.groupId;
 		},
 
+		/**
+		 * Get folder types used in the page.
+		 *
+		 * @return {array}
+		 */
+		getFolderTypes: function () {
+			if ( ! w.imagify.bulk.folderTypes.length ) {
+				$( '.imagify-row-folder-type' ).each( function() {
+					var $this   = $( this ),
+						groupID = $this.data( 'group-id' );
+
+					if ( 'library' === groupID ) {
+						groupID += '|' + $this.data( 'context' );
+					}
+
+					w.imagify.bulk.folderTypes.push( groupID );
+				} );
+			}
+
+			return w.imagify.bulk.folderTypes;
+		},
+
 		/*
 		 * Get the message displayed to the user when (s)he leaves the page.
 		 *
@@ -572,6 +601,61 @@
 			this.globalGain          = 0;
 			this.globalOriginalSize  = 0;
 			this.globalOptimizedSize = 0;
+		},
+
+		/**
+		 * Print optimization stats.
+		 *
+		 * @param {object} data Object containing all Heartbeat IDs.
+		 */
+		updateStats: function ( data ) {
+			var donutData;
+
+			if ( ! data || ! $.isPlainObject( data ) ) {
+				return;
+			}
+
+			if ( w.imagify.bulk.charts.overview.donut.data ) {
+				donutData = w.imagify.bulk.charts.overview.donut.data.datasets[0].data;
+
+				if ( data.unoptimized_attachments === donutData[0] && data.optimized_attachments === donutData[1] && data.errors_attachments === donutData[2] ) {
+					return;
+				}
+			}
+
+			/**
+			 * User account.
+			 */
+			data.unconsumed_quota = data.unconsumed_quota.toFixed( 1 ); // A mystery where a float rounded on php side is not rounded here anymore. JavaScript is fun, it always surprises you in a manner you didn't expect.
+			$( '.imagify-unconsumed-percent' ).html( data.unconsumed_quota + '%' );
+			$( '.imagify-unconsumed-bar' ).css( 'width', data.unconsumed_quota + '%' );
+
+			/**
+			 * Global chart.
+			 */
+			$( '#imagify-overview-chart-percent' ).html( data.optimized_attachments_percent + '<span>%</span>' );
+			$( '.imagify-total-percent' ).html( data.optimized_attachments_percent + '%' );
+
+			w.imagify.bulk.drawOverviewChart( [
+				data.unoptimized_attachments,
+				data.optimized_attachments,
+				data.errors_attachments
+			] );
+
+			/**
+			 * Stats block.
+			 */
+			// The total optimized images.
+			$( '#imagify-total-optimized-attachments' ).html( data.already_optimized_attachments );
+
+			// The original bar.
+			$( '#imagify-original-bar' ).find( '.imagify-barnb' ).html( data.original_human );
+
+			// The optimized bar.
+			$( '#imagify-optimized-bar' ).css( 'width', ( 100 - data.optimized_percent ) + '%' ).find( '.imagify-barnb' ).html( data.optimized_human );
+
+			// The Percent data.
+			$( '#imagify-total-optimized-attachments-pct' ).html( data.optimized_percent + '%' );
 		},
 
 		// Event callbacks =========================================================================
@@ -1082,6 +1166,20 @@
 			// Reset the queue.
 			w.imagify.bulk.queue = [];
 
+			// Fetch and display generic stats if heartbeat is disabled.
+			if ( ! imagifyBulk.heartbeatId ) {
+				$.get( ajaxurl, {
+					_wpnonce: imagifyBulk.ajaxNonce,
+					action:   imagifyBulk.ajaxActions.getStats,
+					types:    w.imagify.bulk.getFolderTypes()
+				} )
+					.done( function( response ) {
+						if ( response.success ) {
+							w.imagify.bulk.updateStats( response.data );
+						}
+					} );
+			}
+
 			// Maybe display error.
 			if ( ! $.isEmptyObject( w.imagify.bulk.status ) ) {
 				$.each( w.imagify.bulk.status, function( groupId, typeStatus ) {
@@ -1160,14 +1258,7 @@
 		 */
 		addHeartbeat: function ( e, data ) {
 			data.imagify_heartbeat = imagifyBulk.heartbeatId;
-
-			if ( ! w.imagify.bulk.folderTypes.length ) {
-				$( '.imagify-row-folder-type' ).each( function() {
-					w.imagify.bulk.folderTypes.push( $( this ).data( 'group-id' ) );
-				} );
-			}
-
-			data.imagify_types = w.imagify.bulk.folderTypes;
+			data.imagify_types     = w.imagify.bulk.getFolderTypes();
 		},
 
 		/**
@@ -1178,55 +1269,9 @@
 		 * @param {object} data Object containing all Heartbeat IDs.
 		 */
 		processHeartbeat: function ( e, data ) {
-			var donutData;
-
-			if ( ! data.imagify_bulk_data ) {
-				return;
+			if ( data.imagify_bulk_data ) {
+				w.imagify.bulk.updateStats( data.imagify_bulk_data );
 			}
-
-			data = data.imagify_bulk_data;
-
-			if ( w.imagify.bulk.charts.overview.donut.data ) {
-				donutData = w.imagify.bulk.charts.overview.donut.data.datasets[0].data;
-
-				if ( data.unoptimized_attachments === donutData[0] && data.optimized_attachments === donutData[1] && data.errors_attachments === donutData[2] ) {
-					return;
-				}
-			}
-
-			/**
-			 * User account.
-			 */
-			data.unconsumed_quota = data.unconsumed_quota.toFixed( 1 ); // A mystery where a float rounded on php side is not rounded here anymore. JavaScript is fun, it always surprises you in a manner you didn't expect.
-			$( '.imagify-unconsumed-percent' ).html( data.unconsumed_quota + '%' );
-			$( '.imagify-unconsumed-bar' ).css( 'width', data.unconsumed_quota + '%' );
-
-			/**
-			 * Global chart.
-			 */
-			$( '#imagify-overview-chart-percent' ).html( data.optimized_attachments_percent + '<span>%</span>' );
-			$( '.imagify-total-percent' ).html( data.optimized_attachments_percent + '%' );
-
-			w.imagify.bulk.drawOverviewChart( [
-				data.unoptimized_attachments,
-				data.optimized_attachments,
-				data.errors_attachments
-			] );
-
-			/**
-			 * Stats block.
-			 */
-			// The total optimized images.
-			$( '#imagify-total-optimized-attachments' ).html( data.already_optimized_attachments );
-
-			// The original bar.
-			$( '#imagify-original-bar' ).find( '.imagify-barnb' ).html( data.original_human );
-
-			// The optimized bar.
-			$( '#imagify-optimized-bar' ).css( 'width', ( 100 - data.optimized_percent ) + '%' ).find( '.imagify-barnb' ).html( data.optimized_human );
-
-			// The Percent data.
-			$( '#imagify-total-optimized-attachments-pct' ).html( data.optimized_percent + '%' );
 		},
 
 		/**

--- a/assets/js/bulk.min.js
+++ b/assets/js/bulk.min.js
@@ -1,1 +1,1305 @@
-!function(a,b){var c=a.propHooks.checked;a.propHooks.checked={set:function(b,d,e){var f;return f=void 0===c?b[e]=d:c(b,d,e),a(b).trigger("change.imagify"),f}},a.fn.imagifyHide=function(b,c){return b&&b>0?this.hide(b,function(){a(this).addClass("hidden").css("display",""),void 0!==c&&c()}):(this.addClass("hidden"),void 0!==c&&c()),this.attr("aria-hidden","true")},a.fn.imagifyShow=function(b,c){return void 0!==c&&c(),b&&b>0?this.show(b,function(){a(this).removeClass("hidden").css("display","")}):this.removeClass("hidden"),this.attr("aria-hidden","false")}}(jQuery),function(a,b,c,d){c.imagify.bulk={charts:{overview:{canvas:!1,donut:!1,data:{labels:[imagifyBulk.labels.overviewChartLabels.unoptimized,imagifyBulk.labels.overviewChartLabels.optimized,imagifyBulk.labels.overviewChartLabels.error],datasets:[{data:[],backgroundColor:["#10121A","#46B1CE","#C51162"],borderWidth:0}]}},files:{donuts:{}},share:{canvas:!1,donut:!1}},queue:[],status:{},displayedWaitMessage:!1,hasMultipleRows:!0,processIsStopped:!1,globalGain:0,globalOriginalSize:0,globalOptimizedSize:0,folderTypes:[],init:function(){if(this.drawOverviewChart(),!imagifyBulk.keyIsValid)return void a("#imagify-bulk-action").on("click.imagify",this.maybeLaunchAllProcesses);this.hasMultipleRows=a('.imagify-bulk-table [name="group[]"]').length>1,a(".imagify-level-selector-button").on("click.imagify",this.openLevelSelectorFromButton),a(".imagify-level-selector-list input").on("change.imagify init.imagify",this.syncLevelSelectorFromRadio).filter(":checked").trigger("init.imagify"),a(b).on("keypress.imagify click.imagify",this.closeLevelSelectors),a('.imagify-bulk-table [name="group[]"]').on("change.imagify init.imagify",this.toggleOptimizationButton).trigger("init.imagify"),a(".imagify-show-table-details").on("click.imagify open.imagify close.imagify",this.toggleOptimizationDetails),a("#imagify-bulk-action").on("click.imagify",this.maybeLaunchAllProcesses),a(".imagify-share-networks a").on("click.imagify",this.share),imagifyBulk.curlMissing||(a(c).on("processQueue.imagify",this.processQueue).on("optimizeFiles.imagify",this.optimizeFiles).on("queueEmpty.imagify",this.queueEmpty),a(b).on("heartbeat-send",this.addHeartbeat).on("heartbeat-tick",this.processHeartbeat))},drawOverviewChart:function(d){var e,f;if(this.charts.overview.canvas||(this.charts.overview.canvas=b.getElementById("imagify-overview-chart"),this.charts.overview.canvas)){if(d=d&&a.isArray(d)?d:[],this.charts.overview.donut)return void(d.length&&(0===d.reduce(function(a,b){return a+b},0)&&(d[0]=1),this.charts.overview.donut.data.datasets[0].data=d,this.charts.overview.donut.update()));this.charts.overview.data.datasets[0].data=[parseInt(this.charts.overview.canvas.getAttribute("data-unoptimized"),10),parseInt(this.charts.overview.canvas.getAttribute("data-optimized"),10),parseInt(this.charts.overview.canvas.getAttribute("data-errors"),10)],e=a.extend({},this.charts.overview.data),d.length&&(e.datasets[0].data=d),0===e.datasets[0].data.reduce(function(a,b){return a+b},0)&&(e.datasets[0].data[0]=1),this.charts.overview.donut=new c.imagify.Chart(this.charts.overview.canvas,{type:"doughnut",data:e,options:{legend:{display:!1},events:[],animation:{easing:"easeOutBounce"},tooltips:{displayColors:!1,callbacks:{label:function(a,b){return b.datasets[a.datasetIndex].data[a.index]}}},responsive:!1,cutoutPercentage:85}}),f='<ul class="imagify-doughnut-legend">',a.each(e.labels,function(a,b){f+='<li><span style="background-color:'+e.datasets[0].backgroundColor[a]+'"></span>'+b+"</li>"}),f+="</ul>",b.getElementById("imagify-overview-chart-legend").innerHTML=f}},drawFileChart:function(b){var d=this.charts.files.donuts;b.each(function(){var b=parseInt(a(this).closest(".imagify-chart").next(".imagipercent").text().replace("%",""),10);if(void 0!==d[this.id])return d[this.id].data.datasets[0].data[0]=b,d[this.id].data.datasets[0].data[1]=100-b,void d[this.id].update();d[this.id]=new c.imagify.Chart(this,{type:"doughnut",data:{datasets:[{data:[b,100-b],backgroundColor:["#00B3D3","#D8D8D8"],borderColor:"#fff",borderWidth:1}]},options:{legend:{display:!1},events:[],animation:{easing:"easeOutBounce"},tooltips:{enabled:!1},responsive:!1}})}),this.charts.files.donuts=d},drawShareChart:function(){var d;if(this.charts.share.canvas||(this.charts.share.canvas=b.getElementById("imagify-ac-chart"),this.charts.share.canvas)){if(d=parseInt(a(this.charts.share.canvas).closest(".imagify-ac-chart").attr("data-percent"),10),this.charts.share.donut)return this.charts.share.donut.data.datasets[0].data[0]=d,this.charts.share.donut.data.datasets[0].data[1]=100-d,void this.charts.share.donut.update();this.charts.share.donut=new c.imagify.Chart(this.charts.share.canvas,{type:"doughnut",data:{datasets:[{data:[d,100-d],backgroundColor:["#40B1D0","#FFFFFF"],borderWidth:0}]},options:{legend:{display:!1},events:[],animation:{easing:"easeOutBounce"},tooltips:{enabled:!1},responsive:!1,cutoutPercentage:70}})}},getAjaxUrl:function(a,b){var d=b.groupId.replace(/[\s_-](\S)/g,function(a,b){return b.toUpperCase()});return a=a.replace("%GROUP_ID%",d),a=imagifyBulk.ajaxActions[a],ajaxurl+c.imagify.concat+"_wpnonce="+imagifyBulk.ajaxNonce+"&optimization_level="+b.level+"&action="+a+"&folder_type="+b.groupId},getConfirmMessage:function(){return imagifyBulk.labels.processing},closeLevelSelector:function(a,b){if(a&&a.length)return void 0!==b&&b>0?void c.setTimeout(function(){c.imagify.bulk.closeLevelSelector(a)},b):void a.attr("aria-hidden","true")},stopProcess:function(b,d){this.processIsStopped=!0,c.imagify.bulk.status[d.groupId]={isError:!0,id:b},a(c).trigger("queueEmpty.imagify")},displayError:function(b,c,d){var e={title:"",html:"",type:"error",customClass:"",width:620,padding:0,showCloseButton:!0,showConfirmButton:!0};a.isPlainObject(b)?d=a.extend({},e,b):(d=d||{},d=a.extend({},e,{title:b||"",html:c||""},d)),d.title=d.title||imagifyBulk.labels.error,d.customClass+=" imagify-sweet-alert",swal(d).catch(swal.noop)},displayErrorInRow:function(b,c){var d,e;return b=a(b()),d=b.find(".imagify-cell-status ~ td"),e=d.length,c=c||"",d.remove(),b.find(".imagify-cell-status").after('<td colspan="'+e+'">'+c+"</td>"),b},displayFolderRow:function(a,b){var d,e,f,g;return"resting"===a?(b.next(".imagify-row-waiting, .imagify-row-working").remove(),void b.imagifyShow()):(d=b.next(".imagify-row-waiting, .imagify-row-working"),"waiting"===a?(f="#d2d3d6",g=imagifyBulk.labels.waitingOtimizationsText):(f="#40b1d0",g=imagifyBulk.labels.imagesOptimizedText.replace("%s","<span>0</span>")),d.length?(d.hasClass("imagify-row-"+a)||(d.attr("class","imagify-row-"+a),d.find(".imagify-cell-checkbox svg").attr("fill",f),d.children(".imagify-cell-images-optimized").html(g)),b.imagifyHide(),void d.imagifyShow()):(d=b.clone().attr({class:"imagify-row-"+a,"aria-hidden":"false"}),e=c.imagify.template("imagify-spinner"),d.children(".imagify-cell-checkbox").html(e()).find("svg").attr("fill",f),d.children(".imagify-cell-title").html('<span class="imagify-cell-label">'+d.children(".imagify-cell-title").text()+"</span>"),d.children(".imagify-cell-images-optimized").html(g),d.children(".imagify-cell-errors, .imagify-cell-optimized, .imagify-cell-original, .imagify-cell-level").text(""),void b.imagifyHide().after(d)))},displayShareBox:function(){var b,d,e,f,g=imagifyBulk.labels.textToShare;if(!this.globalGain||this.queue.length)return this.globalGain=0,this.globalOriginalSize=0,void(this.globalOptimizedSize=0);b=(100-this.globalOptimizedSize/this.globalOriginalSize*100).toFixed(2),d=c.imagify.humanSize(this.globalGain,1),e=c.imagify.humanSize(this.globalOriginalSize,1),g=g.replace("%1$s",d),g=g.replace("%2$s",e),g=encodeURIComponent(g),f=a(".imagify-row-complete"),f.find(".imagify-ac-rt-total-gain").html(d),f.find(".imagify-ac-rt-total-original").html(e),f.find(".imagify-ac-chart").attr("data-percent",b),f.find(".imagify-sn-twitter").attr("href",imagifyBulk.labels.twitterShareURL+"&amp;text="+g),this.drawShareChart(),f.addClass("done").imagifyShow(),a("html, body").animate({scrollTop:f.offset().top},200),this.globalGain=0,this.globalOriginalSize=0,this.globalOptimizedSize=0},openLevelSelectorFromButton:function(b){var c=a("#"+a(this).attr("aria-controls"));b.stopPropagation(),a(".imagify-level-selector-list").not(c).attr("aria-hidden","true"),c.attr("aria-hidden","false").find(":checked").trigger("focus.imagify")},syncLevelSelectorFromRadio:function(){var b=a(this).closest(".imagify-level-choice");b.addClass("imagify-current-level").attr("aria-current","true").siblings(".imagify-level-choice").removeClass("imagify-current-level").attr("aria-current","false"),b.closest(".imagify-level-selector").find(".imagify-current-level-info").html(b.find("label").html())},closeLevelSelectors:function(b){"keypress"===b.type&&27!==b.keyCode&&13!==b.keyCode||c.imagify.bulk.closeLevelSelector(a('.imagify-level-selector-list[aria-hidden="false"]'))},toggleOptimizationButton:function(){if(!c.imagify.bulk.hasMultipleRows&&!this.checked)return void a(this).prop("checked",!0);a('.imagify-bulk-table [name="group[]"]:checked').length?a("#imagify-bulk-action").removeAttr("disabled"):a("#imagify-bulk-action").attr("disabled","disabled")},toggleOptimizationDetails:function(b){var c,d=a(this),e=d.closest(".imagify-bulk-table").find(".imagify-bulk-table-details");c="open"===b.type||"close"!==b.type&&e.hasClass("hidden"),c?(d.html(d.data("label-hide")+'<span class="dashicons dashicons-no-alt"></span>'),e.imagifyShow()):(d.html(d.data("label-show")+'<span class="dashicons dashicons-menu"></span>'),e.imagifyHide())},maybeLaunchAllProcesses:function(){var b;if(!imagifyBulk.keyIsValid)return void c.imagify.bulk.displayError({title:imagifyBulk.labels.invalidAPIKeyTitle,type:"info"});if(imagifyBulk.curlMissing)return void c.imagify.bulk.displayError("",imagifyBulk.labels.curlMissing);if(a('.imagify-bulk-table [name="group[]"]:checked').length&&!a(this).attr("disabled")){if(imagifyBulk.isOverQuota)return void c.imagify.bulk.displayError({title:imagifyBulk.labels.overQuotaTitle,html:a("#tmpl-imagify-overquota-alert").html(),type:"info",customClass:"imagify-swal-has-subtitle imagify-swal-error-header",showConfirmButton:!1});b=a("#tmpl-imagify-bulk-infos"),b.length?swal({title:imagifyBulk.labels.bulkInfoTitle,html:b.html(),type:"",customClass:"imagify-sweet-alert imagify-swal-has-subtitle imagify-before-bulk-infos",showCancelButton:!0,padding:0,width:554,confirmButtonText:imagifyBulk.labels.confirmBulk,cancelButtonText:imagifySwal.labels.cancelButtonText,reverseButtons:!0}).then(function(){var d=a('.imagify-bulk-table [name="group[]"]:checked').first().closest(".imagify-row-folder-type"),e=d.data("group-id"),f=d.data("context");a.get(ajaxurl+c.imagify.concat+"_wpnonce="+imagifyBulk.ajaxNonce+"&action="+imagifyBulk.ajaxActions.bulkInfoSeen+"&folder_type="+e+"&context="+f),b.remove(),c.imagify.bulk.launchAllProcesses()}).catch(swal.noop):c.imagify.bulk.launchAllProcesses()}},launchAllProcesses:function(){var b=a(c),d=a("#imagify-bulk-action"),e=!0;d.attr("disabled","disabled").find(".dashicons").addClass("rotate"),b.on("beforeunload",this.getConfirmMessage),a(".imagify-row-complete").imagifyHide(200,function(){a(this).removeClass("done")}),a(".imagify-show-table-details").trigger("close.imagify"),this.queue=[],this.status={},this.displayedWaitMessage=!1,this.processIsStopped=!1,this.globalGain=0,this.globalOriginalSize=0,this.globalOptimizedSize=0,a('.imagify-bulk-table [name="group[]"]:checked').each(function(){var b=a(this),d=b.closest(".imagify-row-folder-type"),f=d.data("group-id"),g=d.data("context"),h=d.find('.imagify-cell-level [name="level['+f+']"]:checked').val();if(c.imagify.bulk.queue.push({groupId:f,context:g,level:void 0===h?-1:parseInt(h,10)}),c.imagify.bulk.status[f]={isError:!1,id:"waiting"},e)return e=!1,!0;c.imagify.bulk.displayFolderRow("waiting",d)}),b.trigger("processQueue.imagify")},processQueue:function(){var b,d;if(!c.imagify.bulk.processIsStopped){if(!c.imagify.bulk.queue.length)return void a(c).trigger("queueEmpty.imagify");c.imagify.bulk.displayedWaitMessage||(swal({title:imagifyBulk.labels.waitTitle,html:imagifyBulk.labels.waitText,showConfirmButton:!1,padding:0,imageUrl:imagifyBulk.waitImageUrl,customClass:"imagify-sweet-alert"}).catch(swal.noop),c.imagify.bulk.displayedWaitMessage=!0),d=c.imagify.bulk.queue.shift(),b=a("#cb-select-"+d.groupId).closest(".imagify-row-folder-type"),c.imagify.bulk.status[d.groupId].id="fetching",c.imagify.bulk.displayFolderRow("working",b),a.get(c.imagify.bulk.getAjaxUrl("%GROUP_ID%Fetch",d)).done(function(e){if(!c.imagify.bulk.processIsStopped)if(swal.close(),e.success&&(a.isArray(e.data)||a.isPlainObject(e.data))){if(!a.isEmptyObject(e.data))return void a(c).trigger("optimizeFiles.imagify",[d,e.data]);if(c.imagify.bulk.status[d.groupId].id="no-images",!c.imagify.bulk.processIsStopped){if(c.imagify.bulk.hasMultipleRows&&a("#cb-select-"+d.groupId).prop("checked",!1),!c.imagify.bulk.queue.length)return void a(c).trigger("queueEmpty.imagify");c.imagify.bulk.displayFolderRow("resting",b),a(c).trigger("processQueue.imagify")}}else c.imagify.bulk.stopProcess(e.data.message,d)}).fail(function(){c.imagify.bulk.stopProcess("get-unoptimized-images",d)})}},optimizeFiles:function(b,d,e){var f,g,h=a("#cb-select-"+d.groupId).closest(".imagify-row-folder-type"),i=h.next(".imagify-row-working"),j=i.find(".imagify-cell-images-optimized span"),k=parseInt(j.text(),10),l=i.find(".imagify-cell-errors span"),m=parseInt(l.text(),10),n=h.closest(".imagify-bulk-table"),o=n.find(".imagify-row-progress"),p=o.find(".bar"),q={groupId:d.groupId,id:0,thumbnail:"",filename:"",status:"",icon:"",label:"",thumbnails:"",original_size_human:"",new_size_human:"",chartSuffix:"",percent_human:"",overall_saving_human:""};c.imagify.bulk.processIsStopped||(c.imagify.bulk.status[d.groupId].id="optimizing",n.find(".imagify-bulk-table-details thead").html(a("#tmpl-imagify-file-header-"+d.groupId).html()),g=n.find(".imagify-bulk-table-details tbody").text(""),p.css("width","0%").find(".percent").text("0%"),o.slideDown().attr("aria-hidden","false"),f=new ImagifyGulp({buffer_size:imagifyBulk.bufferSizes[d.context]||1,lib:c.imagify.bulk.getAjaxUrl("%GROUP_ID%Optimize",d),images:e,context:d.context}),f.before(function(b){var e=c.imagify.template("imagify-file-row-"+d.groupId);g.prepend(e(a.extend({},q,{status:"compressing",icon:"admin-generic rotate",label:imagifyBulk.labels.optimizing,chartSuffix:b.image_id},b)))}),f.each(function(b){var e=c.imagify.template("imagify-file-row-"+d.groupId),g=a("#"+d.groupId+"-"+b.image);return p.css("width",b.progress+"%").find(".percent").html(b.progress+"%"),b.success?(g.replaceWith(e(a.extend({},q,{status:"complete",icon:"yes",label:imagifyBulk.labels.complete,chartSuffix:b.image},b))),c.imagify.bulk.drawFileChart(a("#"+d.groupId+"-"+b.image).find(".imagify-cell-percentage canvas")),k+=1,void j.text(k)):"already-optimized"===b.error_code?(g.replaceWith(c.imagify.bulk.displayErrorInRow(e(a.extend({},q,{status:"complete",icon:"yes",label:imagifyBulk.labels.alreadyOptimized,chartSuffix:b.image},b)),b.error)),k+=1,void j.text(k)):(g.replaceWith(c.imagify.bulk.displayErrorInRow(e(a.extend({},q,{status:"error",icon:"dismiss",label:imagifyBulk.labels.error,chartSuffix:b.image},b)),b.error||b)),l.length?(m+=1,l.text(m)):(m=1,l=i.find(".imagify-cell-errors").html(imagifyBulk.labels.imagesErrorText.replace("%s","<span>1</span>")).find("span")),void("over-quota"===b.error_code&&(f.stopProcess(),c.imagify.bulk.stopProcess(b.error_code,d))))}),f.done(function(b){c.imagify.bulk.hasMultipleRows&&a("#cb-select-"+d.groupId).prop("checked",!1),b.global_original_size&&(c.imagify.bulk.globalGain+=parseInt(b.global_gain,10),c.imagify.bulk.globalOriginalSize+=parseInt(b.global_original_size,10),c.imagify.bulk.globalOptimizedSize+=parseInt(b.global_optimized_size,10)),c.imagify.bulk.processIsStopped||(c.imagify.bulk.status[d.groupId].isError||(c.imagify.bulk.status[d.groupId].id="done"),h.addClass("updating"),a.get(c.imagify.bulk.getAjaxUrl("getFolderData",d)).done(function(b){b.success&&a.each(b.data,function(a,b){h.children(".imagify-cell-"+a).html(b)}),c.imagify.bulk.displayFolderRow("resting",h)}).always(function(){h.removeClass("updating"),c.imagify.bulk.queue.length?a(c).trigger("processQueue.imagify"):a(c).trigger("queueEmpty.imagify")}))}),f.run())},queueEmpty:function(){var b=a(".imagify-bulk-table"),d={},e=!1,f=!0;c.imagify.bulk.displayShareBox(),c.imagify.bulk.queue=[],a.isEmptyObject(c.imagify.bulk.status)||(a.each(c.imagify.bulk.status,function(a,b){return b.isError?(e=b.id,f=!1,!1):"no-images"!==b.id?(f=!1,!1):void 0}),e?("invalid-api-key"===e?d={title:imagifyBulk.labels.invalidAPIKeyTitle,type:"info"}:"over-quota"===e?d={title:imagifyBulk.labels.overQuotaTitle,html:a("#tmpl-imagify-overquota-alert").html(),type:"info",customClass:"imagify-swal-has-subtitle imagify-swal-error-header",showConfirmButton:!1}:"get-unoptimized-images"!==e&&"consumed-all-data"!==e||(d={title:imagifyBulk.labels.getUnoptimizedImagesErrorTitle,html:imagifyBulk.labels.getUnoptimizedImagesErrorText,type:"info"}),c.imagify.bulk.displayError(d)):f&&c.imagify.bulk.displayError({title:imagifyBulk.labels.noAttachmentToOptimizeTitle,html:imagifyBulk.labels.noAttachmentToOptimizeText,type:"info"})),c.imagify.bulk.status={},a(c).off("beforeunload",c.imagify.bulk.getConfirmMessage),c.imagify.bulk.displayFolderRow("resting",b.find(".imagify-row-folder-type").not(".updating")),b.find(".imagify-row-progress").slideUp().attr("aria-hidden","true").find(".bar").removeAttr("style").find(".percent").text("0%"),a('.imagify-bulk-table [name="group[]"]:checked').length?a("#imagify-bulk-action").removeAttr("disabled").find(".dashicons").removeClass("rotate"):a("#imagify-bulk-action").find(".dashicons").removeClass("rotate")},addHeartbeat:function(b,d){d.imagify_heartbeat=imagifyBulk.heartbeatId,c.imagify.bulk.folderTypes.length||a(".imagify-row-folder-type").each(function(){c.imagify.bulk.folderTypes.push(a(this).data("group-id"))}),d.imagify_types=c.imagify.bulk.folderTypes},processHeartbeat:function(b,d){var e;d.imagify_bulk_data&&(d=d.imagify_bulk_data,c.imagify.bulk.charts.overview.donut.data&&(e=c.imagify.bulk.charts.overview.donut.data.datasets[0].data,d.unoptimized_attachments===e[0]&&d.optimized_attachments===e[1]&&d.errors_attachments===e[2])||(d.unconsumed_quota=d.unconsumed_quota.toFixed(1),a(".imagify-unconsumed-percent").html(d.unconsumed_quota+"%"),a(".imagify-unconsumed-bar").css("width",d.unconsumed_quota+"%"),a("#imagify-overview-chart-percent").html(d.optimized_attachments_percent+"<span>%</span>"),a(".imagify-total-percent").html(d.optimized_attachments_percent+"%"),c.imagify.bulk.drawOverviewChart([d.unoptimized_attachments,d.optimized_attachments,d.errors_attachments]),a("#imagify-total-optimized-attachments").html(d.already_optimized_attachments),a("#imagify-original-bar").find(".imagify-barnb").html(d.original_human),a("#imagify-optimized-bar").css("width",100-d.optimized_percent+"%").find(".imagify-barnb").html(d.optimized_human),a("#imagify-total-optimized-attachments-pct").html(d.optimized_percent+"%")))},share:function(a){var d,e;a.preventDefault(),c.innerWidth?(d=(c.innerWidth-700)/2,e=(c.innerHeight-290)/2):(d=(b.body.clientWidth-700)/2,e=(b.body.clientHeight-290)/2),c.open(this.href,"","status=no, scrollbars=no, menubar=no, top="+e+", left="+d+", width=700, height=290")}},c.imagify.bulk.init()}(jQuery,document,window);
+(function( $, undefined ) { // eslint-disable-line no-shadow, no-shadow-restricted-names
+
+	var jqPropHookChecked = $.propHooks.checked;
+
+	// Force `.prop()` to trigger a `change` event.
+	$.propHooks.checked = {
+		set: function( elem, value, name ) {
+			var ret;
+
+			if ( undefined === jqPropHookChecked ) {
+				ret = ( elem[ name ] = value );
+			} else {
+				ret = jqPropHookChecked( elem, value, name );
+			}
+
+			$( elem ).trigger( 'change.imagify' );
+
+			return ret;
+		}
+	};
+
+	// Custom jQuery functions =====================================================================
+	/**
+	 * Hide element(s).
+	 *
+	 * @param  {int}      duration A duration in ms.
+	 * @param  {function} callback A callback to execute once the element is hidden.
+	 * @return {element}  The jQuery element(s).
+	 */
+	$.fn.imagifyHide = function( duration, callback ) {
+		if ( duration && duration > 0 ) {
+			this.hide( duration, function() {
+				$( this ).addClass( 'hidden' ).css( 'display', '' );
+
+				if ( undefined !== callback ) {
+					callback();
+				}
+			} );
+		} else {
+			this.addClass( 'hidden' );
+
+			if ( undefined !== callback ) {
+				callback();
+			}
+		}
+
+		return this.attr( 'aria-hidden', 'true' );
+	};
+
+	/**
+	 * Show element(s).
+	 *
+	 * @param  {int}      duration A duration in ms.
+	 * @param  {function} callback A callback to execute before starting to display the element.
+	 * @return {element} The jQuery element(s).
+	 */
+	$.fn.imagifyShow = function( duration, callback ) {
+		if ( undefined !== callback ) {
+			callback();
+		}
+
+		if ( duration && duration > 0 ) {
+			this.show( duration, function() {
+				$( this ).removeClass( 'hidden' ).css( 'display', '' );
+			} );
+		} else {
+			this.removeClass( 'hidden' );
+		}
+
+		return this.attr( 'aria-hidden', 'false' );
+	};
+
+}( jQuery ));
+
+
+(function($, d, w, undefined) { // eslint-disable-line no-unused-vars, no-shadow, no-shadow-restricted-names
+
+	w.imagify.bulk = {
+
+		// Properties ==============================================================================
+		charts: {
+			overview: {
+				canvas: false,
+				donut:  false,
+				data:   {
+					// Order: unoptimized, optimized, error.
+					labels: [
+						imagifyBulk.labels.overviewChartLabels.unoptimized,
+						imagifyBulk.labels.overviewChartLabels.optimized,
+						imagifyBulk.labels.overviewChartLabels.error
+					],
+					datasets: [ {
+						data:            [],
+						backgroundColor: [ '#10121A', '#46B1CE', '#C51162' ],
+						borderWidth:     0
+					} ]
+				}
+			},
+			files: {
+				donuts: {}
+			},
+			share: {
+				canvas: false,
+				donut:  false
+			}
+		},
+		// Folder types in queue.
+		queue:                [],
+		// Status of each folder type.
+		status:               {},
+		// Tell if the message displayed when retrieving the image IDs has been shown once.
+		displayedWaitMessage: false,
+		// Tell how many rows are available.
+		hasMultipleRows:      true,
+		// Set to true to stop the whole thing.
+		processIsStopped:     false,
+		// Global stats.
+		globalGain:           0,
+		globalOriginalSize:   0,
+		globalOptimizedSize:  0,
+		// Heartbeat.
+		folderTypes:          [],
+
+		// Methods =================================================================================
+
+		/*
+		 * Init.
+		 */
+		init: function () {
+			// Overview chart.
+			this.drawOverviewChart();
+
+			if ( ! imagifyBulk.keyIsValid ) {
+				$( '#imagify-bulk-action' ).on( 'click.imagify', this.maybeLaunchAllProcesses );
+				return;
+			}
+
+			this.hasMultipleRows = $( '.imagify-bulk-table [name="group[]"]' ).length > 1;
+
+			// Optimization level selector.
+			$( '.imagify-level-selector-button' )
+				.on( 'click.imagify', this.openLevelSelectorFromButton );
+
+			$( '.imagify-level-selector-list input' )
+				.on( 'change.imagify init.imagify', this.syncLevelSelectorFromRadio )
+				.filter( ':checked' )
+				.trigger( 'init.imagify' );
+
+			$( d )
+				.on( 'keypress.imagify click.imagify', this.closeLevelSelectors );
+
+			// Other buttons/UI.
+			$( '.imagify-bulk-table [name="group[]"]' ).on( 'change.imagify init.imagify', this.toggleOptimizationButton ).trigger( 'init.imagify' );
+			$( '.imagify-show-table-details' ).on( 'click.imagify open.imagify close.imagify', this.toggleOptimizationDetails );
+			$( '#imagify-bulk-action' ).on( 'click.imagify', this.maybeLaunchAllProcesses );
+			$( '.imagify-share-networks a' ).on( 'click.imagify', this.share );
+
+			if ( imagifyBulk.curlMissing ) {
+				return;
+			}
+
+			// Optimization events.
+			$( w )
+				.on( 'processQueue.imagify', this.processQueue )
+				.on( 'optimizeFiles.imagify', this.optimizeFiles )
+				.on( 'queueEmpty.imagify', this.queueEmpty );
+
+			// Heartbeat.
+			if ( imagifyBulk.ajaxActions.getStats && $( '.imagify-bulk-table [data-group-id="library"][data-context="wp"]' ).length ) {
+				// If large library.
+				imagifyBulk.heartbeatId = false;
+			}
+
+			if ( imagifyBulk.heartbeatId ) {
+				$( d )
+					.on( 'heartbeat-send', this.addHeartbeat )
+					.on( 'heartbeat-tick', this.processHeartbeat );
+			}
+		},
+
+		/**
+		 * Overview chart.
+		 * Used for the big overview chart.
+		 */
+		drawOverviewChart: function ( data ) {
+			var initData, legend;
+
+			if ( ! this.charts.overview.canvas ) {
+				this.charts.overview.canvas = d.getElementById( 'imagify-overview-chart' );
+
+				if ( ! this.charts.overview.canvas ) {
+					return;
+				}
+			}
+
+			data = data && $.isArray( data ) ? data : [];
+
+			if ( this.charts.overview.donut ) {
+				// Update existing donut.
+				if ( data.length ) {
+					if ( data.reduce( function( a, b ) { return a + b; }, 0 ) === 0 ) {
+						data[0] = 1;
+					}
+
+					this.charts.overview.donut.data.datasets[0].data = data;
+					this.charts.overview.donut.update();
+				}
+				return;
+			}
+
+			// Create new donut.
+			this.charts.overview.data.datasets[0].data = [
+				parseInt( this.charts.overview.canvas.getAttribute( 'data-unoptimized' ), 10 ),
+				parseInt( this.charts.overview.canvas.getAttribute( 'data-optimized' ), 10 ),
+				parseInt( this.charts.overview.canvas.getAttribute( 'data-errors' ), 10 )
+			];
+			initData = $.extend( {}, this.charts.overview.data );
+
+			if ( data.length ) {
+				initData.datasets[0].data = data;
+			}
+
+			if ( initData.datasets[0].data.reduce( function( a, b ) { return a + b; }, 0 ) === 0 ) {
+				initData.datasets[0].data[0] = 1;
+			}
+
+			this.charts.overview.donut = new w.imagify.Chart( this.charts.overview.canvas, {
+				type:    'doughnut',
+				data:    initData,
+				options: {
+					legend: {
+						display: false
+					},
+					events:    [],
+					animation: {
+						easing: 'easeOutBounce'
+					},
+					tooltips: {
+						displayColors: false,
+						callbacks:     {
+							label: function( tooltipItem, localData ) {
+								return localData.datasets[ tooltipItem.datasetIndex ].data[ tooltipItem.index ];
+							}
+						}
+					},
+					responsive:       false,
+					cutoutPercentage: 85
+				}
+			} );
+
+			// Then generate the legend and insert it to your page somewhere.
+			legend = '<ul class="imagify-doughnut-legend">';
+
+			$.each( initData.labels, function( i, label ) {
+				legend += '<li><span style="background-color:' + initData.datasets[0].backgroundColor[ i ] + '"></span>' + label + '</li>';
+			} );
+
+			legend += '</ul>';
+
+			d.getElementById( 'imagify-overview-chart-legend' ).innerHTML = legend;
+		},
+
+		/**
+		 * Mini chart.
+		 * Used for the charts on each file row.
+		 *
+		 * @param {element} canvas A jQuery canvas element.
+		 */
+		drawFileChart: function ( canvas ) {
+			var donuts = this.charts.files.donuts;
+
+			canvas.each( function() {
+				var value = parseInt( $( this ).closest( '.imagify-chart' ).next( '.imagipercent' ).text().replace( '%', '' ), 10 );
+
+				if ( undefined !== donuts[ this.id ] ) {
+					// Update existing donut.
+					donuts[ this.id ].data.datasets[0].data[0] = value;
+					donuts[ this.id ].data.datasets[0].data[1] = 100 - value;
+					donuts[ this.id ].update();
+					return;
+				}
+
+				// Create new donut.
+				donuts[ this.id ] = new w.imagify.Chart( this, {
+					type: 'doughnut',
+					data: {
+						datasets: [{
+							data:            [ value, 100 - value ],
+							backgroundColor: [ '#00B3D3', '#D8D8D8' ],
+							borderColor:     '#fff',
+							borderWidth:     1
+						}]
+					},
+					options: {
+						legend: {
+							display: false
+						},
+						events:    [],
+						animation: {
+							easing: 'easeOutBounce'
+						},
+						tooltips: {
+							enabled: false
+						},
+						responsive: false
+					}
+				} );
+			} );
+
+			this.charts.files.donuts = donuts;
+		},
+
+		/*
+		 * Share Chart.
+		 * Used for the chart in the share box.
+		 */
+		drawShareChart: function () {
+			var value;
+
+			if ( ! this.charts.share.canvas ) {
+				this.charts.share.canvas = d.getElementById( 'imagify-ac-chart' );
+
+				if ( ! this.charts.share.canvas ) {
+					return;
+				}
+			}
+
+			value = parseInt( $( this.charts.share.canvas ).closest( '.imagify-ac-chart' ).attr( 'data-percent' ), 10 );
+
+			if ( this.charts.share.donut ) {
+				// Update existing donut.
+				this.charts.share.donut.data.datasets[0].data[0] = value;
+				this.charts.share.donut.data.datasets[0].data[1] = 100 - value;
+				this.charts.share.donut.update();
+				return;
+			}
+
+			// Create new donut.
+			this.charts.share.donut = new w.imagify.Chart( this.charts.share.canvas, {
+				type: 'doughnut',
+				data: {
+					datasets: [{
+						data:            [ value, 100 - value ],
+						backgroundColor: [ '#40B1D0', '#FFFFFF' ],
+						borderWidth:     0
+					}]
+				},
+				options: {
+					legend: {
+						display: false
+					},
+					events:    [],
+					animation: {
+						easing: 'easeOutBounce'
+					},
+					tooltips: {
+						enabled: false
+					},
+					responsive:       false,
+					cutoutPercentage: 70
+				}
+			} );
+		},
+
+		/*
+		 * Get the URL used for ajax requests.
+		 *
+		 * @param  {string} action An ajax action, or part of it.
+		 * @param  {object} item   The current item.
+		 * @return {string}
+		 */
+		getAjaxUrl: function ( action, item ) {
+			var camelGroupID = item.groupId.replace( /[\s_-](\S)/g, function( c, l ) {
+				return l.toUpperCase();
+			} );
+
+			action = action.replace( '%GROUP_ID%', camelGroupID );
+			action = imagifyBulk.ajaxActions[ action ];
+
+			return ajaxurl + w.imagify.concat + '_wpnonce=' + imagifyBulk.ajaxNonce + '&optimization_level=' + item.level + '&action=' + action + '&folder_type=' + item.groupId;
+		},
+
+		/**
+		 * Get folder types used in the page.
+		 *
+		 * @return {array}
+		 */
+		getFolderTypes: function () {
+			if ( ! w.imagify.bulk.folderTypes.length ) {
+				$( '.imagify-row-folder-type' ).each( function() {
+					var $this   = $( this ),
+						groupID = $this.data( 'group-id' );
+
+					if ( 'library' === groupID ) {
+						groupID += '|' + $this.data( 'context' );
+					}
+
+					w.imagify.bulk.folderTypes.push( groupID );
+				} );
+			}
+
+			return w.imagify.bulk.folderTypes;
+		},
+
+		/*
+		 * Get the message displayed to the user when (s)he leaves the page.
+		 *
+		 * @return {string}
+		 */
+		getConfirmMessage: function () {
+			return imagifyBulk.labels.processing;
+		},
+
+		/*
+		 * Close the given optimization level selector.
+		 *
+		 * @param {object} $lists A jQuery object.
+		 * @param {int}    timer  Timer in ms to close the selector.
+		 */
+		closeLevelSelector: function ( $lists, timer ) {
+			if ( ! $lists || ! $lists.length ) {
+				return;
+			}
+
+			if ( undefined !== timer && timer > 0 ) {
+				w.setTimeout( function() {
+					w.imagify.bulk.closeLevelSelector( $lists );
+				}, timer );
+				return;
+			}
+
+			$lists.attr( 'aria-hidden', 'true' );
+		},
+
+		/*
+		 * Stop everything and update the current item status as an error.
+		 *
+		 * @param {string} errorId An error ID.
+		 * @param {object} item    The current item.
+		 */
+		stopProcess: function ( errorId, item ) {
+			this.processIsStopped = true;
+
+			w.imagify.bulk.status[ item.groupId ] = {
+				isError: true,
+				id:      errorId
+			};
+
+			$( w ).trigger( 'queueEmpty.imagify' );
+		},
+
+		/*
+		 * Display an error message in a modal.
+		 *
+		 * @param {string} title The modal title.
+		 * @param {string} text  The modal text.
+		 * @param {object} args  Other less common args.
+		 */
+		displayError: function ( title, text, args ) {
+			var def = {
+				title:             '',
+				html:              '',
+				type:              'error',
+				customClass:       '',
+				width:             620,
+				padding:           0,
+				showCloseButton:   true,
+				showConfirmButton: true
+			};
+
+			if ( $.isPlainObject( title ) ) {
+				args = $.extend( {}, def, title );
+			} else {
+				args = args || {};
+				args = $.extend( {}, def, {
+					title: title || '',
+					html:  text  || ''
+				}, args );
+			}
+
+			args.title        = args.title || imagifyBulk.labels.error;
+			args.customClass += ' imagify-sweet-alert';
+
+			swal( args ).catch( swal.noop );
+		},
+
+		/*
+		 * Display an error message in a file row.
+		 *
+		 * @param  {function} $row The row template.
+		 * @param  {string}   text The error text.
+		 * @return {element}       The row jQuery element.
+		 */
+		displayErrorInRow: function ( $row, text ) {
+			var $toReplace, colspan;
+
+			$row       = $( $row() );
+			$toReplace = $row.find( '.imagify-cell-status ~ td' );
+			colspan    = $toReplace.length;
+			text       = text || '';
+
+			$toReplace.remove();
+			$row.find( '.imagify-cell-status' ).after( '<td colspan="' + colspan + '">' + text + '</td>' );
+
+			return $row;
+		},
+
+		/*
+		 * Display one of the 3 "folder" rows.
+		 *
+		 * @param {string}  state One of the 3 states: 'resting' (it's the "normal" row), 'waiting' (waiting for other optimizations to finish), and 'working'.
+		 * @param {element} $row  jQuery element of the "normal" row.
+		 */
+		displayFolderRow: function ( state, $row ) {
+			var $newRow, spinnerTemplate, spinnerColor, text;
+
+			if ( 'resting' === state ) {
+				$row.next( '.imagify-row-waiting, .imagify-row-working' ).remove();
+				$row.imagifyShow();
+				return;
+			}
+
+			// This part won't work to display multiple $newRow.
+			$newRow = $row.next( '.imagify-row-waiting, .imagify-row-working' );
+
+			if ( 'waiting' === state ) {
+				spinnerColor = '#d2d3d6';
+				text         = imagifyBulk.labels.waitingOtimizationsText;
+			} else {
+				spinnerColor = '#40b1d0';
+				text         = imagifyBulk.labels.imagesOptimizedText.replace( '%s', '<span>0</span>' );
+			}
+
+			if ( $newRow.length ) {
+				if ( ! $newRow.hasClass( 'imagify-row-' + state ) ) {
+					// Should happen when switching from 'waiting' to 'working'.
+					$newRow.attr( 'class', 'imagify-row-' + state );
+					$newRow.find( '.imagify-cell-checkbox svg' ).attr( 'fill', spinnerColor );
+					$newRow.children( '.imagify-cell-images-optimized' ).html( text );
+				}
+
+				$row.imagifyHide();
+				$newRow.imagifyShow();
+				return;
+			}
+
+			// Build the new row, based on a clone of the original one.
+			$newRow = $row.clone().attr( {
+				'class':       'imagify-row-' + state,
+				'aria-hidden': 'false'
+			} );
+
+			spinnerTemplate = w.imagify.template( 'imagify-spinner' );
+			$newRow.children( '.imagify-cell-checkbox' ).html( spinnerTemplate() ).find( 'svg' ).attr( 'fill', spinnerColor );
+			$newRow.children( '.imagify-cell-title' ).html( '<span class="imagify-cell-label">' + $newRow.children( '.imagify-cell-title' ).text() + '</span>' );
+			$newRow.children( '.imagify-cell-images-optimized' ).html( text );
+			$newRow.children( '.imagify-cell-errors, .imagify-cell-optimized, .imagify-cell-original, .imagify-cell-level' ).text( '' );
+
+			$row.imagifyHide().after( $newRow );
+		},
+
+		/*
+		 * Display the share box.
+		 */
+		displayShareBox: function () {
+			var text2share = imagifyBulk.labels.textToShare,
+				percent, gainHuman, originalSizeHuman,
+				$complete;
+
+			if ( ! this.globalGain || this.queue.length ) {
+				this.globalGain          = 0;
+				this.globalOriginalSize  = 0;
+				this.globalOptimizedSize = 0;
+				return;
+			}
+
+			percent           = ( 100 - 100 * ( this.globalOptimizedSize / this.globalOriginalSize ) ).toFixed( 2 );
+			gainHuman         = w.imagify.humanSize( this.globalGain, 1 );
+			originalSizeHuman = w.imagify.humanSize( this.globalOriginalSize, 1 );
+
+			text2share = text2share.replace( '%1$s', gainHuman );
+			text2share = text2share.replace( '%2$s', originalSizeHuman );
+			text2share = encodeURIComponent( text2share );
+
+			$complete = $( '.imagify-row-complete' );
+			$complete.find( '.imagify-ac-rt-total-gain' ).html( gainHuman );
+			$complete.find( '.imagify-ac-rt-total-original' ).html( originalSizeHuman );
+			$complete.find( '.imagify-ac-chart' ).attr( 'data-percent', percent );
+			$complete.find( '.imagify-sn-twitter' ).attr( 'href', imagifyBulk.labels.twitterShareURL + '&amp;text=' + text2share );
+
+			// Chart.
+			this.drawShareChart();
+
+			$complete.addClass( 'done' ).imagifyShow();
+
+			$( 'html, body' ).animate( {
+				scrollTop: $complete.offset().top
+			}, 200 );
+
+			// Reset the stats.
+			this.globalGain          = 0;
+			this.globalOriginalSize  = 0;
+			this.globalOptimizedSize = 0;
+		},
+
+		/**
+		 * Print optimization stats.
+		 *
+		 * @param {object} data Object containing all Heartbeat IDs.
+		 */
+		updateStats: function ( data ) {
+			var donutData;
+
+			if ( ! data || ! $.isPlainObject( data ) ) {
+				return;
+			}
+
+			if ( w.imagify.bulk.charts.overview.donut.data ) {
+				donutData = w.imagify.bulk.charts.overview.donut.data.datasets[0].data;
+
+				if ( data.unoptimized_attachments === donutData[0] && data.optimized_attachments === donutData[1] && data.errors_attachments === donutData[2] ) {
+					return;
+				}
+			}
+
+			/**
+			 * User account.
+			 */
+			data.unconsumed_quota = data.unconsumed_quota.toFixed( 1 ); // A mystery where a float rounded on php side is not rounded here anymore. JavaScript is fun, it always surprises you in a manner you didn't expect.
+			$( '.imagify-unconsumed-percent' ).html( data.unconsumed_quota + '%' );
+			$( '.imagify-unconsumed-bar' ).css( 'width', data.unconsumed_quota + '%' );
+
+			/**
+			 * Global chart.
+			 */
+			$( '#imagify-overview-chart-percent' ).html( data.optimized_attachments_percent + '<span>%</span>' );
+			$( '.imagify-total-percent' ).html( data.optimized_attachments_percent + '%' );
+
+			w.imagify.bulk.drawOverviewChart( [
+				data.unoptimized_attachments,
+				data.optimized_attachments,
+				data.errors_attachments
+			] );
+
+			/**
+			 * Stats block.
+			 */
+			// The total optimized images.
+			$( '#imagify-total-optimized-attachments' ).html( data.already_optimized_attachments );
+
+			// The original bar.
+			$( '#imagify-original-bar' ).find( '.imagify-barnb' ).html( data.original_human );
+
+			// The optimized bar.
+			$( '#imagify-optimized-bar' ).css( 'width', ( 100 - data.optimized_percent ) + '%' ).find( '.imagify-barnb' ).html( data.optimized_human );
+
+			// The Percent data.
+			$( '#imagify-total-optimized-attachments-pct' ).html( data.optimized_percent + '%' );
+		},
+
+		// Event callbacks =========================================================================
+
+		/*
+		 * Optimization level selector: on button click, open the dropdown and focus the current radio input.
+		 * The dropdown must be open or the focus event won't be triggered.
+		 *
+		 * @param {object} e jQuery's Event object.
+		 */
+		openLevelSelectorFromButton: function ( e ) {
+			var $list = $( '#' + $( this ).attr( 'aria-controls' ) );
+			// Stop click event from bubbling: this will allow to close the selector list if anything else id clicked.
+			e.stopPropagation();
+			// Close other lists.
+			$( '.imagify-level-selector-list' ).not( $list ).attr( 'aria-hidden', 'true' );
+			// Open the corresponding list and focus the radio.
+			$list.attr( 'aria-hidden', 'false' ).find( ':checked' ).trigger( 'focus.imagify' );
+		},
+
+		/*
+		 * Optimization level selector: on radio change, make the row "current" and update the button text.
+		 */
+		syncLevelSelectorFromRadio: function () {
+			var $row = $( this ).closest( '.imagify-level-choice' );
+			// Update rows attributes.
+			$row.addClass( 'imagify-current-level' ).attr( 'aria-current', 'true' ).siblings( '.imagify-level-choice' ).removeClass( 'imagify-current-level' ).attr( 'aria-current', 'false' );
+			// Change the button text.
+			$row.closest( '.imagify-level-selector' ).find( '.imagify-current-level-info' ).html( $row.find( 'label' ).html() );
+		},
+
+		/*
+		 * Optimization level selector: on Escape or Enter kaystroke, close the dropdown.
+		 *
+		 * @param {object} e jQuery's Event object.
+		 */
+		closeLevelSelectors: function ( e ) {
+			if ( 'keypress' === e.type && 27 !== e.keyCode && 13 !== e.keyCode ) {
+				return;
+			}
+			w.imagify.bulk.closeLevelSelector( $( '.imagify-level-selector-list[aria-hidden="false"]' ) );
+		},
+
+		/*
+		 * Enable or disable the Optimization button depending on the checked checkboxes.
+		 * Also, if there is only 1 checkbox in the page, don't allow it to be unchecked.
+		 */
+		toggleOptimizationButton: function () {
+			// Prevent uncheck if there is only one checkbox.
+			if ( ! w.imagify.bulk.hasMultipleRows && ! this.checked ) {
+				$( this ).prop( 'checked', true );
+				return;
+			}
+
+			// Enable or disable the Optimization button.
+			if ( $( '.imagify-bulk-table [name="group[]"]:checked' ).length ) {
+				$( '#imagify-bulk-action' ).removeAttr( 'disabled' );
+			} else {
+				$( '#imagify-bulk-action' ).attr( 'disabled', 'disabled' );
+			}
+		},
+
+		/*
+		 * Display/Hide optimization details.
+		 *
+		 * @param {object} e jQuery's Event object.
+		 */
+		toggleOptimizationDetails: function ( e ) {
+			var $button  = $( this ),
+				$details = $button.closest( '.imagify-bulk-table' ).find( '.imagify-bulk-table-details' ),
+				openDetails;
+
+			if ( 'open' === e.type ) {
+				openDetails = true;
+			} else if ( 'close' === e.type ) {
+				openDetails = false;
+			} else {
+				openDetails = $details.hasClass( 'hidden' );
+			}
+
+			if ( openDetails ) {
+				$button.html( $button.data( 'label-hide' ) + '<span class="dashicons dashicons-no-alt"></span>' );
+				$details.imagifyShow();
+			} else {
+				$button.html( $button.data( 'label-show' ) + '<span class="dashicons dashicons-menu"></span>' );
+				$details.imagifyHide();
+			}
+		},
+
+		/*
+		 * Maybe display a modal, then launch all processes.
+		 */
+		maybeLaunchAllProcesses: function () {
+			var $infosModal;
+
+			if ( ! imagifyBulk.keyIsValid ) {
+				w.imagify.bulk.displayError( {
+					title: imagifyBulk.labels.invalidAPIKeyTitle,
+					type:  'info'
+				} );
+				return;
+			}
+
+			if ( imagifyBulk.curlMissing ) {
+				w.imagify.bulk.displayError( '', imagifyBulk.labels.curlMissing );
+				return;
+			}
+
+			if ( ! $( '.imagify-bulk-table [name="group[]"]:checked' ).length ) {
+				return;
+			}
+
+			if ( $( this ).attr( 'disabled' ) ) {
+				return;
+			}
+
+			if ( imagifyBulk.isOverQuota ) {
+				// Swal information when over quota.
+				w.imagify.bulk.displayError( {
+					title:             imagifyBulk.labels.overQuotaTitle,
+					html:              $( '#tmpl-imagify-overquota-alert' ).html(),
+					type:              'info',
+					customClass:       'imagify-swal-has-subtitle imagify-swal-error-header',
+					showConfirmButton: false
+				} );
+				return;
+			}
+
+			$infosModal = $( '#tmpl-imagify-bulk-infos' );
+
+			if ( $infosModal.length ) {
+				// Swal Information before loading the optimize process.
+				swal( {
+					title:             imagifyBulk.labels.bulkInfoTitle,
+					html:              $infosModal.html(),
+					type:              '',
+					customClass:       'imagify-sweet-alert imagify-swal-has-subtitle imagify-before-bulk-infos',
+					showCancelButton:  true,
+					padding:           0,
+					width:             554,
+					confirmButtonText: imagifyBulk.labels.confirmBulk,
+					cancelButtonText:  imagifySwal.labels.cancelButtonText,
+					reverseButtons:    true
+				} ).then( function() {
+					var $row    = $( '.imagify-bulk-table [name="group[]"]:checked' ).first().closest( '.imagify-row-folder-type' ),
+						groupId = $row.data( 'group-id' ),
+						context = $row.data( 'context' );
+
+					$.get( ajaxurl + w.imagify.concat + '_wpnonce=' + imagifyBulk.ajaxNonce + '&action=' + imagifyBulk.ajaxActions.bulkInfoSeen + '&folder_type=' + groupId + '&context=' + context );
+					$infosModal.remove();
+
+					w.imagify.bulk.launchAllProcesses();
+				} ).catch( swal.noop );
+			} else {
+				w.imagify.bulk.launchAllProcesses();
+			}
+		},
+
+		/*
+		 * Build the queue and launch all processes.
+		 */
+		launchAllProcesses: function () {
+			var $w      = $( w ),
+				$button = $( '#imagify-bulk-action' ),
+				skip    = true;
+
+			// Disable the button.
+			$button.attr( 'disabled', 'disabled' ).find( '.dashicons' ).addClass( 'rotate' );
+
+			// Add a message to be displayed when the user wants to quit the page.
+			$w.on( 'beforeunload', this.getConfirmMessage );
+
+			// Hide the "Complete" message.
+			$( '.imagify-row-complete' ).imagifyHide( 200, function() {
+				$( this ).removeClass( 'done' );
+			} );
+
+			// Close the optimization details.
+			$( '.imagify-show-table-details' ).trigger( 'close.imagify' );
+
+			// Make sure to reset properties.
+			this.queue                = [];
+			this.status               = {};
+			this.displayedWaitMessage = false;
+			this.processIsStopped     = false;
+			this.globalGain           = 0;
+			this.globalOriginalSize   = 0;
+			this.globalOptimizedSize  = 0;
+
+			$( '.imagify-bulk-table [name="group[]"]:checked' ).each( function() {
+				var $checkbox = $( this ),
+					$row      = $checkbox.closest( '.imagify-row-folder-type' ),
+					groupId   = $row.data( 'group-id' ),
+					context   = $row.data( 'context' ),
+					level     = $row.find( '.imagify-cell-level [name="level[' + groupId + ']"]:checked' ).val();
+
+				// Build the queue.
+				w.imagify.bulk.queue.push( {
+					groupId: groupId,
+					context: context,
+					level:   undefined === level ? -1 : parseInt( level, 10 )
+				} );
+
+				// Set the status.
+				w.imagify.bulk.status[ groupId ] = {
+					isError: false,
+					id:      'waiting'
+				};
+
+				// Display a "waiting" message + spinner into the folder rows.
+				if ( skip ) {
+					// No need to do that for the first one, we'll display a "working" row instead.
+					skip = false;
+					return true;
+				}
+
+				// Display the "waiting" folder row and hide the "normal" one.
+				w.imagify.bulk.displayFolderRow( 'waiting', $row );
+			} );
+
+			// Process the queue.
+			$w.trigger( 'processQueue.imagify' );
+		},
+
+		/*
+		 * Process the first item in the queue.
+		 */
+		processQueue: function () {
+			var $row, item;
+
+			if ( w.imagify.bulk.processIsStopped ) {
+				return;
+			}
+
+			if ( ! w.imagify.bulk.queue.length ) {
+				$( w ).trigger( 'queueEmpty.imagify' );
+				return;
+			}
+
+			if ( ! w.imagify.bulk.displayedWaitMessage ) {
+				// Display an alert to wait.
+				swal( {
+					title:             imagifyBulk.labels.waitTitle,
+					html:              imagifyBulk.labels.waitText,
+					showConfirmButton: false,
+					padding:           0,
+					imageUrl:          imagifyBulk.waitImageUrl,
+					customClass:       'imagify-sweet-alert'
+				} ).catch( swal.noop );
+				w.imagify.bulk.displayedWaitMessage = true;
+			}
+
+			/**
+			 * Fetch files for the first folder type in the queue.
+			 */
+			item = w.imagify.bulk.queue.shift();
+			$row = $( '#cb-select-' + item.groupId ).closest( '.imagify-row-folder-type' );
+
+			// Update status.
+			w.imagify.bulk.status[ item.groupId ].id = 'fetching';
+
+			// Display the "working" folder row and hide the "normal" one.
+			w.imagify.bulk.displayFolderRow( 'working', $row );
+
+			// Fetch image IDs.
+			$.get( w.imagify.bulk.getAjaxUrl( '%GROUP_ID%Fetch', item ) )
+				.done( function( response ) {
+					if ( w.imagify.bulk.processIsStopped ) {
+						return;
+					}
+
+					swal.close();
+
+					// Success.
+					if ( response.success && ( $.isArray( response.data ) || $.isPlainObject( response.data ) ) ) { // Array if empty, object otherwize.
+						if ( ! $.isEmptyObject( response.data ) ) {
+							// Optimize the files.
+							$( w ).trigger( 'optimizeFiles.imagify', [ item, response.data ] );
+							return;
+						}
+
+						// No images.
+						w.imagify.bulk.status[ item.groupId ].id = 'no-images';
+
+						if ( ! w.imagify.bulk.processIsStopped ) {
+							if ( w.imagify.bulk.hasMultipleRows ) {
+								$( '#cb-select-' + item.groupId ).prop( 'checked', false );
+							}
+
+							if ( ! w.imagify.bulk.queue.length ) {
+								$( w ).trigger( 'queueEmpty.imagify' );
+								return;
+							}
+
+							// Reset the folder row.
+							w.imagify.bulk.displayFolderRow( 'resting', $row );
+
+							$( w ).trigger( 'processQueue.imagify' );
+						}
+						return;
+					}
+
+					// Error.
+					w.imagify.bulk.stopProcess( response.data.message, item );
+				} )
+				.fail( function() {
+					// Error.
+					w.imagify.bulk.stopProcess( 'get-unoptimized-images', item );
+				} );
+		},
+
+		/*
+		 * Optimize files.
+		 *
+		 * @param {object} e     jQuery's Event object.
+		 * @param {object} item  Current item (from the queue).
+		 * @param {object} files A list of file IDs (key) and URLs (values).
+		 */
+		optimizeFiles: function ( e, item, files ) {
+			var $row             = $( '#cb-select-' + item.groupId ).closest( '.imagify-row-folder-type' ),
+				$workingRow      = $row.next( '.imagify-row-working' ),
+				$optimizedCount  = $workingRow.find( '.imagify-cell-images-optimized span' ),
+				optimizedCount   = parseInt( $optimizedCount.text(), 10 ),
+				$errorsCount     = $workingRow.find( '.imagify-cell-errors span' ),
+				errorsCount      = parseInt( $errorsCount.text(), 10 ),
+				$table           = $row.closest( '.imagify-bulk-table' ),
+				$progressBar     = $table.find( '.imagify-row-progress' ),
+				$progress        = $progressBar.find( '.bar' ),
+				defaultsTemplate = {
+					groupId:              item.groupId,
+					id:                   0,
+					thumbnail:            '', // Image src.
+					filename:             '',
+					status:               '',
+					icon:                 '',
+					label:                '',
+					thumbnails:           '',
+					original_size_human:  '',
+					new_size_human:       '',
+					chartSuffix:          '',
+					percent_human:        '',
+					overall_saving_human: ''
+				},
+				Optimizer, $resultsContainer;
+
+			if ( w.imagify.bulk.processIsStopped ) {
+				return;
+			}
+
+			// Update folder status.
+			w.imagify.bulk.status[ item.groupId ].id = 'optimizing';
+
+			// Fill in the result table header.
+			$table.find( '.imagify-bulk-table-details thead' ).html( $( '#tmpl-imagify-file-header-' + item.groupId ).html() );
+
+			// Empty the result table body.
+			$resultsContainer = $table.find( '.imagify-bulk-table-details tbody' ).text( '' );
+
+			// Reset and display the progress bar.
+			$progress.css( 'width', '0%' ).find( '.percent' ).text( '0%' );
+			$progressBar.slideDown().attr( 'aria-hidden', 'false' );
+
+			// Optimize the files.
+			Optimizer = new ImagifyGulp( {
+				'buffer_size': imagifyBulk.bufferSizes[ item.context ] || 1,
+				'lib':         w.imagify.bulk.getAjaxUrl( '%GROUP_ID%Optimize', item ),
+				'images':      files,
+				'context':     item.context
+			} );
+
+			// Before the attachment optimization, add a file row displaying the optimization process.
+			Optimizer.before( function( data ) {
+				var template = w.imagify.template( 'imagify-file-row-' + item.groupId );
+
+				$resultsContainer.prepend( template( $.extend( {}, defaultsTemplate, {
+					status:      'compressing',
+					icon:        'admin-generic rotate',
+					label:       imagifyBulk.labels.optimizing,
+					chartSuffix: data.image_id
+				}, data ) ) );
+			} );
+
+			// After the attachment optimization.
+			Optimizer.each( function( data ) {
+				var template = w.imagify.template( 'imagify-file-row-' + item.groupId ),
+					$fileRow = $( '#' + item.groupId + '-' + data.image );
+
+				// Update the progress bar.
+				$progress.css( 'width', data.progress + '%' ).find( '.percent' ).html( data.progress + '%' );
+
+				if ( data.success ) {
+					// Image successfully optimized.
+					$fileRow.replaceWith( template( $.extend( {}, defaultsTemplate, {
+						status:      'complete',
+						icon:        'yes',
+						label:       imagifyBulk.labels.complete,
+						chartSuffix: data.image
+					}, data ) ) );
+
+					w.imagify.bulk.drawFileChart( $( '#' + item.groupId + '-' + data.image ).find( '.imagify-cell-percentage canvas' ) ); // Don't use $fileRow, its DOM is not refreshed with the new values.
+
+					// Update the optimized images counter.
+					optimizedCount += 1;
+					$optimizedCount.text( optimizedCount );
+					return;
+				}
+
+				if ( 'already-optimized' === data.error_code ) {
+					// The image was already optimized.
+					$fileRow.replaceWith( w.imagify.bulk.displayErrorInRow( template( $.extend( {}, defaultsTemplate, {
+						status:      'complete',
+						icon:        'yes',
+						label:       imagifyBulk.labels.alreadyOptimized,
+						chartSuffix: data.image
+					}, data ) ), data.error ) );
+
+					// Update the optimized images counter.
+					optimizedCount += 1;
+					$optimizedCount.text( optimizedCount );
+					return;
+				}
+
+				// Display the error in the file row.
+				$fileRow.replaceWith( w.imagify.bulk.displayErrorInRow( template( $.extend( {}, defaultsTemplate, {
+					status:      'error',
+					icon:        'dismiss',
+					label:       imagifyBulk.labels.error,
+					chartSuffix: data.image
+				}, data ) ), data.error || data ) );
+
+				// Update the "working" folder row.
+				if ( ! $errorsCount.length ) {
+					errorsCount  = 1;
+					$errorsCount = $workingRow.find( '.imagify-cell-errors' ).html( imagifyBulk.labels.imagesErrorText.replace( '%s', '<span>1</span>' ) ).find( 'span' );
+				} else {
+					errorsCount += 1;
+					$errorsCount.text( errorsCount );
+				}
+
+				if ( 'over-quota' === data.error_code ) {
+					// No more data, stop everything.
+					Optimizer.stopProcess();
+					w.imagify.bulk.stopProcess( data.error_code, item );
+				}
+			} );
+
+			// After all image optimizations.
+			Optimizer.done( function( data ) {
+				// Uncheck the checkbox.
+				if ( w.imagify.bulk.hasMultipleRows ) {
+					$( '#cb-select-' + item.groupId ).prop( 'checked', false );
+				}
+
+				if ( data.global_original_size ) {
+					w.imagify.bulk.globalGain          += parseInt( data.global_gain, 10 );
+					w.imagify.bulk.globalOriginalSize  += parseInt( data.global_original_size, 10 );
+					w.imagify.bulk.globalOptimizedSize += parseInt( data.global_optimized_size, 10 );
+				}
+
+				if ( w.imagify.bulk.processIsStopped ) {
+					return;
+				}
+
+				// Update folder type status.
+				if ( ! w.imagify.bulk.status[ item.groupId ].isError ) {
+					w.imagify.bulk.status[ item.groupId ].id = 'done';
+				}
+
+				// Update the folder row.
+				$row.addClass( 'updating' );
+
+				$.get( w.imagify.bulk.getAjaxUrl( 'getFolderData', item ) )
+					.done( function( response ) {
+						if ( response.success ) {
+							$.each( response.data, function( dataName, dataHtml ) {
+								$row.children( '.imagify-cell-' + dataName ).html( dataHtml );
+							} );
+						}
+						w.imagify.bulk.displayFolderRow( 'resting', $row );
+					} )
+					.always( function() {
+						$row.removeClass( 'updating' );
+
+						if ( ! w.imagify.bulk.queue.length ) {
+							$( w ).trigger( 'queueEmpty.imagify' );
+						} else {
+							$( w ).trigger( 'processQueue.imagify' );
+						}
+					} );
+			} );
+
+			// Run.
+			Optimizer.run();
+		},
+
+		/*
+		 * End.
+		 */
+		queueEmpty: function () {
+			var $tables   = $( '.imagify-bulk-table' ),
+				errorArgs = {},
+				hasError  = false,
+				noImages  = true;
+
+			// Display the share box.
+			w.imagify.bulk.displayShareBox();
+
+			// Reset the queue.
+			w.imagify.bulk.queue = [];
+
+			// Fetch and display generic stats if heartbeat is disabled.
+			if ( ! imagifyBulk.heartbeatId ) {
+				$.get( ajaxurl, {
+					_wpnonce: imagifyBulk.ajaxNonce,
+					action:   imagifyBulk.ajaxActions.getStats,
+					types:    w.imagify.bulk.getFolderTypes()
+				} )
+					.done( function( response ) {
+						if ( response.success ) {
+							w.imagify.bulk.updateStats( response.data );
+						}
+					} );
+			}
+
+			// Maybe display error.
+			if ( ! $.isEmptyObject( w.imagify.bulk.status ) ) {
+				$.each( w.imagify.bulk.status, function( groupId, typeStatus ) {
+					if ( typeStatus.isError ) {
+						// One error is enough to display a message.
+						hasError = typeStatus.id;
+						noImages = false;
+						return false;
+					}
+					if ( 'no-images' !== typeStatus.id ) {
+						// All groups must have this ID.
+						noImages = false;
+						return false;
+					}
+				} );
+
+				if ( hasError ) {
+					if ( 'invalid-api-key' === hasError ) {
+						errorArgs = {
+							title: imagifyBulk.labels.invalidAPIKeyTitle,
+							type:  'info'
+						};
+					}
+					else if ( 'over-quota' === hasError ) {
+						errorArgs = {
+							title:             imagifyBulk.labels.overQuotaTitle,
+							html:              $( '#tmpl-imagify-overquota-alert' ).html(),
+							type:              'info',
+							customClass:       'imagify-swal-has-subtitle imagify-swal-error-header',
+							showConfirmButton: false
+						};
+					}
+					else if ( 'get-unoptimized-images' === hasError || 'consumed-all-data' === hasError ) {
+						errorArgs = {
+							title: imagifyBulk.labels.getUnoptimizedImagesErrorTitle,
+							html:  imagifyBulk.labels.getUnoptimizedImagesErrorText,
+							type:  'info'
+						};
+					}
+					w.imagify.bulk.displayError( errorArgs );
+				}
+				else if ( noImages ) {
+					w.imagify.bulk.displayError( {
+						title: imagifyBulk.labels.noAttachmentToOptimizeTitle,
+						html:  imagifyBulk.labels.noAttachmentToOptimizeText,
+						type:  'info'
+					} );
+				}
+			}
+
+			// Reset status.
+			w.imagify.bulk.status = {};
+
+			// Unlink the message displayed when the user wants to quit the page.
+			$( w ).off( 'beforeunload', w.imagify.bulk.getConfirmMessage );
+
+			// Display the "normal" folder rows (the values of the last one should being updated via ajax, don't display it for now).
+			w.imagify.bulk.displayFolderRow( 'resting', $tables.find( '.imagify-row-folder-type' ).not( '.updating' ) );
+
+			// Reset the progress bars.
+			$tables.find( '.imagify-row-progress' ).slideUp().attr( 'aria-hidden', 'true' ).find( '.bar' ).removeAttr( 'style' ).find( '.percent' ).text( '0%' );
+
+			// Enable (or not) the main button.
+			if ( $( '.imagify-bulk-table [name="group[]"]:checked' ).length ) {
+				$( '#imagify-bulk-action' ).removeAttr( 'disabled' ).find( '.dashicons' ).removeClass( 'rotate' );
+			} else {
+				$( '#imagify-bulk-action' ).find( '.dashicons' ).removeClass( 'rotate' );
+			}
+		},
+
+		/**
+		 * Add our Heartbeat ID on "heartbeat-send" event.
+		 *
+		 * @param {object} e    Event object.
+		 * @param {object} data Object containing all Heartbeat IDs.
+		 */
+		addHeartbeat: function ( e, data ) {
+			data.imagify_heartbeat = imagifyBulk.heartbeatId;
+			data.imagify_types     = w.imagify.bulk.getFolderTypes();
+		},
+
+		/**
+		 * Listen for the custom event "heartbeat-tick" on $(document).
+		 * It allows to update various data periodically.
+		 *
+		 * @param {object} e    Event object.
+		 * @param {object} data Object containing all Heartbeat IDs.
+		 */
+		processHeartbeat: function ( e, data ) {
+			if ( ! data.imagify_bulk_data ) {
+				return;
+			}
+
+			w.imagify.bulk.updateStats( data.imagify_bulk_data );
+		},
+
+		/**
+		 * Open a popup window when the user clicks on a share link.
+		 *
+		 * @param {object} e jQuery Event object.
+		 */
+		share: function ( e ) {
+			var width  = 700,
+				height = 290,
+				clientLeft, clientTop;
+
+			e.preventDefault();
+
+			if ( w.innerWidth ) {
+				clientLeft = ( w.innerWidth - width ) / 2;
+				clientTop  = ( w.innerHeight - height ) / 2;
+			} else {
+				clientLeft = ( d.body.clientWidth - width ) / 2;
+				clientTop  = ( d.body.clientHeight - height ) / 2;
+			}
+
+			w.open( this.href, '', 'status=no, scrollbars=no, menubar=no, top=' + clientTop + ', left=' + clientLeft + ', width=' + width + ', height=' + height );
+		}
+	};
+
+	w.imagify.bulk.init();
+
+} )(jQuery, document, window);

--- a/inc/3rd-party/nextgen-gallery/inc/admin/enqueue.php
+++ b/inc/3rd-party/nextgen-gallery/inc/admin/enqueue.php
@@ -33,7 +33,6 @@ function _imagify_ngg_admin_print_styles() {
 	$assets->remove_deferred_localization( 'bulk', 'imagifyBulk' );
 
 	$l10n = $assets->get_localization_data( 'bulk', array(
-		'heartbeatId' => 'update_ngg_bulk_data',
 		'bufferSizes' => array(
 			'NGG' => get_imagify_bulk_buffer_size( 3 ),
 		),

--- a/inc/3rd-party/nextgen-gallery/inc/admin/heartbeat.php
+++ b/inc/3rd-party/nextgen-gallery/inc/admin/heartbeat.php
@@ -3,43 +3,6 @@ defined( 'ABSPATH' ) || die( 'Cheatin\' uh?' );
 
 global $pagenow;
 
-add_filter( 'heartbeat_received', '_imagify_ngg_heartbeat_received', 10, 2 );
-/**
- * Prepare the data that goes back with the Heartbeat API.
- *
- * @since 1.5
- *
- * @param  array $response  The Heartbeat response.
- * @param  array $data      The $_POST data sent.
- * @return array
- */
-function _imagify_ngg_heartbeat_received( $response, $data ) {
-	if ( ! isset( $data['imagify_heartbeat'] ) || 'update_ngg_bulk_data' !== $data['imagify_heartbeat'] ) {
-		return $response;
-	}
-
-	add_filter( 'imagify_count_saving_data', 'imagify_ngg_count_saving_data', 8 );
-	$saving_data = imagify_count_saving_data();
-	$user        = new Imagify_User();
-
-	$response['imagify_bulk_data'] = array(
-		// User account.
-		'unconsumed_quota'              => is_wp_error( $user ) ? 0 : $user->get_percent_unconsumed_quota(),
-		// Global chart.
-		'optimized_attachments_percent' => imagify_ngg_percent_optimized_attachments(),
-		'unoptimized_attachments'       => imagify_ngg_count_unoptimized_attachments(),
-		'optimized_attachments'         => imagify_ngg_count_optimized_attachments(),
-		'errors_attachments'            => imagify_ngg_count_error_attachments(),
-		// Stats block.
-		'already_optimized_attachments' => number_format_i18n( $saving_data['count'] ),
-		'original_human'                => imagify_size_format( $saving_data['original_size'], 1 ),
-		'optimized_human'               => imagify_size_format( $saving_data['optimized_size'], 1 ),
-		'optimized_percent'             => $saving_data['percent'],
-	);
-
-	return $response;
-}
-
 /**
  * Update the Heartbeat API settings.
  *

--- a/inc/admin/heartbeat.php
+++ b/inc/admin/heartbeat.php
@@ -14,81 +14,12 @@ add_filter( 'heartbeat_received', '_imagify_heartbeat_received', 10, 2 );
  * @return array
  */
 function _imagify_heartbeat_received( $response, $data ) {
-	if ( empty( $data['imagify_heartbeat'] ) || 'update_bulk_data' !== $data['imagify_heartbeat'] ) {
-		return $response;
+	if ( isset( $data['imagify_heartbeat'], $data['imagify_types'] ) && 'update_bulk_data' === $data['imagify_heartbeat'] ) {
+		$folder_types = is_array( $data['imagify_types'] ) ? array_flip( array_filter( $data['imagify_types'] ) ) : array();
+		$response['imagify_bulk_data'] = imagify_get_bulk_stats( $folder_types, array(
+			'fullset' => true,
+		) );
 	}
-
-	$user     = new Imagify_User();
-	$types    = ! empty( $data['imagify_types'] ) && is_array( $data['imagify_types'] ) ? array_flip( $data['imagify_types'] ) : array();
-	$new_data = array(
-		// User account.
-		'unconsumed_quota'              => is_wp_error( $user ) ? 0 : $user->get_percent_unconsumed_quota(),
-		// Global chart.
-		'total_attachments'             => 0,
-		'unoptimized_attachments'       => 0,
-		'optimized_attachments'         => 0,
-		'errors_attachments'            => 0,
-		// Stats block.
-		'already_optimized_attachments' => 0,
-		'original_human'                => 0,
-		'optimized_human'               => 0,
-	);
-
-	if ( isset( $types['library'] ) ) {
-		/**
-		 * Library.
-		 */
-		$saving_data = imagify_count_saving_data();
-
-		// Global chart.
-		$new_data['total_attachments']             += imagify_count_attachments();
-		$new_data['unoptimized_attachments']       += imagify_count_unoptimized_attachments();
-		$new_data['optimized_attachments']         += imagify_count_optimized_attachments();
-		$new_data['errors_attachments']            += imagify_count_error_attachments();
-		// Stats block.
-		$new_data['already_optimized_attachments'] += $saving_data['count'];
-		$new_data['original_human']                += $saving_data['original_size'];
-		$new_data['optimized_human']               += $saving_data['optimized_size'];
-	}
-
-	if ( isset( $types['custom-folders'] ) ) {
-		/**
-		 * Custom folders.
-		 */
-		// Global chart.
-		$new_data['total_attachments']             += Imagify_Files_Stats::count_all_files();
-		$new_data['unoptimized_attachments']       += Imagify_Files_Stats::count_no_status_files();
-		$new_data['optimized_attachments']         += Imagify_Files_Stats::count_optimized_files();
-		$new_data['errors_attachments']            += Imagify_Files_Stats::count_error_files();
-		// Stats block.
-		$new_data['already_optimized_attachments'] += Imagify_Files_Stats::count_success_files();
-		$new_data['original_human']                += Imagify_Files_Stats::get_original_size();
-		$new_data['optimized_human']               += Imagify_Files_Stats::get_optimized_size();
-	}
-
-	/**
-	 * Percentages.
-	 */
-	if ( $new_data['total_attachments'] && $new_data['optimized_attachments'] ) {
-		$new_data['optimized_attachments_percent'] = round( 100 * $new_data['optimized_attachments'] / $new_data['total_attachments'] );
-	} else {
-		$new_data['optimized_attachments_percent'] = 0;
-	}
-
-	if ( $new_data['original_human'] && $new_data['optimized_human'] ) {
-		$new_data['optimized_percent'] = ceil( 100 - ( 100 * $new_data['optimized_human'] / $new_data['original_human'] ) );
-	} else {
-		$new_data['optimized_percent'] = 0;
-	}
-
-	/**
-	 * Formating.
-	 */
-	$new_data['already_optimized_attachments'] = number_format_i18n( $new_data['already_optimized_attachments'] );
-	$new_data['original_human']                = imagify_size_format( $new_data['original_human'], 1 );
-	$new_data['optimized_human']               = imagify_size_format( $new_data['optimized_human'], 1 );
-
-	$response['imagify_bulk_data'] = $new_data;
 
 	return $response;
 }

--- a/inc/classes/class-imagify-views.php
+++ b/inc/classes/class-imagify-views.php
@@ -15,7 +15,7 @@ class Imagify_Views {
 	 * @var   string
 	 * @since 1.7
 	 */
-	const VERSION = '1.0';
+	const VERSION = '1.0.1';
 
 	/**
 	 * Slug used for the settings page URL.
@@ -251,23 +251,14 @@ class Imagify_Views {
 	 * @access public
 	 */
 	public function display_bulk_page() {
-		$data = array(
-			// Global chart.
-			'total_attachments'             => 0,
-			'unoptimized_attachments'       => 0,
-			'optimized_attachments'         => 0,
-			'errors_attachments'            => 0,
-			// Stats block.
-			'already_optimized_attachments' => 0,
-			'original_size'                 => 0,
-			'optimized_size'                => 0,
-			'optimized_percent'             => 0,
+		$types = array();
+		$data  = array(
 			// Limits.
-			'unoptimized_attachment_limit'  => 0,
+			'unoptimized_attachment_limit' => 0,
 			// What to optimize.
-			'icon'                          => 'images-alt2',
-			'title'                         => __( 'Optimize your images', 'imagify' ),
-			'groups'                        => array(),
+			'icon'                         => 'images-alt2',
+			'title'                        => __( 'Optimize your images', 'imagify' ),
+			'groups'                       => array(),
 		);
 
 		if ( imagify_is_screen( 'bulk' ) ) {
@@ -275,87 +266,77 @@ class Imagify_Views {
 				/**
 				 * Library: in each site.
 				 */
-				$total_saving_data = imagify_count_saving_data();
-
-				// Global chart.
-				$data['total_attachments']             += imagify_count_attachments();
-				$data['unoptimized_attachments']       += imagify_count_unoptimized_attachments();
-				$data['optimized_attachments']         += imagify_count_optimized_attachments();
-				$data['errors_attachments']            += imagify_count_error_attachments();
-				// Stats block.
-				$data['already_optimized_attachments'] += $total_saving_data['count'];
-				$data['original_size']                 += $total_saving_data['original_size'];
-				$data['optimized_size']                += $total_saving_data['optimized_size'];
-				// Limits.
-				$data['unoptimized_attachment_limit']  += imagify_get_unoptimized_attachment_limit();
-				// Group.
-				$data['groups']['library'] = array(
-					/**
-					 * The group_id corresponds to the file names like 'part-bulk-optimization-results-row-{$group_id}'.
-					 * It is also used in get_imagify_localize_script_translations() and imagify_get_folder_type_data().
-					 */
-					'group_id' => 'library',
-					'context'  => 'wp',
-					'title'    => __( 'Media Library', 'imagify' ),
-					/* translators: 1 is the opening of a link, 2 is the closing of this link. */
-					'footer'   => sprintf( __( 'You can also re-optimize your images from your %1$sMedia Library%2$s screen.', 'imagify' ), '<a href="' . esc_url( admin_url( 'upload.php' ) ) . '">', '</a>' ),
-				);
+				$types['library|wp'] = 1;
 			}
 
 			if ( imagify_can_optimize_custom_folders() && ( imagify_is_active_for_network() && is_network_admin() || ! imagify_is_active_for_network() ) ) {
 				/**
 				 * Custom folders: in network admin only if network activated, in each site otherwise.
 				 */
-				// Global chart.
-				$data['total_attachments']             += Imagify_Files_Stats::count_all_files();
-				$data['unoptimized_attachments']       += Imagify_Files_Stats::count_no_status_files();
-				$data['optimized_attachments']         += Imagify_Files_Stats::count_optimized_files();
-				$data['errors_attachments']            += Imagify_Files_Stats::count_error_files();
-				// Stats block.
-				$data['already_optimized_attachments'] += Imagify_Files_Stats::count_success_files();
-				$data['original_size']                 += Imagify_Files_Stats::get_original_size();
-				$data['optimized_size']                += Imagify_Files_Stats::get_optimized_size();
-
-				if ( ! Imagify_Folders_DB::get_instance()->has_items() ) {
-					// New Feature!
-					$data['no-custom-folders'] = true;
-				} elseif ( Imagify_Folders_DB::get_instance()->has_active_folders() ) {
-					// Group.
-					$data['groups']['custom-folders'] = array(
-						'group_id' => 'custom-folders',
-						'context'  => 'File',
-						'title'    => __( 'Custom folders', 'imagify' ),
-						/* translators: 1 is the opening of a link, 2 is the closing of this link. */
-						'footer'   => sprintf( __( 'You can re-optimize your images more finely directly in the %1$simages management%2$s.', 'imagify' ), '<a href="' . esc_url( get_imagify_admin_url( 'files-list' ) ) . '">', '</a>' ),
-					);
-				}
+				$types['custom-folders'] = 1;
 			}
 		}
+
+		/**
+		 * Filter the types to display in the bulk optimization page.
+		 *
+		 * @since  1.7.1
+		 * @author Grégory Viguier
+		 *
+		 * @param array $types The folder types displayed on the page. If a folder type is "library", the context should be suffixed after a pipe character. They are passed as array keys.
+		 */
+		$types = apply_filters( 'imagify_bulk_page_types', $types );
+		$types = array_filter( (array) $types );
+
+		if ( isset( $types['library|wp'] ) ) {
+			// Limits.
+			$data['unoptimized_attachment_limit'] += imagify_get_unoptimized_attachment_limit();
+			// Group.
+			$data['groups']['library'] = array(
+				/**
+				 * The group_id corresponds to the file names like 'part-bulk-optimization-results-row-{$group_id}'.
+				 * It is also used in get_imagify_localize_script_translations() and imagify_get_folder_type_data().
+				 */
+				'group_id' => 'library',
+				'context'  => 'wp',
+				'title'    => __( 'Media Library', 'imagify' ),
+				/* translators: 1 is the opening of a link, 2 is the closing of this link. */
+				'footer'   => sprintf( __( 'You can also re-optimize your images from your %1$sMedia Library%2$s screen.', 'imagify' ), '<a href="' . esc_url( admin_url( 'upload.php' ) ) . '">', '</a>' ),
+			);
+		}
+
+		if ( isset( $types['custom-folders'] ) ) {
+			if ( ! Imagify_Folders_DB::get_instance()->has_items() ) {
+				// New Feature!
+				$data['no-custom-folders'] = true;
+			} elseif ( Imagify_Folders_DB::get_instance()->has_active_folders() ) {
+				// Group.
+				$data['groups']['custom-folders'] = array(
+					'group_id' => 'custom-folders',
+					'context'  => 'File',
+					'title'    => __( 'Custom folders', 'imagify' ),
+					/* translators: 1 is the opening of a link, 2 is the closing of this link. */
+					'footer'   => sprintf( __( 'You can re-optimize your images more finely directly in the %1$simages management%2$s.', 'imagify' ), '<a href="' . esc_url( get_imagify_admin_url( 'files-list' ) ) . '">', '</a>' ),
+				);
+			}
+		}
+
+		// Add generic stats.
+		$data = array_merge( $data, imagify_get_bulk_stats( $types, array(
+			'fullset' => true,
+		) ) );
 
 		/**
 		 * Filter the data to use on the bulk optimization page.
 		 *
 		 * @since  1.7
+		 * @since  1.7.1 Added the $types parameter.
 		 * @author Grégory Viguier
 		 *
-		 * @param array $data The data to use.
+		 * @param array $data  The data to use.
+		 * @param array $types The folder types displayed on the page. They are passed as array keys.
 		 */
-		$data = apply_filters( 'imagify_bulk_page_data', $data );
-
-		/**
-		 * Percentages.
-		 */
-		if ( $data['total_attachments'] && $data['optimized_attachments'] ) {
-			$data['optimized_attachments_percent'] = round( 100 * $data['optimized_attachments'] / $data['total_attachments'] );
-		} else {
-			$data['optimized_attachments_percent'] = 0;
-		}
-
-		if ( $data['original_size'] && $data['optimized_size'] ) {
-			$data['optimized_percent'] = ceil( 100 - ( 100 * $data['optimized_size'] / $data['original_size'] ) );
-		} else {
-			$data['optimized_percent'] = 0;
-		}
+		$data = apply_filters( 'imagify_bulk_page_data', $data, $types );
 
 		$this->print_template( 'page-bulk', $data );
 	}

--- a/inc/functions/admin-stats.php
+++ b/inc/functions/admin-stats.php
@@ -666,3 +666,122 @@ function imagify_calculate_total_image_size( $image_ids, $partial_total_images, 
 
 	return $total_size_images;
 }
+
+/**
+ * Get all generic stats to be used in the bulk optimization page.
+ *
+ * @since  1.7.1
+ * @author Grégory Viguier
+ *
+ * @param  array $types The folder types. If a folder type is "library", the context should be suffixed after a pipe character. They are passed as array keys.
+ * @param  array $args  {
+ *     Optional. An array of arguments.
+ *
+ *     @type bool $fullset True to return the full set of data. False to return only the main data.
+ *     @type bool $formatting Some of the data is returned formatted.
+ * }
+ * @return array
+ */
+function imagify_get_bulk_stats( $types, $args = array() ) {
+	$types = $types && is_array( $types ) ? $types : array();
+	$args  = array_merge( array(
+		'fullset'    => false,
+		'formatting' => true,
+	), (array) $args );
+
+	$data = array(
+		// Global chart.
+		'total_attachments'             => 0,
+		'unoptimized_attachments'       => 0,
+		'optimized_attachments'         => 0,
+		'errors_attachments'            => 0,
+		// Stats block.
+		'already_optimized_attachments' => 0,
+		'original_human'                => 0,
+		'optimized_human'               => 0,
+	);
+
+	if ( isset( $types['library|wp'] ) ) {
+		/**
+		 * Library.
+		 */
+		$saving_data = imagify_count_saving_data();
+
+		// Global chart.
+		$data['total_attachments']             += imagify_count_attachments();
+		$data['unoptimized_attachments']       += imagify_count_unoptimized_attachments();
+		$data['optimized_attachments']         += imagify_count_optimized_attachments();
+		$data['errors_attachments']            += imagify_count_error_attachments();
+		// Stats block.
+		$data['already_optimized_attachments'] += $saving_data['count'];
+		$data['original_human']                += $saving_data['original_size'];
+		$data['optimized_human']               += $saving_data['optimized_size'];
+	}
+
+	if ( isset( $types['custom-folders'] ) ) {
+		/**
+		 * Custom folders.
+		 */
+		// Global chart.
+		$data['total_attachments']             += Imagify_Files_Stats::count_all_files();
+		$data['unoptimized_attachments']       += Imagify_Files_Stats::count_no_status_files();
+		$data['optimized_attachments']         += Imagify_Files_Stats::count_optimized_files();
+		$data['errors_attachments']            += Imagify_Files_Stats::count_error_files();
+		// Stats block.
+		$data['already_optimized_attachments'] += Imagify_Files_Stats::count_success_files();
+		$data['original_human']                += Imagify_Files_Stats::get_original_size();
+		$data['optimized_human']               += Imagify_Files_Stats::get_optimized_size();
+	}
+
+	/**
+	 * Full set of data.
+	 */
+	if ( $args['fullset'] ) {
+		// User account.
+		$user = new Imagify_User();
+		$data['unconsumed_quota'] = is_wp_error( $user ) ? 0 : $user->get_percent_unconsumed_quota();
+	}
+
+	/**
+	 * Filter the generic stats used in the bulk optimization page.
+	 *
+	 * @since  1.7.1
+	 * @author Grégory Viguier
+	 *
+	 * @param array $data  The data.
+	 * @param array $types The folder types. They are passed as array keys.
+	 * @param array $args  {
+	 *     Optional. An array of arguments.
+	 *
+	 *     @type bool $fullset True to return the full set of data. False to return only the main data.
+	 *     @type bool $formatting Some of the data is returned formatted.
+	 * }
+	 */
+	$data = apply_filters( 'imagify_bulk_stats', $data, $types, $args );
+
+	/**
+	 * Percentages.
+	 */
+	if ( $data['total_attachments'] && $data['optimized_attachments'] ) {
+		$data['optimized_attachments_percent'] = round( 100 * $data['optimized_attachments'] / $data['total_attachments'] );
+	} else {
+		$data['optimized_attachments_percent'] = 0;
+	}
+
+	if ( $data['original_human'] && $data['optimized_human'] ) {
+		$data['optimized_percent'] = ceil( 100 - ( 100 * $data['optimized_human'] / $data['original_human'] ) );
+	} else {
+		$data['optimized_percent'] = 0;
+	}
+
+	/**
+	 * Formating.
+	 */
+	if ( $args['formatting'] ) {
+		$data['already_optimized_attachments'] = number_format_i18n( $data['already_optimized_attachments'] );
+		$data['original_human']                = imagify_size_format( $data['original_human'], 1 );
+		$data['optimized_human']               = imagify_size_format( $data['optimized_human'], 1 );
+	}
+
+	return $data;
+}

--- a/inc/functions/deprecated.php
+++ b/inc/functions/deprecated.php
@@ -586,6 +586,46 @@ if ( class_exists( 'C_NextGEN_Bootstrap' ) && class_exists( 'Mixin' ) && get_sit
 		add_filter( 'imagify_count_saving_data'             , 'imagify_ngg_count_saving_data', 8 );
 	}
 
+	/**
+	 * Prepare the data that goes back with the Heartbeat API.
+	 *
+	 * @since 1.5
+	 * @since 1.7.1 Deprecated.
+	 * @deprecated
+	 *
+	 * @param  array $response  The Heartbeat response.
+	 * @param  array $data      The $_POST data sent.
+	 * @return array
+	 */
+	function _imagify_ngg_heartbeat_received( $response, $data ) {
+		_deprecated_function( __FUNCTION__ . '()', '1.7.1' );
+
+		if ( ! isset( $data['imagify_heartbeat'] ) || 'update_ngg_bulk_data' !== $data['imagify_heartbeat'] ) {
+			return $response;
+		}
+
+		add_filter( 'imagify_count_saving_data', 'imagify_ngg_count_saving_data', 8 );
+		$saving_data = imagify_count_saving_data();
+		$user        = new Imagify_User();
+
+		$response['imagify_bulk_data'] = array(
+			// User account.
+			'unconsumed_quota'              => is_wp_error( $user ) ? 0 : $user->get_percent_unconsumed_quota(),
+			// Global chart.
+			'optimized_attachments_percent' => imagify_ngg_percent_optimized_attachments(),
+			'unoptimized_attachments'       => imagify_ngg_count_unoptimized_attachments(),
+			'optimized_attachments'         => imagify_ngg_count_optimized_attachments(),
+			'errors_attachments'            => imagify_ngg_count_error_attachments(),
+			// Stats block.
+			'already_optimized_attachments' => number_format_i18n( $saving_data['count'] ),
+			'original_human'                => imagify_size_format( $saving_data['original_size'], 1 ),
+			'optimized_human'               => imagify_size_format( $saving_data['optimized_size'], 1 ),
+			'optimized_percent'             => $saving_data['percent'],
+		);
+
+		return $response;
+	}
+
 endif;
 
 /**

--- a/inc/functions/i18n.php
+++ b/inc/functions/i18n.php
@@ -182,6 +182,11 @@ function get_imagify_localize_script_translations( $context ) {
 				}
 			}
 
+			if ( get_transient( 'imagify_large_library' ) ) {
+				// On huge media libraries, don't use heartbeat, and fetch stats only when the process ends.
+				$translations['ajaxActions']['getStats'] = 'imagify_bulk_get_stats';
+			}
+
 			if ( isset( $translations['bufferSizes']['wp'] ) ) {
 				/**
 				 * Filter the number of parallel queries during the Bulk Optimization (library).

--- a/views/page-bulk.php
+++ b/views/page-bulk.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin\' uh?' );
 
 						<div class="imagify-number-you-optimized">
 							<p>
-								<span id="imagify-total-optimized-attachments" class="number"><?php echo esc_html( number_format_i18n( $data['already_optimized_attachments'] ) ); ?></span>
+								<span id="imagify-total-optimized-attachments" class="number"><?php echo esc_html( $data['already_optimized_attachments'] ); ?></span>
 								<span class="text">
 									<?php
 									printf(
@@ -36,12 +36,12 @@ defined( 'ABSPATH' ) || die( 'Cheatin\' uh?' );
 						<div class="imagify-bars">
 							<p><?php esc_html_e( 'Original size', 'imagify' ); ?></p>
 							<div class="imagify-bar-negative base-transparent right-outside-number">
-								<div id="imagify-original-bar" class="imagify-progress" style="width: 100%"><span class="imagify-barnb"><?php echo esc_html( imagify_size_format( $data['original_size'], 1 ) ); ?></span></div>
+								<div id="imagify-original-bar" class="imagify-progress" style="width: 100%"><span class="imagify-barnb"><?php echo esc_html( $data['original_human'] ); ?></span></div>
 							</div>
 
 							<p><?php esc_html_e( 'Optimized size', 'imagify' ); ?></p>
 							<div class="imagify-bar-primary base-transparent right-outside-number">
-								<div id="imagify-optimized-bar" class="imagify-progress" style="width: <?php echo max( 100 - $data['optimized_percent'], 0 ); ?>%"><span class="imagify-barnb"><?php echo esc_html( imagify_size_format( $data['optimized_size'], 1 ) ); ?></span></div>
+								<div id="imagify-optimized-bar" class="imagify-progress" style="width: <?php echo max( 100 - $data['optimized_percent'], 0 ); ?>%"><span class="imagify-barnb"><?php echo esc_html( $data['optimized_human'] ); ?></span></div>
 							</div>
 
 						</div>


### PR DESCRIPTION
On the bulk optimization page, don't use heartbeat to fetch stats in case of large media library.
To that purpose:
- In such case, fetch data only when the optimization process is finished. It must meet 2 conditions: the media library is listed (so, not in the NGG page for example), and we have a large media library.
- Introduced `imagify_get_bulk_stats()` and filters to factorize code about those stats.
- Removed NGG heartbeat callback and use filters instead.