### PR TITLE
Improved label of the webp option

### DIFF
--- a/views/part-settings-webp.php
+++ b/views/part-settings-webp.php
@@ -10,7 +10,7 @@ $settings = Imagify_Settings::get_instance();
 		<?php
 		$settings->field_checkbox( [
 			'option_name' => 'convert_to_webp',
-			'label'       => __( 'Convert images to webp format', 'imagify' ),
+			'label'       => __( 'Create webp versions of images', 'imagify' ),
 			'attributes'  => [
 				'aria-describedby' => 'describe-convert_to_webp',
 			],


### PR DESCRIPTION
The process to have webp images does not "convert" images, in the sense of "replace"; but "add" webp images along the non-webp images. By changing this label we try to make it more clear for the users.