### PR TITLE
Fixes #372: Conflict with plugins using outdated Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 	],
 	"type": "wordpress-plugin",
 	"config": {
+		"classloader-suffix": "WPMediaImagifyWordPressPlugin",
 		"classmap-authoritative": true,
 		"sort-packages": true
 	},
@@ -34,6 +35,7 @@
 		"composer/installers": "~1.0"
 	},
 	"require-dev": {
+		"dangoodman/composer-for-wordpress": "^2.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
 		"phpcompatibility/phpcompatibility-wp": "*",
 		"squizlabs/php_codesniffer": "^3.2",


### PR DESCRIPTION
Use [Composer for WordPress](https://github.com/dangoodman/composer-for-wordpress) Composer plugin as dev dependency to "namespace" the Composer class loader itself. This will prevent conflicts with plugins using an old version of Composer.