### PR TITLE
Fixes fatal error on Imagify update

### DIFF
--- a/inc/admin/custom-folders.php
+++ b/inc/admin/custom-folders.php
@@ -3,14 +3,15 @@ defined( 'ABSPATH' ) || die( 'Cheatin\' uh?' );
 
 add_filter( 'upgrader_post_install', 'imagify_sync_theme_plugin_files_on_update', IMAGIFY_INT_MAX, 3 );
 /**
- * Sync files after a theme or plugin has been updated.
+ * Sync files right after a theme or plugin has been updated.
  *
  * @since  1.7
  * @author Grégory Viguier
  *
- * @param bool  $response   Installation response.
- * @param array $hook_extra Extra arguments passed to hooked filters.
- * @param array $result     Installation result data.
+ * @param  bool  $response   Installation response.
+ * @param  array $hook_extra Extra arguments passed to hooked filters.
+ * @param  array $result     Installation result data.
+ * @return bool
  */
 function imagify_sync_theme_plugin_files_on_update( $response, $hook_extra, $result ) {
 	global $wpdb;
@@ -19,6 +20,34 @@ function imagify_sync_theme_plugin_files_on_update( $response, $hook_extra, $res
 		return $response;
 	}
 
+	$folders_to_sync = get_site_transient( 'imagify_themes_plugins_to_sync' );
+	$folders_to_sync = is_array( $folders_to_sync ) ? $folders_to_sync : array();
+
+	$folders_to_sync[] = $result['destination'];
+
+	set_site_transient( 'imagify_themes_plugins_to_sync', $folders_to_sync, DAY_IN_SECONDS );
+
+	return $response;
+}
+
+add_action( 'admin_init', 'imagify_sync_theme_plugin_files_after_update' );
+/**
+ * Sync files after some themes or plugins have been updated.
+ *
+ * @since  1.7.1.2
+ * @author Grégory Viguier
+ */
+function imagify_sync_theme_plugin_files_after_update() {
+	global $wpdb;
+
+	$folders_to_sync = get_site_transient( 'imagify_themes_plugins_to_sync' );
+
+	if ( ! $folders_to_sync || ! is_array( $folders_to_sync ) ) {
+		return;
+	}
+
+	delete_site_transient( 'imagify_themes_plugins_to_sync' );
+
 	$folders_db = Imagify_Folders_DB::get_instance();
 	$files_db   = Imagify_Files_DB::get_instance();
 
@@ -26,39 +55,31 @@ function imagify_sync_theme_plugin_files_on_update( $response, $hook_extra, $res
 		return;
 	}
 
-	if ( ! Imagify_Requirements::is_api_key_valid() ) {
-		return;
+	foreach ( $folders_to_sync as $folder_path ) {
+		$folder_path = trailingslashit( $folder_path );
+
+		if ( Imagify_Files_Scan::is_path_forbidden( $folder_path ) ) {
+			// This theme or plugin must not be optimized.
+			continue;
+		}
+
+		// Get the related folder.
+		$placeholder = Imagify_Files_Scan::add_placeholder( $folder_path );
+		$folder      = Imagify_Folders_DB::get_instance()->get_in( 'path', $placeholder );
+
+		if ( ! $folder ) {
+			// This theme or plugin is not in the database.
+			continue;
+		}
+
+		// Sync the folder files.
+		Imagify_Custom_Folders::synchronize_files_from_folders( array(
+			$folder['folder_id'] => array(
+				'folder_id'   => $folder['folder_id'],
+				'path'        => $placeholder,
+				'active'      => $folder['active'],
+				'folder_path' => $folder_path,
+			),
+		) );
 	}
-
-	if ( Imagify_Requirements::is_over_quota() ) {
-		return;
-	}
-
-	$folder_path = trailingslashit( $result['destination'] );
-
-	if ( Imagify_Files_Scan::is_path_forbidden( $folder_path ) ) {
-		// This theme or plugin must not be optimized.
-		return $response;
-	}
-
-	// Get the related folder.
-	$placeholder = Imagify_Files_Scan::add_placeholder( $folder_path );
-	$folder      = Imagify_Folders_DB::get_instance()->get_in( 'path', $placeholder );
-
-	if ( ! $folder ) {
-		// This theme or plugin is not in the database.
-		return $response;
-	}
-
-	// Sync the folder files.
-	Imagify_Custom_Folders::synchronize_files_from_folders( array(
-		$folder['folder_id'] => array(
-			'folder_id'   => $folder['folder_id'],
-			'path'        => $placeholder,
-			'active'      => $folder['active'],
-			'folder_path' => $folder_path,
-		),
-	) );
-
-	return $response;
 }

--- a/inc/classes/class-imagify.php
+++ b/inc/classes/class-imagify.php
@@ -11,7 +11,7 @@ class Imagify extends Imagify_Deprecated {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.1.1';
+	const VERSION = '1.1.2';
 	/**
 	 * The Imagify API endpoint.
 	 *
@@ -63,6 +63,11 @@ class Imagify extends Imagify_Deprecated {
 	 * The constructor.
 	 */
 	protected function __construct() {
+		if ( ! class_exists( 'Imagify_Filesystem' ) ) {
+			// Dirty patch used when updating from 1.7.
+			include_once IMAGIFY_CLASSES_PATH . 'class-imagify-filesystem.php';
+		}
+
 		$this->api_key    = get_imagify_option( 'api_key' );
 		$this->filesystem = Imagify_Filesystem::get_instance();
 
@@ -98,13 +103,21 @@ class Imagify extends Imagify_Deprecated {
 	 */
 	public function get_user() {
 		static $user;
+		global $wp_current_filter;
 
-		if ( ! isset( $user ) ) {
+		if ( isset( $user ) ) {
+			return $user;
+		}
+
+		if ( ! in_array( 'upgrader_post_install', (array) $wp_current_filter, true ) ) {
 			$this->headers = $this->all_headers;
 
 			$user = $this->http_call( 'users/me/', array(
 				'timeout' => 10,
 			) );
+		} else {
+			// Dirty patch used when updating from 1.7.
+			$user = new WP_Error();
 		}
 
 		return $user;


### PR DESCRIPTION
In `imagify_sync_theme_plugin_files_on_update()`, the class `Imagify` from the new plugin was loaded, calling new code while old code is already loaded.
The solution is to patch `Imagify` for the updates from 1.7, and delay the job in `admin_init` instead of `upgrader_post_install`, using a transient.