### PR TITLE
Escape % characters  for prepared SQL queries

### DIFF
--- a/inc/classes/class-imagify-admin-ajax-post.php
+++ b/inc/classes/class-imagify-admin-ajax-post.php
@@ -688,7 +688,9 @@ class Imagify_Admin_Ajax_Post {
 		$mime_types   = Imagify_DB::get_mime_types();
 		$statuses     = Imagify_DB::get_post_statuses();
 		$nodata_join  = Imagify_DB::get_required_wp_metadata_join_clause();
-		$nodata_where = Imagify_DB::get_required_wp_metadata_where_clause();
+		$nodata_where = Imagify_DB::get_required_wp_metadata_where_clause( array(
+			'prepared' => true,
+		) );
 		$ids          = $wpdb->get_col( $wpdb->prepare( // WPCS: unprepared SQL ok.
 			"
 			SELECT p.ID

--- a/inc/functions/attachments.php
+++ b/inc/functions/attachments.php
@@ -124,7 +124,10 @@ function imagify_has_attachments_without_required_metadata() {
 	$mime_types   = Imagify_DB::get_mime_types();
 	$statuses     = Imagify_DB::get_post_statuses();
 	$nodata_join  = Imagify_DB::get_required_wp_metadata_join_clause( 'p.ID', false, false );
-	$nodata_where = Imagify_DB::get_required_wp_metadata_where_clause( array(), false, false );
+	$nodata_where = Imagify_DB::get_required_wp_metadata_where_clause( array(
+		'matching' => false,
+		'test'     => false,
+	) );
 	$has          = (bool) $wpdb->get_var( // WPCS: unprepared SQL ok.
 		"
 		SELECT p.ID


### PR DESCRIPTION
When a query is "prepared" (aka `vsprintf()`), escape the % characters that are parts of LIKE clauses.
Changed 2 methods signature to prevent having 4 parameters.