### PR TITLE
Fixes #286: Imagify_Filesystem::get_site_root() failure on multisite

### DIFF
--- a/inc/classes/class-imagify-filesystem.php
+++ b/inc/classes/class-imagify-filesystem.php
@@ -761,12 +761,12 @@ class Imagify_Filesystem extends WP_Filesystem_Direct {
 			$wp_path_rel_to_home = str_ireplace( $home, '', $siteurl ); /* $siteurl - $home */
 			$pos                 = strripos( str_replace( '\\', '/', ABSPATH ), trailingslashit( $wp_path_rel_to_home ) );
 			$root_path           = substr( ABSPATH, 0, $pos );
-			$root_path           = trailingslashit( str_replace( '\\', '/', $root_path ) );
+			$root_path           = trailingslashit( wp_normalize_path( $root_path ) );
 			return $root_path;
 		}
 
 		if ( ! defined( 'PATH_CURRENT_SITE' ) || ! is_multisite() || is_main_site() ) {
-			$root_path = str_replace( '\\', '/', ABSPATH );
+			$root_path = $this->get_abspath();
 			return $root_path;
 		}
 
@@ -774,11 +774,12 @@ class Imagify_Filesystem extends WP_Filesystem_Direct {
 		 * For a multisite in its own directory, get_home_path() returns the expected path only for the main site.
 		 *
 		 * Friend, each time an attempt is made to improve this method, and especially this part, please increment the following counter.
-		 * Improvement attempts: 2.
+		 * Improvement attempts: 3.
 		 */
-		$document_root     = trailingslashit( str_replace( '\\', '/', wp_unslash( $_SERVER['DOCUMENT_ROOT'] ) ) );
+		$document_root     = realpath( wp_unslash( $_SERVER['DOCUMENT_ROOT'] ) ); // `realpath()` is needed for those cases where $_SERVER['DOCUMENT_ROOT'] is totally different from ABSPATH.
+		$document_root     = trailingslashit( str_replace( '\\', '/', $document_root ) );
 		$path_current_site = trim( str_replace( '\\', '/', PATH_CURRENT_SITE ), '/' );
-		$root_path         = trailingslashit( $document_root . $path_current_site );
+		$root_path         = trailingslashit( wp_normalize_path( $document_root . $path_current_site ) );
 
 		return $root_path;
 	}


### PR DESCRIPTION
Sometimes `$_SERVER['DOCUMENT_ROOT']` does not "fit" `ABSPATH` at all (symlink?). Using `realpath()` fixes the issue.