### PR TITLE
Update class-imagify-abstract-attachment.php

### DIFF
--- a/inc/classes/class-imagify-abstract-attachment.php
+++ b/inc/classes/class-imagify-abstract-attachment.php
@@ -252,8 +252,9 @@ abstract class Imagify_Abstract_Attachment extends Imagify_Abstract_Attachment_D
 		}
 
 		$backup_path = $this->get_raw_backup_path();
+		$has_backup = apply_filters('imagify_has_backup', $this->filesystem->exists( $backup_path ), $backup_path);
 
-		if ( $backup_path && $this->filesystem->exists( $backup_path ) ) {
+		if ( $backup_path && $has_backup) {
 			return $backup_path;
 		}
 

--- a/inc/classes/class-imagify-abstract-attachment.php
+++ b/inc/classes/class-imagify-abstract-attachment.php
@@ -763,7 +763,8 @@ abstract class Imagify_Abstract_Attachment extends Imagify_Abstract_Attachment_D
 	 * @return bool True if the attachment has a backup.
 	 */
 	public function has_backup() {
-		return (bool) $this->get_backup_path();
+		$has_backup = $this->get_backup_path();
+		return apply_filters('imagify_has_backup', (bool) $has_backup, $has_backup);
 	}
 
 	/**

--- a/inc/classes/class-imagify-abstract-attachment.php
+++ b/inc/classes/class-imagify-abstract-attachment.php
@@ -763,8 +763,7 @@ abstract class Imagify_Abstract_Attachment extends Imagify_Abstract_Attachment_D
 	 * @return bool True if the attachment has a backup.
 	 */
 	public function has_backup() {
-		$has_backup = $this->get_backup_path();
-		return apply_filters('imagify_has_backup', (bool) $has_backup, $has_backup);
+		return (bool) $this->get_backup_path();
 	}
 
 	/**


### PR DESCRIPTION
Allow 3rd party plugin to filter hs_backup().
Backup maybe not available in server, only accessible using CDN.

Our **WP Stateless** plugin remove attachment files from server (in **Stateless** Mode), after uploading to GCS (Google Cloud Storage). 
So we need a way to tell Imagify that backup exists in GCS, even though not exist in server.
When **Imagify** tries to restore we use `before_imagify_restore_attachment` to restore backup image if not exists to server from GCS.