### PR TITLE
Fixes #376: strpos() on non-string needles

### DIFF
--- a/inc/classes/class-imagify-files-scan.php
+++ b/inc/classes/class-imagify-files-scan.php
@@ -143,7 +143,7 @@ class Imagify_Files_Scan {
 			}
 		}
 
-		foreach ( $folders as $folder ) {
+		foreach ( $folders as $folder => $i ) {
 			if ( strpos( $file_path, $folder ) === 0 ) {
 				return true;
 			}


### PR DESCRIPTION
Because of `$folders = array_flip( $folders );` earlier, the needles used in `strpos()` were integers (array numeric keys before `array_flip()`).