### PR TITLE
Fixes #258: support for content folders outside WP folder

### DIFF
--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -269,6 +269,22 @@ function _imagify_new_upgrade( $network_version, $site_version ) {
 		// Rename the option that stores the NGG table version. Since the table is also updated in 1.7, let's simply delete the option.
 		delete_option( $wpdb->prefix . 'ngg_imagify_data_db_version' );
 	}
+
+	// 1.8.1
+	if ( version_compare( $site_version, '1.8.1' ) < 0 ) {
+		// Custom folders: replace `{{ABSPATH}}/` by `{{ROOT}}/`.
+		$filesystem  = imagify_get_filesystem();
+		$replacement = '{{ROOT}}/';
+
+		if ( $filesystem->has_wp_its_own_directory() ) {
+			$replacement .= str_replace( $filesystem->get_site_root(), '', $filesystem->get_abspath() );
+		}
+
+		$replacement = Imagify_DB::esc_like( $replacement );
+
+		$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->base_prefix}imagify_files SET path = REPLACE( path, '{{ABSPATH}}/', %s ) WHERE path LIKE %s", $replacement, '{{ABSPATH}}/%' ) );
+		$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->base_prefix}imagify_folders SET path = REPLACE( path, '{{ABSPATH}}/', %s ) WHERE path LIKE %s", $replacement, '{{ABSPATH}}/%' ) );
+	}
 }
 
 add_action( 'upgrader_process_complete', 'imagify_maybe_reset_opcache', 20, 2 );

--- a/inc/classes/class-imagify-admin-ajax-post.php
+++ b/inc/classes/class-imagify-admin-ajax-post.php
@@ -16,7 +16,7 @@ class Imagify_Admin_Ajax_Post {
 	 * @since  1.6.11
 	 * @author Grégory Viguier
 	 */
-	const VERSION = '1.0.4';
+	const VERSION = '1.0.5';
 
 	/**
 	 * Actions to be triggered on admin ajax and admin post.
@@ -1355,7 +1355,7 @@ class Imagify_Admin_Ajax_Post {
 		}
 
 		$folder = trailingslashit( sanitize_text_field( $_POST['folder'] ) );
-		$folder = realpath( $this->filesystem->get_abspath() . ltrim( $folder, '/' ) );
+		$folder = realpath( $this->filesystem->get_site_root() . ltrim( $folder, '/' ) );
 
 		if ( ! $folder ) {
 			imagify_die( __( 'This folder doesn\'t exist.', 'imagify' ) );
@@ -1376,13 +1376,13 @@ class Imagify_Admin_Ajax_Post {
 		$views    = Imagify_Views::get_instance();
 		$output   = '';
 
-		if ( $this->filesystem->is_abspath( $folder ) ) {
+		if ( $this->filesystem->is_site_root( $folder ) ) {
 			$output .= $views->get_template( 'part-settings-files-tree-row', array(
 				'relative_path'     => '/',
 				// Value #///# Label.
-				'checkbox_value'    => '{{ABSPATH}}/#///#' . esc_attr__( 'Site\'s root', 'imagify' ),
+				'checkbox_value'    => '{{ROOT}}/#///#' . esc_attr__( 'Site\'s root', 'imagify' ),
 				'checkbox_id'       => 'ABSPATH',
-				'checkbox_selected' => isset( $selected['{{ABSPATH}}/'] ),
+				'checkbox_selected' => isset( $selected['{{ROOT}}/'] ),
 				'label'             => __( 'Site\'s root', 'imagify' ),
 				'no_button'         => true,
 			) );

--- a/inc/classes/class-imagify-custom-folders.php
+++ b/inc/classes/class-imagify-custom-folders.php
@@ -14,7 +14,7 @@ class Imagify_Custom_Folders {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.0.2';
+	const VERSION = '1.0.3';
 
 
 	/** ----------------------------------------------------------------------------------------- */
@@ -38,7 +38,7 @@ class Imagify_Custom_Folders {
 		}
 
 		$filesystem = imagify_get_filesystem();
-		$backup_dir = $filesystem->get_abspath() . 'imagify-backup/';
+		$backup_dir = $filesystem->get_site_root() . 'imagify-backup/';
 
 		/**
 		 * Filter the backup directory path (custom folders).
@@ -79,14 +79,14 @@ class Imagify_Custom_Folders {
 	 */
 	public static function get_file_backup_path( $file_path ) {
 		$file_path  = wp_normalize_path( (string) $file_path );
-		$abspath    = imagify_get_filesystem()->get_abspath();
+		$site_root  = imagify_get_filesystem()->get_site_root();
 		$backup_dir = self::get_backup_dir_path();
 
 		if ( ! $file_path ) {
 			return false;
 		}
 
-		return str_replace( $abspath, $backup_dir, $file_path );
+		return str_replace( $site_root, $backup_dir, $file_path );
 	}
 
 
@@ -402,7 +402,7 @@ class Imagify_Custom_Folders {
 	 *                         Array(
 	 *                             [7] => Array(
 	 *                                 [folder_id] => 7
-	 *                                 [path] => {{ABSPATH}}/custom-path/
+	 *                                 [path] => {{ROOT}}/custom-path/
 	 *                                 [active] => 1
 	 *                                 [folder_path] => /absolute/path/to/custom-path/
 	 *                             )
@@ -478,7 +478,7 @@ class Imagify_Custom_Folders {
 	 *                                [_2] => Array(
 	 *                                    [file_id]            => 2
 	 *                                    [folder_id]          => 7
-	 *                                    [path]               => {{ABSPATH}}/custom-path/image-1.jpg
+	 *                                    [path]               => {{ROOT}}/custom-path/image-1.jpg
 	 *                                    [optimization_level] => null
 	 *                                    [status]             => null
 	 *                                    [file_path]          => /absolute/path/to/custom-path/image-1.jpg
@@ -486,7 +486,7 @@ class Imagify_Custom_Folders {
 	 *                                [_3] => Array(
 	 *                                    [file_id]            => 3
 	 *                                    [folder_id]          => 7
-	 *                                    [path]               => {{ABSPATH}}/custom-path/image-2.jpg
+	 *                                    [path]               => {{ROOT}}/custom-path/image-2.jpg
 	 *                                    [optimization_level] => 2
 	 *                                    [status]             => success
 	 *                                    [file_path]          => /absolute/path/to/custom-path/image-2.jpg
@@ -1017,14 +1017,15 @@ class Imagify_Custom_Folders {
 		}
 
 		$active_folder_ids = array();
-		$has_abspath       = false;
+		$has_site_root     = false;
 
 		foreach ( $active_folders as $i => $active_folder ) {
 			$active_folders[ $i ] = $folders_db->cast_row( $active_folder );
 			$active_folder_ids[]  = $active_folders[ $i ][ $folders_key ];
 
-			if ( '{{ABSPATH}}/' === $active_folders[ $i ]['path'] ) {
-				$has_abspath = true;
+			if ( '{{ROOT}}/' === $active_folders[ $i ]['path'] ) {
+				$has_site_root = true;
+				break;
 			}
 		}
 
@@ -1044,7 +1045,7 @@ class Imagify_Custom_Folders {
 			$inactive_file              = $files_db->cast_row( $inactive_file );
 			$inactive_file['full_path'] = Imagify_Files_Scan::remove_placeholder( $inactive_file['path'] );
 
-			if ( $has_abspath ) {
+			if ( $has_site_root ) {
 				$inactive_file['dirname'] = $filesystem->dir_path( $inactive_file['full_path'] );
 			}
 
@@ -1060,7 +1061,7 @@ class Imagify_Custom_Folders {
 					$file_ids_by_folder[ $folder_id ] = array();
 				}
 
-				if ( '{{ABSPATH}}/' === $active_folder['path'] ) {
+				if ( '{{ROOT}}/' === $active_folder['path'] ) {
 					// For the site's root: only direct childs.
 					if ( $inactive_file['dirname'] === $active_folder['full_path'] ) {
 						// This file is in the site's root folder.
@@ -1199,7 +1200,7 @@ class Imagify_Custom_Folders {
 		sort( $placeholders );
 
 		foreach ( $placeholders as $i => $placeholder_path ) {
-			if ( '{{ABSPATH}}/' === $placeholder_path ) {
+			if ( '{{ROOT}}/' === $placeholder_path ) {
 				continue;
 			}
 

--- a/inc/classes/class-imagify-files-list-table.php
+++ b/inc/classes/class-imagify-files-list-table.php
@@ -17,7 +17,7 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * @since 1.7
 	 * @author Grégory Viguier
 	 */
-	const VERSION = '1.0.1';
+	const VERSION = '1.0.2';
 
 	/**
 	 * Class version.
@@ -309,7 +309,7 @@ class Imagify_Files_List_Table extends WP_List_Table {
 		$counts         = $wpdb->get_results( "SELECT folder_id, COUNT( $files_key_esc ) AS count FROM $files_table GROUP BY folder_id", OBJECT_K ); // WPCS: unprepared SQL ok.
 
 		foreach ( $folders as $folder ) {
-			if ( '{{ABSPATH}}/' === $folder->path ) {
+			if ( '{{ROOT}}/' === $folder->path ) {
 				$root_id = $folder->folder_id;
 				$folder_filters[ $folder->folder_id ] = '/';
 			} else {
@@ -363,7 +363,10 @@ class Imagify_Files_List_Table extends WP_List_Table {
 		$status_filter = self::get_status_filter();
 
 		// Display the filters.
-		$this->screen->render_screen_reader_content( 'heading_views' );
+		if ( method_exists( $this->screen, 'render_screen_reader_content' ) ) {
+			// Introduced in WP 4.4.
+			$this->screen->render_screen_reader_content( 'heading_views' );
+		}
 		?>
 		<div class="wp-filter">
 			<div class="filter-items">
@@ -566,7 +569,7 @@ class Imagify_Files_List_Table extends WP_List_Table {
 			$format = '<a href="' . esc_url( add_query_arg( 'folder-filter', $item->folder_id, get_imagify_admin_url( 'files-list' ) ) ) . '">%s</a>';
 		}
 
-		if ( '{{ABSPATH}}/' === $item->folder_path ) {
+		if ( '{{ROOT}}/' === $item->folder_path ) {
 			// It's the site's root.
 			printf( $format, __( 'Site\'s root', 'imagify' ) );
 		} else {

--- a/inc/classes/class-imagify-files-scan.php
+++ b/inc/classes/class-imagify-files-scan.php
@@ -16,7 +16,7 @@ class Imagify_Files_Scan {
 	 * @since  1.7
 	 * @author Grégory Viguier
 	 */
-	const VERSION = '1.1';
+	const VERSION = '1.1.1';
 
 	/**
 	 * Get files (optimizable by Imagify) recursively from a specific folder.
@@ -51,7 +51,7 @@ class Imagify_Files_Scan {
 		}
 
 		// Finally we made all our validations.
-		if ( $filesystem->is_abspath( $folder ) ) {
+		if ( $filesystem->is_site_root( $folder ) ) {
 			// For the site's root, we don't look in sub-folders.
 			$dir    = new DirectoryIterator( $folder );
 			$dir    = new Imagify_Files_Iterator( $dir, false );
@@ -169,10 +169,11 @@ class Imagify_Files_Scan {
 		}
 
 		$filesystem = imagify_get_filesystem();
+		$site_root  = $filesystem->get_site_root();
 		$abspath    = $filesystem->get_abspath();
 		$folders    = array(
 			// Server.
-			$abspath . 'cgi-bin',                          // `cgi-bin`
+			$site_root . 'cgi-bin',                        // `cgi-bin`
 			// WordPress.
 			$abspath . 'wp-admin',                         // `wp-admin`
 			$abspath . WPINC,                              // `wp-includes`
@@ -451,7 +452,7 @@ class Imagify_Files_Scan {
 			'{{THEMES}}/'     => WP_CONTENT_DIR . '/themes',
 			'{{UPLOADS}}/'    => $filesystem->get_main_upload_basedir(),
 			'{{CONTENT}}/'    => WP_CONTENT_DIR,
-			'{{ABSPATH}}/'    => ABSPATH,
+			'{{ROOT}}/'       => $filesystem->get_site_root(),
 		);
 		$replacements = array_map( array( $filesystem, 'normalize_dir_path' ), $replacements );
 
@@ -474,13 +475,14 @@ class Imagify_Files_Scan {
 			return $replacements;
 		}
 
+		$filesystem   = imagify_get_filesystem();
 		$replacements = array(
 			'{{PLUGINS}}/'    => plugins_url( '/' ),
 			'{{MU_PLUGINS}}/' => plugins_url( '/', WPMU_PLUGIN_DIR . '/.' ),
 			'{{THEMES}}/'     => content_url( 'themes/' ),
-			'{{UPLOADS}}/'    => imagify_get_filesystem()->get_main_upload_baseurl(),
+			'{{UPLOADS}}/'    => $filesystem->get_main_upload_baseurl(),
 			'{{CONTENT}}/'    => content_url( '/' ),
-			'{{ABSPATH}}/'    => site_url( '/' ),
+			'{{ROOT}}/'       => $filesystem->get_site_root_url(),
 		);
 
 		return $replacements;

--- a/inc/classes/class-imagify-filesystem.php
+++ b/inc/classes/class-imagify-filesystem.php
@@ -17,7 +17,7 @@ class Imagify_Filesystem extends WP_Filesystem_Direct {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.1';
+	const VERSION = '1.2';
 
 	/**
 	 * Delimiter used for regex patterns.
@@ -209,15 +209,15 @@ class Imagify_Filesystem extends WP_Filesystem_Direct {
 			return $this->is_dir( $path ) && $this->is_writable( $path );
 		}
 
-		$abspath = $this->get_abspath();
+		$site_root = $this->get_site_root();
 
-		if ( strpos( $path, $abspath ) !== 0 ) {
+		if ( strpos( $path, $site_root ) !== 0 ) {
 			return false;
 		}
 
-		$bits = str_replace( $abspath, '', $path );
+		$bits = str_replace( $site_root, '', $path );
 		$bits = explode( '/', $bits );
-		$path = untrailingslashit( $abspath );
+		$path = untrailingslashit( $site_root );
 
 		foreach ( $bits as $bit ) {
 			$path .= '/' . $bit;
@@ -337,7 +337,7 @@ class Imagify_Filesystem extends WP_Filesystem_Direct {
 	 * @return bool
 	 */
 	public function is_symlinked( $file_path ) {
-		static $abspath;
+		static $site_root;
 		static $plugin_paths = array();
 		global $wp_plugin_paths;
 
@@ -351,13 +351,13 @@ class Imagify_Filesystem extends WP_Filesystem_Direct {
 			return false;
 		}
 
-		if ( ! isset( $abspath ) ) {
-			$abspath = $this->normalize_path_for_comparison( $this->get_abspath() );
+		if ( ! isset( $site_root ) ) {
+			$site_root = $this->normalize_path_for_comparison( $this->get_site_root() );
 		}
 
 		$lower_file_path = $this->normalize_path_for_comparison( $real_path );
 
-		if ( strpos( $lower_file_path, $abspath ) !== 0 ) {
+		if ( strpos( $lower_file_path, $site_root ) !== 0 ) {
 			return true;
 		}
 
@@ -604,19 +604,14 @@ class Imagify_Filesystem extends WP_Filesystem_Direct {
 	 * @return string|bool       A relative path. Can return the absolute path or false in case of a failure.
 	 */
 	public function make_path_relative( $file_path, $base = '' ) {
-		static $abspath;
 		global $wp_plugin_paths;
 
 		if ( ! $file_path ) {
 			return false;
 		}
 
-		if ( ! isset( $abspath ) ) {
-			$abspath = wp_normalize_path( ABSPATH );
-		}
-
 		$file_path = wp_normalize_path( $file_path );
-		$base      = $base ? $this->normalize_dir_path( $base ) : $abspath;
+		$base      = $base ? $this->normalize_dir_path( $base ) : $this->get_site_root();
 		$pos       = strpos( $file_path, $base );
 
 		if ( false === $pos && $wp_plugin_paths && is_array( $wp_plugin_paths ) ) {
@@ -676,6 +671,20 @@ class Imagify_Filesystem extends WP_Filesystem_Direct {
 	/** ----------------------------------------------------------------------------------------- */
 
 	/**
+	 * Tell if WordPress is installed in its own directory: aka WP's path !== site's path.
+	 *
+	 * @since  1.8.1
+	 * @access public
+	 * @see    https://codex.wordpress.org/Giving_WordPress_Its_Own_Directory
+	 * @author Grégory Viguier
+	 *
+	 * @return string
+	 */
+	public function has_wp_its_own_directory() {
+		return $this->get_abspath() !== $this->get_site_root();
+	}
+
+	/**
 	 * The path to the server's root is not always '/', it can also be '//' or 'C://'.
 	 * I am get_root.
 	 *
@@ -692,7 +701,7 @@ class Imagify_Filesystem extends WP_Filesystem_Direct {
 			return $groot;
 		}
 
-		$groot = preg_replace( '@^((?:.:)?/+).*@', '$1', $this->get_abspath() );
+		$groot = preg_replace( '@^((?:.:)?/+).*@', '$1', $this->get_site_root() );
 
 		return $groot;
 	}
@@ -713,7 +722,109 @@ class Imagify_Filesystem extends WP_Filesystem_Direct {
 	}
 
 	/**
-	 * Get a clean value of ABSPATH that can be used in string replacements.
+	 * Get the path to the site's root.
+	 *
+	 * @since  1.8.1
+	 * @access public
+	 * @see    get_home_path()
+	 * @author Grégory Viguier
+	 *
+	 * @return string
+	 */
+	public function get_site_root() {
+		static $root_path;
+
+		if ( isset( $root_path ) ) {
+			return $root_path;
+		}
+
+		$home    = set_url_scheme( get_option( 'home' ), 'http' );
+		$siteurl = set_url_scheme( get_option( 'siteurl' ), 'http' );
+
+		if ( ! empty( $home ) && 0 !== strcasecmp( $home, $siteurl ) ) {
+			$wp_path_rel_to_home = str_ireplace( $home, '', $siteurl ); /* $siteurl - $home */
+			$pos                 = strripos( str_replace( '\\', '/', $_SERVER['SCRIPT_FILENAME'] ), trailingslashit( $wp_path_rel_to_home ) );
+			$root_path           = substr( $_SERVER['SCRIPT_FILENAME'], 0, $pos );
+			$root_path           = trailingslashit( str_replace( '\\', '/', $root_path ) );
+			return $root_path;
+		}
+
+		if ( ! defined( 'PATH_CURRENT_SITE' ) || ! is_multisite() || is_main_site() ) {
+			$root_path = str_replace( '\\', '/', ABSPATH );
+			return $root_path;
+		}
+
+		// For a multisite in its own directory, get_home_path() returns the expected path only for the main site.
+		$script_filename   = str_replace( '\\', '/', $_SERVER['SCRIPT_FILENAME'] );
+		$path_current_site = '/' . trim( str_replace( '\\', '/', PATH_CURRENT_SITE ), '/' ) . '/';
+		$pos               = strripos( $script_filename, $path_current_site );
+
+		if ( false === $pos ) {
+			$root_path = str_replace( '\\', '/', ABSPATH );
+			return $root_path;
+		}
+
+		$root_path = substr( $script_filename, 0, $pos ) . $path_current_site;
+		return $root_path;
+	}
+
+	/**
+	 * Get the URL of the site's root. It corresponds to the main site's home page URL.
+	 *
+	 * @since  1.8.1
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @return string
+	 */
+	public function get_site_root_url() {
+		static $root_url;
+
+		if ( isset( $root_url ) ) {
+			return $root_url;
+		}
+
+		if ( ! is_multisite() || is_main_site() ) {
+			$root_url = home_url( '/' );
+			return $root_url;
+		}
+
+		$current_network = false;
+
+		if ( function_exists( 'get_network' ) ) {
+			$current_network = get_network();
+		} elseif ( function_exists( 'get_current_site' ) ) {
+			$current_network = get_current_site();
+		}
+
+		if ( ! $current_network ) {
+			$root_url = home_url( '/' );
+			return $root_url;
+		}
+
+		$root_url = is_ssl() ? 'https' : 'http';
+		$root_url = set_url_scheme( 'http://' . $current_network->domain . $current_network->path, $root_url );
+		$root_url = trailingslashit( $root_url );
+
+		return $root_url;
+	}
+
+	/**
+	 * Tell if a path is the site's root.
+	 *
+	 * @since  1.8.1
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @param  string $path The path.
+	 * @return bool
+	 */
+	public function is_site_root( $path ) {
+		return $this->normalize_dir_path( $path ) === $this->get_site_root();
+	}
+
+	/**
+	 * Get a clean value of ABSPATH.
 	 *
 	 * @since  1.7.1
 	 * @access public
@@ -740,7 +851,7 @@ class Imagify_Filesystem extends WP_Filesystem_Direct {
 
 		} elseif ( false === $pos && class_exists( 'ReflectionClass' ) ) {
 			// Imagify is symlinked (dude, you look for trouble).
-			$reflector = new ReflectionClass( 'Requests' );
+			$reflector = new ReflectionClass( 'WP' );
 			$test_file = $reflector->getFileName();
 			$pos       = strpos( $test_file, $abspath );
 
@@ -760,7 +871,7 @@ class Imagify_Filesystem extends WP_Filesystem_Direct {
 	}
 
 	/**
-	 * Tell if a path is the site's root (ABSPATH).
+	 * Tell if a path is WP's root (ABSPATH).
 	 *
 	 * @since  1.7.1
 	 * @access public

--- a/views/part-settings-custom-folders.php
+++ b/views/part-settings-custom-folders.php
@@ -22,8 +22,8 @@ if ( $custom_folders ) {
 	natcasesort( $custom_folders );
 	$custom_folders = array_map( 'trailingslashit', $custom_folders );
 
-	if ( isset( $custom_folders['{{ABSPATH}}/'] ) ) {
-		$custom_folders['{{ABSPATH}}/'] = __( 'Site\'s root', 'imagify' );
+	if ( isset( $custom_folders['{{ROOT}}/'] ) ) {
+		$custom_folders['{{ROOT}}/'] = __( 'Site\'s root', 'imagify' );
 	}
 }
 

--- a/views/part-settings-row-custom-folder.php
+++ b/views/part-settings-row-custom-folder.php
@@ -1,7 +1,7 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin\' uh?' );
 ?>
-<p class="imagify-custom-folder-line" data-path="<?php echo '{{ABSPATH}}/' === $data['value'] ? '/' : esc_attr( $data['label'] ); ?>">
+<p class="imagify-custom-folder-line" data-path="<?php echo '{{ROOT}}/' === $data['value'] ? '/' : esc_attr( $data['label'] ); ?>">
 	<input type="hidden" name="imagify_settings[custom_folders][]" value="<?php echo esc_attr( $data['value'] ); ?>" />
 	<?php echo esc_html( $data['label'] ); ?>
 	<button type="button" class="imagify-custom-folders-remove"><span class="imagify-custom-folders-remove-text"><?php _ex( 'Remove', 'custom folder', 'imagify' ); ?></span><i class="dashicons dashicons-no-alt" aria-hidden="true"></i></button>


### PR DESCRIPTION
Basically, `ABSPATH` is not the path site's root folder.