### PR TITLE
Compatibility with WP 5.3: auto-resize

### DIFF
--- a/classes/CDN/PushCDNInterface.php
+++ b/classes/CDN/PushCDNInterface.php
@@ -89,7 +89,7 @@ interface PushCDNInterface {
 	 * @access public
 	 * @author Grégory Viguier
 	 *
-	 * @param  string $file_name Name of the file. Leave empty for the full size file.
+	 * @param  string $file_name Name of the file. Leave empty for the full size file. Use 'original' to get the path to the original file.
 	 * @return string            Path to the file.
 	 */
 	public function get_file_path( $file_name = false );

--- a/classes/Context/AbstractContext.php
+++ b/classes/Context/AbstractContext.php
@@ -64,16 +64,6 @@ abstract class AbstractContext implements ContextInterface {
 	protected $thumbnail_sizes;
 
 	/**
-	 * Tell if the optimization process is allowed resize in this context.
-	 *
-	 * @var    bool
-	 * @since  1.9
-	 * @access protected
-	 * @author Grégory Viguier
-	 */
-	protected $can_resize;
-
-	/**
 	 * Tell if the optimization process is allowed to backup in this context.
 	 *
 	 * @var    bool
@@ -167,7 +157,7 @@ abstract class AbstractContext implements ContextInterface {
 	 * @return bool
 	 */
 	public function can_resize() {
-		return $this->can_resize;
+		return $this->get_resizing_threshold() > 0;
 	}
 
 	/**

--- a/classes/Context/ContextInterface.php
+++ b/classes/Context/ContextInterface.php
@@ -79,6 +79,18 @@ interface ContextInterface {
 	public function get_thumbnail_sizes();
 
 	/**
+	 * Get images max width for this context. This is used when resizing.
+	 * 0 means to not resize.
+	 *
+	 * @since  1.9.8
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @return int
+	 */
+	public function get_resizing_threshold();
+
+	/**
 	 * Tell if the optimization process is allowed resize in this context.
 	 *
 	 * @since  1.9

--- a/classes/Context/CustomFolders.php
+++ b/classes/Context/CustomFolders.php
@@ -41,14 +41,18 @@ class CustomFolders extends AbstractContext {
 	protected $thumbnail_sizes = [];
 
 	/**
-	 * Tell if the optimization process is allowed resize in this context.
+	 * Get images max width for this context. This is used when resizing.
+	 * 0 means to not resize.
 	 *
-	 * @var    bool
-	 * @since  1.9
-	 * @access protected
+	 * @since  1.9.8
+	 * @access public
 	 * @author Grégory Viguier
+	 *
+	 * @return int
 	 */
-	protected $can_resize = false;
+	public function get_resizing_threshold() {
+		return 0;
+	}
 
 	/**
 	 * Tell if the optimization process is allowed to backup in this context.

--- a/classes/Context/Noop.php
+++ b/classes/Context/Noop.php
@@ -77,16 +77,17 @@ class Noop implements ContextInterface {
 	}
 
 	/**
-	 * Tell if the optimization process is allowed resize in this context.
+	 * Get images max width for this context. This is used when resizing.
+	 * 0 means to not resize.
 	 *
-	 * @since  1.9
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *
-	 * @return bool
+	 * @return int
 	 */
-	public function can_resize() {
-		return false;
+	public function get_resizing_threshold() {
+		return 0;
 	}
 
 	/**

--- a/classes/Context/WP.php
+++ b/classes/Context/WP.php
@@ -23,6 +23,16 @@ class WP extends AbstractContext {
 	protected $context = 'wp';
 
 	/**
+	 * Images max width for this context. This is used when resizing.
+	 *
+	 * @var    int
+	 * @since  1.9.8
+	 * @access protected
+	 * @author Grégory Viguier
+	 */
+	protected $resizing_threshold;
+
+	/**
 	 * Get the thumbnail sizes for this context, except the full size.
 	 *
 	 * @since  1.9
@@ -50,22 +60,27 @@ class WP extends AbstractContext {
 	}
 
 	/**
-	 * Tell if the optimization process is allowed resize in this context.
+	 * Get images max width for this context. This is used when resizing.
+	 * 0 means to not resize.
 	 *
-	 * @since  1.9
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *
-	 * @return bool
+	 * @return int
 	 */
-	public function can_resize() {
-		if ( isset( $this->can_resize ) ) {
-			return $this->can_resize;
+	public function get_resizing_threshold() {
+		if ( isset( $this->resizing_threshold ) ) {
+			return $this->resizing_threshold;
 		}
 
-		$this->can_resize = get_imagify_option( 'resize_larger' ) && get_imagify_option( 'resize_larger_w' ) > 0;
+		if ( ! get_imagify_option( 'resize_larger' ) ) {
+			$this->resizing_threshold = 0;
+		} else {
+			$this->resizing_threshold = max( 0, get_imagify_option( 'resize_larger_w' ) );
+		}
 
-		return $this->can_resize;
+		return $this->resizing_threshold;
 	}
 
 	/**

--- a/classes/Media/AbstractMedia.php
+++ b/classes/Media/AbstractMedia.php
@@ -237,13 +237,41 @@ abstract class AbstractMedia implements MediaInterface {
 			return false;
 		}
 
-		$backup_path = $this->get_raw_original_path();
+		$original_path = $this->get_raw_original_path();
 
-		if ( ! $backup_path || ! $this->filesystem->exists( $backup_path ) ) {
+		if ( ! $original_path || ! $this->filesystem->exists( $original_path ) ) {
 			return false;
 		}
 
-		return $backup_path;
+		return $original_path;
+	}
+
+
+	/** ----------------------------------------------------------------------------------------- */
+	/** FULL SIZE FILE ========================================================================== */
+	/** ----------------------------------------------------------------------------------------- */
+
+	/**
+	 * Get the path to the media’s full size file if the file exists.
+	 *
+	 * @since  1.9.7
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @return string|bool The file path. False if it doesn't exist.
+	 */
+	public function get_fullsize_path() {
+		if ( ! $this->is_valid() ) {
+			return false;
+		}
+
+		$original_path = $this->get_raw_fullsize_path();
+
+		if ( ! $original_path || ! $this->filesystem->exists( $original_path ) ) {
+			return false;
+		}
+
+		return $original_path;
 	}
 
 
@@ -398,7 +426,7 @@ abstract class AbstractMedia implements MediaInterface {
 			return false;
 		}
 
-		$dimensions = $this->filesystem->get_image_size( $this->get_raw_original_path() );
+		$dimensions = $this->filesystem->get_image_size( $this->get_raw_fullsize_path() );
 
 		if ( ! $dimensions ) {
 			// Could not get the new dimensions.
@@ -487,7 +515,7 @@ abstract class AbstractMedia implements MediaInterface {
 			return $this->file_type;
 		}
 
-		$path = $this->get_raw_original_path();
+		$path = $this->get_raw_fullsize_path();
 
 		if ( ! $path ) {
 			return $this->file_type;
@@ -506,7 +534,7 @@ abstract class AbstractMedia implements MediaInterface {
 	 * @see    $this->get_media_files()
 	 * @author Grégory Viguier
 	 *
-	 * @param  array $files An array with the size names as keys ('full' is used for the original file), and arrays of data as values.
+	 * @param  array $files An array with the size names as keys ('full' is used for the full size file), and arrays of data as values.
 	 * @return array
 	 */
 	protected function filter_media_files( $files ) {
@@ -516,7 +544,7 @@ abstract class AbstractMedia implements MediaInterface {
 		 * @since  1.9
 		 * @author Grégory Viguier
 		 *
-		 * @param array          $files An array with the size names as keys ('full' is used for the original file), and arrays of data as values.
+		 * @param array          $files An array with the size names as keys ('full' is used for the full size file), and arrays of data as values.
 		 * @param MediaInterface $media This instance.
 		 */
 		return (array) apply_filters( 'imagify_media_files', $files, $this );

--- a/classes/Media/AbstractMedia.php
+++ b/classes/Media/AbstractMedia.php
@@ -254,7 +254,7 @@ abstract class AbstractMedia implements MediaInterface {
 	/**
 	 * Get the path to the media’s full size file if the file exists.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *

--- a/classes/Media/CustomFolders.php
+++ b/classes/Media/CustomFolders.php
@@ -125,7 +125,7 @@ class CustomFolders extends AbstractMedia {
 	/**
 	 * Get the URL of the media’s full size file.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *
@@ -152,7 +152,7 @@ class CustomFolders extends AbstractMedia {
 	/**
 	 * Get the path to the media’s full size file, even if the file doesn't exist.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *

--- a/classes/Media/CustomFolders.php
+++ b/classes/Media/CustomFolders.php
@@ -11,6 +11,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
  */
 class CustomFolders extends AbstractMedia {
 	use \Imagify\Traits\MediaRowTrait;
+	use \Imagify\Deprecated\Traits\Media\CustomFoldersDeprecatedTrait;
 
 	/**
 	 * Context (where the media "comes from").
@@ -90,15 +91,47 @@ class CustomFolders extends AbstractMedia {
 	/** ----------------------------------------------------------------------------------------- */
 
 	/**
-	 * Get the original media's URL.
+	 * Get the original media's path.
 	 *
 	 * @since  1.9
 	 * @access public
 	 * @author Grégory Viguier
 	 *
+	 * @return string|bool The file path. False on failure.
+	 */
+	public function get_raw_original_path() {
+		if ( ! $this->is_valid() ) {
+			return false;
+		}
+
+		if ( $this->get_cdn() ) {
+			return $this->get_cdn()->get_file_path( 'original' );
+		}
+
+		$row = $this->get_row();
+
+		if ( ! $row || empty( $row['path'] ) ) {
+			return false;
+		}
+
+		return \Imagify_Files_Scan::remove_placeholder( $row['path'] );
+	}
+
+
+	/** ----------------------------------------------------------------------------------------- */
+	/** FULL SIZE FILE ========================================================================== */
+	/** ----------------------------------------------------------------------------------------- */
+
+	/**
+	 * Get the URL of the media’s full size file.
+	 *
+	 * @since  1.9.7
+	 * @access public
+	 * @author Grégory Viguier
+	 *
 	 * @return string|bool The file URL. False on failure.
 	 */
-	public function get_original_url() {
+	public function get_fullsize_url() {
 		if ( ! $this->is_valid() ) {
 			return false;
 		}
@@ -117,15 +150,15 @@ class CustomFolders extends AbstractMedia {
 	}
 
 	/**
-	 * Get the original media's path.
+	 * Get the path to the media’s full size file, even if the file doesn't exist.
 	 *
-	 * @since  1.9
+	 * @since  1.9.7
 	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return string|bool The file path. False on failure.
 	 */
-	public function get_raw_original_path() {
+	public function get_raw_fullsize_path() {
 		if ( ! $this->is_valid() ) {
 			return false;
 		}
@@ -224,14 +257,14 @@ class CustomFolders extends AbstractMedia {
 	}
 
 	/**
-	 * Get the list of the files of this media, including the original file.
+	 * Get the list of the files of this media, including the full size file.
 	 *
 	 * @since  1.9
 	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return array {
-	 *     An array with the size names as keys ('full' is used for the original file), and arrays of data as values:
+	 *     An array with the size names as keys ('full' is used for the full size file), and arrays of data as values:
 	 *
 	 *     @type string $size      The size name.
 	 *     @type string $path      Absolute path to the file.
@@ -246,9 +279,9 @@ class CustomFolders extends AbstractMedia {
 			return [];
 		}
 
-		$original_path = $this->get_raw_original_path();
+		$fullsize_path = $this->get_raw_fullsize_path();
 
-		if ( ! $original_path ) {
+		if ( ! $fullsize_path ) {
 			return [];
 		}
 
@@ -256,7 +289,7 @@ class CustomFolders extends AbstractMedia {
 		$sizes      = [
 			'full' => [
 				'size'      => 'full',
-				'path'      => $original_path,
+				'path'      => $fullsize_path,
 				'width'     => $dimensions['width'],
 				'height'    => $dimensions['height'],
 				'mime-type' => $this->get_mime_type(),

--- a/classes/Media/MediaInterface.php
+++ b/classes/Media/MediaInterface.php
@@ -88,17 +88,6 @@ interface MediaInterface {
 	/** ----------------------------------------------------------------------------------------- */
 
 	/**
-	 * Get the original media's URL.
-	 *
-	 * @since  1.9
-	 * @access public
-	 * @author Grégory Viguier
-	 *
-	 * @return string|bool The file URL. False on failure.
-	 */
-	public function get_original_url();
-
-	/**
 	 * Get the original file path, even if the file doesn't exist.
 	 *
 	 * @since  1.9
@@ -119,6 +108,44 @@ interface MediaInterface {
 	 * @return string|bool The file path. False if it doesn't exist.
 	 */
 	public function get_original_path();
+
+
+	/** ----------------------------------------------------------------------------------------- */
+	/** FULL SIZE FILE ========================================================================== */
+	/** ----------------------------------------------------------------------------------------- */
+
+	/**
+	 * Get the URL of the media’s full size file.
+	 *
+	 * @since  1.9.7
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @return string|bool The file URL. False on failure.
+	 */
+	public function get_fullsize_url();
+
+	/**
+	 * Get the path to the media’s full size file, even if the file doesn't exist.
+	 *
+	 * @since  1.9.7
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @return string|bool The file path. False on failure.
+	 */
+	public function get_raw_fullsize_path();
+
+	/**
+	 * Get the path to the media’s full size file if the file exists.
+	 *
+	 * @since  1.9.7
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @return string|bool The file path. False if it doesn't exist.
+	 */
+	public function get_fullsize_path();
 
 
 	/** ----------------------------------------------------------------------------------------- */

--- a/classes/Media/MediaInterface.php
+++ b/classes/Media/MediaInterface.php
@@ -117,7 +117,7 @@ interface MediaInterface {
 	/**
 	 * Get the URL of the media’s full size file.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *
@@ -128,7 +128,7 @@ interface MediaInterface {
 	/**
 	 * Get the path to the media’s full size file, even if the file doesn't exist.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *
@@ -139,7 +139,7 @@ interface MediaInterface {
 	/**
 	 * Get the path to the media’s full size file if the file exists.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *

--- a/classes/Media/Noop.php
+++ b/classes/Media/Noop.php
@@ -131,7 +131,7 @@ class Noop implements MediaInterface {
 	/**
 	 * Get the URL of the media’s full size file.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *
@@ -144,7 +144,7 @@ class Noop implements MediaInterface {
 	/**
 	 * Get the path to the media’s full size file, even if the file doesn't exist.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *
@@ -157,7 +157,7 @@ class Noop implements MediaInterface {
 	/**
 	 * Get the path to the media’s full size file if the file exists.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *

--- a/classes/Media/Noop.php
+++ b/classes/Media/Noop.php
@@ -10,6 +10,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
  * @author Grégory Viguier
  */
 class Noop implements MediaInterface {
+	use \Imagify\Deprecated\Traits\Media\NoopDeprecatedTrait;
 
 	/**
 	 * Tell if the given entry can be accepted in the constructor.
@@ -97,19 +98,6 @@ class Noop implements MediaInterface {
 	/** ----------------------------------------------------------------------------------------- */
 
 	/**
-	 * Get the original media's URL.
-	 *
-	 * @since  1.9
-	 * @access public
-	 * @author Grégory Viguier
-	 *
-	 * @return string|bool The file URL. False on failure.
-	 */
-	public function get_original_url() {
-		return false;
-	}
-
-	/**
 	 * Get the original file path, even if the file doesn't exist.
 	 *
 	 * @since  1.9
@@ -132,6 +120,50 @@ class Noop implements MediaInterface {
 	 * @return string|bool The file path. False if it doesn't exist.
 	 */
 	public function get_original_path() {
+		return false;
+	}
+
+
+	/** ----------------------------------------------------------------------------------------- */
+	/** FULL SIZE FILE ========================================================================== */
+	/** ----------------------------------------------------------------------------------------- */
+
+	/**
+	 * Get the URL of the media’s full size file.
+	 *
+	 * @since  1.9.7
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @return string|bool The file URL. False on failure.
+	 */
+	public function get_fullsize_url() {
+		return false;
+	}
+
+	/**
+	 * Get the path to the media’s full size file, even if the file doesn't exist.
+	 *
+	 * @since  1.9.7
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @return string|bool The file path. False on failure.
+	 */
+	public function get_raw_fullsize_path() {
+		return false;
+	}
+
+	/**
+	 * Get the path to the media’s full size file if the file exists.
+	 *
+	 * @since  1.9.7
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @return string|bool The file path. False if it doesn't exist.
+	 */
+	public function get_fullsize_path() {
 		return false;
 	}
 

--- a/classes/Media/WP.php
+++ b/classes/Media/WP.php
@@ -16,7 +16,7 @@ class WP extends AbstractMedia {
 	 * Tell if we’re playing in WP 5.3’s garden.
 	 *
 	 * @var    bool
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access protected
 	 * @author Grégory Viguier
 	 */
@@ -108,7 +108,7 @@ class WP extends AbstractMedia {
 	/**
 	 * Get the URL of the media’s full size file.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *
@@ -131,7 +131,7 @@ class WP extends AbstractMedia {
 	/**
 	 * Get the path to the media’s full size file, even if the file doesn't exist.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *
@@ -411,7 +411,7 @@ class WP extends AbstractMedia {
 	/**
 	 * Tell if we’re playing in WP 5.3’s garden.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access protected
 	 * @author Grégory Viguier
 	 *

--- a/classes/Media/WP.php
+++ b/classes/Media/WP.php
@@ -10,6 +10,17 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
  * @author Grégory Viguier
  */
 class WP extends AbstractMedia {
+	use \Imagify\Deprecated\Traits\Media\WPDeprecatedTrait;
+
+	/**
+	 * Tell if we’re playing in WP 5.3’s garden.
+	 *
+	 * @var    bool
+	 * @since  1.9.7
+	 * @access protected
+	 * @author Grégory Viguier
+	 */
+	protected $is_wp53;
 
 	/**
 	 * The constructor.
@@ -58,15 +69,52 @@ class WP extends AbstractMedia {
 	/** ----------------------------------------------------------------------------------------- */
 
 	/**
-	 * Get the original media's URL.
+	 * Get the original file path, even if the file doesn't exist.
 	 *
 	 * @since  1.9
 	 * @access public
 	 * @author Grégory Viguier
 	 *
+	 * @return string|bool The file path. False on failure.
+	 */
+	public function get_raw_original_path() {
+		if ( ! $this->is_valid() ) {
+			return false;
+		}
+
+		if ( $this->get_cdn() ) {
+			return $this->get_cdn()->get_file_path( 'original' );
+		}
+
+		if ( $this->is_wp_53() ) {
+			// `wp_get_original_image_path()` may return false.
+			$path = wp_get_original_image_path( $this->id );
+		} else {
+			$path = false;
+		}
+
+		if ( ! $path ) {
+			$path = get_attached_file( $this->id );
+		}
+
+		return $path ? $path : false;
+	}
+
+
+	/** ----------------------------------------------------------------------------------------- */
+	/** FULL SIZE FILE ========================================================================== */
+	/** ----------------------------------------------------------------------------------------- */
+
+	/**
+	 * Get the URL of the media’s full size file.
+	 *
+	 * @since  1.9.7
+	 * @access public
+	 * @author Grégory Viguier
+	 *
 	 * @return string|bool The file URL. False on failure.
 	 */
-	public function get_original_url() {
+	public function get_fullsize_url() {
 		if ( ! $this->is_valid() ) {
 			return false;
 		}
@@ -81,15 +129,15 @@ class WP extends AbstractMedia {
 	}
 
 	/**
-	 * Get the original media's path.
+	 * Get the path to the media’s full size file, even if the file doesn't exist.
 	 *
-	 * @since  1.9
+	 * @since  1.9.7
 	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return string|bool The file path. False on failure.
 	 */
-	public function get_raw_original_path() {
+	public function get_raw_fullsize_path() {
 		if ( ! $this->is_valid() ) {
 			return false;
 		}
@@ -149,6 +197,7 @@ class WP extends AbstractMedia {
 
 	/**
 	 * Create the media thumbnails.
+	 * With WP 5.3+, this will also generate a new full size file if the original file is wider or taller than a defined threshold.
 	 *
 	 * @since  1.9
 	 * @access public
@@ -167,8 +216,31 @@ class WP extends AbstractMedia {
 
 		$metadata = wp_generate_attachment_metadata( $this->get_id(), $this->get_raw_original_path() );
 
-		if ( empty( $metadata['sizes'] ) ) {
-			return new \WP_Error( 'thumbnails_creation_filure', __( 'New thumbnails could not be created.', 'imagify' ) );
+		if ( empty( $metadata['file'] ) ) {
+			// Σ(ﾟДﾟ).
+			update_post_meta( $this->get_id(), '_wp_attachment_metadata', $metadata );
+
+			return true;
+		}
+
+		/**
+		 * Don't change the full size file name.
+		 * WP 5.3+ will rename the full size file if the resizing threshold has changed (not the same as the one used to generate it previously).
+		 * This will force WP to keep the previous file name.
+		 */
+		$old_full_size_path      = $this->get_raw_fullsize_path();
+		$old_full_size_file_name = $this->filesystem->file_name( $old_full_size_path );
+		$new_full_size_file_name = $this->filesystem->file_name( $metadata['file'] );
+
+		if ( $new_full_size_file_name !== $old_full_size_file_name ) {
+			$new_full_size_path = $this->filesystem->dir_path( $old_full_size_path ) . $new_full_size_file_name;
+
+			$moved = $this->filesystem->move( $new_full_size_path, $old_full_size_path, true );
+
+			if ( $moved ) {
+				$metadata['file'] = $this->filesystem->dir_path( $metadata['file'] ) . $old_full_size_file_name;
+				update_post_meta( $this->get_id(), '_wp_attached_file', $metadata['file'] );
+			}
 		}
 
 		update_post_meta( $this->get_id(), '_wp_attachment_metadata', $metadata );
@@ -205,14 +277,14 @@ class WP extends AbstractMedia {
 	}
 
 	/**
-	 * Get the list of the files of this media, including the original file.
+	 * Get the list of the files of this media, including the full size file.
 	 *
 	 * @since  1.9
 	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return array {
-	 *     An array with the size names as keys ('full' is used for the original file), and arrays of data as values:
+	 *     An array with the size names as keys ('full' is used for the full size file), and arrays of data as values:
 	 *
 	 *     @type string $size      The size name.
 	 *     @type string $path      Absolute path to the file.
@@ -227,9 +299,9 @@ class WP extends AbstractMedia {
 			return [];
 		}
 
-		$original_path = $this->get_raw_original_path();
+		$fullsize_path = $this->get_raw_fullsize_path();
 
-		if ( ! $original_path ) {
+		if ( ! $fullsize_path ) {
 			return [];
 		}
 
@@ -237,7 +309,7 @@ class WP extends AbstractMedia {
 		$all_sizes  = [
 			'full' => [
 				'size'      => 'full',
-				'path'      => $original_path,
+				'path'      => $fullsize_path,
 				'width'     => $dimensions['width'],
 				'height'    => $dimensions['height'],
 				'mime-type' => $this->get_mime_type(),
@@ -257,7 +329,7 @@ class WP extends AbstractMedia {
 			return $all_sizes;
 		}
 
-		$dir_path              = $this->filesystem->dir_path( $original_path );
+		$dir_path              = $this->filesystem->dir_path( $fullsize_path );
 		$disallowed_sizes      = get_imagify_option( 'disallowed-sizes' );
 		$is_active_for_network = imagify_is_active_for_network();
 
@@ -304,7 +376,7 @@ class WP extends AbstractMedia {
 	 * Update the media data dimensions.
 	 *
 	 * @since  1.9
-	 * @access public
+	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param array $dimensions {
@@ -329,5 +401,29 @@ class WP extends AbstractMedia {
 		$metadata['height'] = $dimensions['height'];
 
 		update_post_meta( $this->get_id(), '_wp_attachment_metadata', $metadata );
+	}
+
+
+	/** ----------------------------------------------------------------------------------------- */
+	/** INTERNAL TOOLS ========================================================================== */
+	/** ----------------------------------------------------------------------------------------- */
+
+	/**
+	 * Tell if we’re playing in WP 5.3’s garden.
+	 *
+	 * @since  1.9.7
+	 * @access protected
+	 * @author Grégory Viguier
+	 *
+	 * @return bool
+	 */
+	protected function is_wp_53() {
+		if ( isset( $this->is_wp53 ) ) {
+			return $this->is_wp53;
+		}
+
+		$this->is_wp53 = function_exists( 'wp_get_original_image_path' );
+
+		return $this->is_wp53;
 	}
 }

--- a/classes/Optimization/Data/AbstractData.php
+++ b/classes/Optimization/Data/AbstractData.php
@@ -321,7 +321,7 @@ abstract class AbstractData implements DataInterface {
 
 		if ( $use_webp && ! empty( $data['sizes'][ $webp_size_name ]['success'] ) ) {
 			// Try with the webp file first.
-			$filepath = $media->get_raw_original_path();
+			$filepath = $media->get_raw_fullsize_path();
 			$filepath = $filepath ? imagify_path_to_webp( $filepath ) : false;
 
 			if ( ! $filepath || ! $this->filesystem->exists( $filepath ) ) {
@@ -331,7 +331,7 @@ abstract class AbstractData implements DataInterface {
 
 		if ( ! $filepath ) {
 			// No webp? The full size then.
-			$filepath = $media->get_original_path();
+			$filepath = $media->get_fullsize_path();
 		}
 
 		if ( ! $filepath ) {

--- a/classes/Optimization/Data/CustomFolders.php
+++ b/classes/Optimization/Data/CustomFolders.php
@@ -153,7 +153,7 @@ class CustomFolders extends AbstractData {
 			$old_data['status']             = $data['status'];
 			$old_data['modified']           = 0;
 
-			$file_path = $this->get_media()->get_original_path();
+			$file_path = $this->get_media()->get_fullsize_path();
 
 			if ( $file_path ) {
 				$old_data['hash'] = md5_file( $file_path );
@@ -263,7 +263,7 @@ class CustomFolders extends AbstractData {
 		$imagify_columns = $column_defaults;
 
 		// Also set the new file hash.
-		$file_path = $this->get_media()->get_original_path();
+		$file_path = $this->get_media()->get_fullsize_path();
 
 		if ( $file_path ) {
 			$imagify_columns['hash'] = md5_file( $file_path );

--- a/classes/Optimization/File.php
+++ b/classes/Optimization/File.php
@@ -173,7 +173,7 @@ class File {
 	/** ----------------------------------------------------------------------------------------- */
 
 	/**
-	 * Resize an image if it is bigger than the maximum width defined in the settings.
+	 * Resize an image if it is bigger than the maximum width provided.
 	 *
 	 * @since  1.9
 	 * @access public
@@ -186,7 +186,7 @@ class File {
 	 *     @type int $width  The image width.
 	 *     @type int $height The image height.
 	 * }
-	 * @param  int   $max_width Maximum width defined in the settings.
+	 * @param  int   $max_width Maximum width to resize to.
 	 * @return string|WP_Error  Path the the resized image. A WP_Error object on failure.
 	 */
 	public function resize( $dimensions = [], $max_width = 0 ) {
@@ -194,6 +194,13 @@ class File {
 
 		if ( is_wp_error( $can_be_processed ) ) {
 			return $can_be_processed;
+		}
+
+		if ( ! $max_width ) {
+			return new \WP_Error(
+				'no_resizing_threshold',
+				__( 'No threshold provided for resizing.', 'imagify' )
+			);
 		}
 
 		if ( ! $this->is_image() ) {
@@ -232,10 +239,6 @@ class File {
 
 		if ( ! $dimensions ) {
 			$dimensions = $this->get_dimensions();
-		}
-
-		if ( ! $max_width ) {
-			$max_width = $this->get_option( 'resize_larger_w' );
 		}
 
 		// Prevent removal of the exif data when resizing (only works with Imagick).

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -970,7 +970,7 @@ abstract class AbstractProcess implements ProcessInterface {
 		/**
 		 * Delete the webp versions.
 		 * If the full size file and the original file are not the same, the full size is considered like a thumbnail.
-		 * In that case we must also delete the webp file assocoated to the full size.
+		 * In that case we must also delete the webp file associated to the full size.
 		 */
 		$keep_full_webp = $media->get_raw_original_path() === $media->get_raw_fullsize_path();
 		$this->delete_webp_files( $keep_full_webp );

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -1249,7 +1249,7 @@ abstract class AbstractProcess implements ProcessInterface {
 			);
 		}
 
-		$resize_width = $this->get_option( 'resize_larger_w' );
+		$resize_width = $media->get_context_instance()->get_resizing_threshold();
 
 		if ( $resize_width >= $dimensions['width'] ) {
 			// No need to resize.

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
  * @author Grégory Viguier
  */
 abstract class AbstractProcess implements ProcessInterface {
+	use \Imagify\Deprecated\Traits\Optimization\Process\AbstractProcessDeprecatedTrait;
 
 	/**
 	 * The suffix used in the thumbnail size name.
@@ -176,15 +177,15 @@ abstract class AbstractProcess implements ProcessInterface {
 	}
 
 	/**
-	 * Get the File instance.
+	 * Get the File instance of the original file.
 	 *
-	 * @since  1.9
+	 * @since  1.9.7
 	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return File|false
 	 */
-	public function get_file() {
+	public function get_original_file() {
 		if ( isset( $this->file ) ) {
 			return $this->file;
 		}
@@ -193,6 +194,29 @@ abstract class AbstractProcess implements ProcessInterface {
 
 		if ( $this->get_media() ) {
 			$this->file = new File( $this->get_media()->get_raw_original_path() );
+		}
+
+		return $this->file;
+	}
+
+	/**
+	 * Get the File instance of the full size file.
+	 *
+	 * @since  1.9.7
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @return File|false
+	 */
+	public function get_fullsize_file() {
+		if ( isset( $this->file ) ) {
+			return $this->file;
+		}
+
+		$this->file = false;
+
+		if ( $this->get_media() ) {
+			$this->file = new File( $this->get_media()->get_raw_fullsize_path() );
 		}
 
 		return $this->file;
@@ -402,7 +426,7 @@ abstract class AbstractProcess implements ProcessInterface {
 
 				if ( $webp ) {
 					// We have at least one webp conversion to do: create a temporary backup.
-					$backuped = $this->get_file()->backup( $media->get_raw_backup_path() );
+					$backuped = $this->get_original_file()->backup( $media->get_raw_backup_path() );
 
 					if ( $backuped ) {
 						// See \Imagify\Job\MediaOptimization->delete_backup().
@@ -652,6 +676,7 @@ abstract class AbstractProcess implements ProcessInterface {
 					$response = $file->optimize( [
 						'backup'             => ! $response['backuped'] && $this->can_backup( $size ),
 						'backup_path'        => $media->get_raw_backup_path(),
+						'backup_source'      => 'full' === $thumb_size ? $media->get_original_path() : null,
 						'optimization_level' => $optimization_level,
 						'convert'            => $webp ? 'webp' : '',
 						'keep_exif'          => $this->can_keep_exif( $size ),
@@ -847,22 +872,22 @@ abstract class AbstractProcess implements ProcessInterface {
 
 		$this->lock( 'restoring' );
 
-		$backup_path = $media->get_backup_path();
-		$media_path  = $media->get_raw_original_path();
+		$backup_path   = $media->get_backup_path();
+		$original_path = $media->get_raw_original_path();
 
-		if ( $backup_path === $media_path ) {
+		if ( $backup_path === $original_path ) {
 			// Uh?!
 			$this->unlock();
 			return new \WP_Error( 'same_path', __( 'Image path and backup path are identical.', 'imagify' ) );
 		}
 
-		$dest_dir = $this->filesystem->dir_path( $media_path );
+		$dest_dir = $this->filesystem->dir_path( $original_path );
 
 		if ( ! $this->filesystem->exists( $dest_dir ) ) {
 			$this->filesystem->make_dir( $dest_dir );
 		}
 
-		$dest_file_is_writable = ! $this->filesystem->exists( $media_path ) || $this->filesystem->is_writable( $media_path );
+		$dest_file_is_writable = ! $this->filesystem->exists( $original_path ) || $this->filesystem->is_writable( $original_path );
 
 		if ( ! $dest_file_is_writable || ! $this->filesystem->is_writable( $dest_dir ) ) {
 			$this->unlock();
@@ -887,14 +912,14 @@ abstract class AbstractProcess implements ProcessInterface {
 
 		if ( ! is_wp_error( $response ) ) {
 			// Create the original image from the backup.
-			$response = $this->filesystem->copy( $backup_path, $media_path, true );
+			$response = $this->filesystem->copy( $backup_path, $original_path, true );
 
 			if ( ! $response ) {
 				// Failure.
 				$response = new \WP_Error( 'copy_failed', __( 'The backup file could not be copied over the optimized one.', 'imagify' ) );
 			} else {
 				// Backup successfully copied.
-				$this->filesystem->chmod_file( $media_path );
+				$this->filesystem->chmod_file( $original_path );
 
 				// Remove old optimization data.
 				$this->get_data()->delete_optimization_data();
@@ -904,7 +929,7 @@ abstract class AbstractProcess implements ProcessInterface {
 					$media->update_dimensions();
 
 					// Delete the webp version.
-					$this->delete_webp_file( $media_path );
+					$this->delete_webp_file( $original_path );
 
 					// Restore the thumbnails.
 					$response = $this->restore_thumbnails();
@@ -940,10 +965,18 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * @return bool|WP_Error True on success. A \WP_Error instance on failure.
 	 */
 	protected function restore_thumbnails() {
-		// Delete the webp versions.
-		$this->delete_webp_files( true );
+		$media = $this->get_media();
+
+		/**
+		 * Delete the webp versions.
+		 * If the full size file and the original file are not the same, the full size is considered like a thumbnail.
+		 * In that case we must also delete the webp file assocoated to the full size.
+		 */
+		$keep_full_webp = $media->get_raw_original_path() === $media->get_raw_fullsize_path();
+		$this->delete_webp_files( $keep_full_webp );
+
 		// Generate new thumbnails.
-		return $this->get_media()->generate_thumbnails();
+		return $media->generate_thumbnails();
 	}
 
 
@@ -1144,7 +1177,7 @@ abstract class AbstractProcess implements ProcessInterface {
 	 */
 	protected function get_temporary_copy_path( $size, $sizes = null ) {
 		if ( 'full' === $size ) {
-			$path = $this->get_media()->get_raw_original_path();
+			$path = $this->get_media()->get_raw_fullsize_path();
 		} else {
 			if ( ! isset( $sizes ) ) {
 				$sizes = $this->get_media()->get_media_files();
@@ -1242,7 +1275,8 @@ abstract class AbstractProcess implements ProcessInterface {
 		}
 
 		if ( $this->can_backup( $size ) ) {
-			$backuped = $file->backup( $media->get_raw_backup_path() );
+			$source   = 'full' === $size ? $media->get_original_path() : null;
+			$backuped = $file->backup( $media->get_raw_backup_path(), $source );
 
 			if ( is_wp_error( $backuped ) ) {
 				// The backup failed.

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -179,7 +179,7 @@ abstract class AbstractProcess implements ProcessInterface {
 	/**
 	 * Get the File instance of the original file.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *
@@ -202,7 +202,7 @@ abstract class AbstractProcess implements ProcessInterface {
 	/**
 	 * Get the File instance of the full size file.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *

--- a/classes/Optimization/Process/ProcessInterface.php
+++ b/classes/Optimization/Process/ProcessInterface.php
@@ -49,7 +49,7 @@ interface ProcessInterface {
 	/**
 	 * Get the File instance of the original file.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *
@@ -60,7 +60,7 @@ interface ProcessInterface {
 	/**
 	 * Get the File instance of the full size file.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *

--- a/classes/Optimization/Process/ProcessInterface.php
+++ b/classes/Optimization/Process/ProcessInterface.php
@@ -47,15 +47,26 @@ interface ProcessInterface {
 	public function get_media();
 
 	/**
-	 * Get the File instance.
+	 * Get the File instance of the original file.
 	 *
-	 * @since  1.9
+	 * @since  1.9.7
 	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return File|false
 	 */
-	public function get_file();
+	public function get_original_file();
+
+	/**
+	 * Get the File instance of the full size file.
+	 *
+	 * @since  1.9.7
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @return File|false
+	 */
+	public function get_fullsize_file();
 
 	/**
 	 * Tell if the current media is valid.

--- a/classes/Optimization/Process/WP.php
+++ b/classes/Optimization/Process/WP.php
@@ -214,8 +214,8 @@ class WP extends AbstractProcess {
 		$metadata          = wp_get_attachment_metadata( $media_id );
 		$metadata['sizes'] = ! empty( $metadata['sizes'] ) && is_array( $metadata['sizes'] ) ? $metadata['sizes'] : [];
 
-		$destination_dir = $this->filesystem->dir_path( $media->get_raw_original_path() );
-		$file            = new File( $media->get_backup_path() );
+		$destination_dir = $this->filesystem->dir_path( $media->get_raw_fullsize_path() );
+		$backup_file     = new File( $media->get_backup_path() );
 		$without_errors  = [];
 		$has_new_data    = false;
 
@@ -225,7 +225,7 @@ class WP extends AbstractProcess {
 			$thumbnail_data['path'] = $destination_dir . $thumbnail_data['file'];
 
 			if ( ! $this->filesystem->exists( $thumbnail_data['path'] ) ) {
-				$result = $file->create_thumbnail( $thumbnail_data );
+				$result = $backup_file->create_thumbnail( $thumbnail_data );
 
 				if ( is_array( $result ) ) {
 					// New file.

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
 	"autoload": {
 		"psr-4": {
 			"Imagify\\": "classes/",
+			"Imagify\\Deprecated\\Traits\\": "inc/deprecated/Traits/",
 			"Imagify\\ThirdParty\\AS3CF\\": "inc/3rd-party/amazon-s3-and-cloudfront/classes/",
 			"Imagify\\ThirdParty\\EnableMediaReplace\\": "inc/3rd-party/enable-media-replace/classes/",
 			"Imagify\\ThirdParty\\FormidablePro\\": "inc/3rd-party/formidable-pro/classes/",

--- a/inc/3rd-party/amazon-s3-and-cloudfront/classes/CDN/WP/AS3.php
+++ b/inc/3rd-party/amazon-s3-and-cloudfront/classes/CDN/WP/AS3.php
@@ -38,7 +38,7 @@ class AS3 implements PushCDNInterface {
 	 * Tell if we’re playing in WP 5.3’s garden.
 	 *
 	 * @var    bool
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access protected
 	 * @author Grégory Viguier
 	 */
@@ -495,7 +495,7 @@ class AS3 implements PushCDNInterface {
 	/**
 	 * Tell if we’re playing in WP 5.3’s garden.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access protected
 	 * @author Grégory Viguier
 	 *

--- a/inc/3rd-party/amazon-s3-and-cloudfront/classes/CDN/WP/AS3.php
+++ b/inc/3rd-party/amazon-s3-and-cloudfront/classes/CDN/WP/AS3.php
@@ -35,6 +35,16 @@ class AS3 implements PushCDNInterface {
 	protected $filesystem;
 
 	/**
+	 * Tell if we’re playing in WP 5.3’s garden.
+	 *
+	 * @var    bool
+	 * @since  1.9.7
+	 * @access protected
+	 * @author Grégory Viguier
+	 */
+	protected $is_wp53;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since  1.9
@@ -309,16 +319,34 @@ class AS3 implements PushCDNInterface {
 	 * @access public
 	 * @author Grégory Viguier
 	 *
-	 * @param  string $file_name Name of the file. Leave empty for the full size file.
+	 * @param  string $file_name Name of the file. Leave empty for the full size file. Use 'original' to get the path to the original file.
 	 * @return string            Path to the file.
 	 */
 	public function get_file_path( $file_name = false ) {
-		$file_path = get_attached_file( $this->id, true );
-
-		if ( $file_name ) {
-			// It's not the full size.
-			$file_path = $this->filesystem->dir_path( $file_path ) . $file_name;
+		if ( ! $file_name ) {
+			// Full size.
+			return get_attached_file( $this->id, true );
 		}
+
+		if ( 'original' === $file_name ) {
+			// Original file.
+			if ( $this->is_wp_53() ) {
+				// `wp_get_original_image_path()` may return false.
+				$file_path = wp_get_original_image_path( $this->id );
+			} else {
+				$file_path = false;
+			}
+
+			if ( ! $file_path ) {
+				$file_path = get_attached_file( $this->id, true );
+			}
+
+			return $file_path;
+		}
+
+		// Thumbnail.
+		$file_path = get_attached_file( $this->id, true );
+		$file_path = $this->filesystem->dir_path( $file_path ) . $file_name;
 
 		return $file_path;
 	}
@@ -462,5 +490,24 @@ class AS3 implements PushCDNInterface {
 
 		// If the attachment has a 'filesize' metadata, that means the local files are meant to be deleted.
 		return (bool) get_post_meta( $this->id, 'wpos3_filesize_total', true );
+	}
+
+	/**
+	 * Tell if we’re playing in WP 5.3’s garden.
+	 *
+	 * @since  1.9.7
+	 * @access protected
+	 * @author Grégory Viguier
+	 *
+	 * @return bool
+	 */
+	protected function is_wp_53() {
+		if ( isset( $this->is_wp53 ) ) {
+			return $this->is_wp53;
+		}
+
+		$this->is_wp53 = function_exists( 'wp_get_original_image_path' );
+
+		return $this->is_wp53;
 	}
 }

--- a/inc/3rd-party/nextgen-gallery/classes/Context/NGG.php
+++ b/inc/3rd-party/nextgen-gallery/classes/Context/NGG.php
@@ -55,16 +55,6 @@ class NGG extends \Imagify\Context\AbstractContext {
 	protected $thumbnail_sizes = [];
 
 	/**
-	 * Tell if the optimization process is allowed resize in this context.
-	 *
-	 * @var    bool
-	 * @since  1.9
-	 * @access protected
-	 * @author Grégory Viguier
-	 */
-	protected $can_resize = false;
-
-	/**
 	 * Tell if the optimization process is allowed to backup in this context.
 	 *
 	 * @var    bool
@@ -83,6 +73,20 @@ class NGG extends \Imagify\Context\AbstractContext {
 	 * @author Grégory Viguier
 	 */
 	protected $can_keep_exif = true;
+
+	/**
+	 * Get images max width for this context. This is used when resizing.
+	 * 0 means to not resize.
+	 *
+	 * @since  1.9.8
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @return int
+	 */
+	public function get_resizing_threshold() {
+		return 0;
+	}
 
 	/**
 	 * Get user capacity to operate Imagify in this context.

--- a/inc/3rd-party/nextgen-gallery/classes/Media/NGG.php
+++ b/inc/3rd-party/nextgen-gallery/classes/Media/NGG.php
@@ -10,6 +10,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
  * @author Grégory Viguier
  */
 class NGG extends \Imagify\Media\AbstractMedia {
+	use \Imagify\Deprecated\Traits\Media\NGGDeprecatedTrait;
 
 	/**
 	 * Context (where the media "comes from").
@@ -151,15 +152,41 @@ class NGG extends \Imagify\Media\AbstractMedia {
 	/** ----------------------------------------------------------------------------------------- */
 
 	/**
-	 * Get the original media's URL.
+	 * Get the original file path, even if the file doesn't exist.
 	 *
 	 * @since  1.9
 	 * @access public
 	 * @author Grégory Viguier
 	 *
+	 * @return string|bool The file path. False on failure.
+	 */
+	public function get_raw_original_path() {
+		if ( ! $this->is_valid() ) {
+			return false;
+		}
+
+		if ( $this->get_cdn() ) {
+			return $this->get_cdn()->get_file_path( 'original' );
+		}
+
+		return ! empty( $this->image->imagePath ) ? $this->image->imagePath : false;
+	}
+
+
+	/** ----------------------------------------------------------------------------------------- */
+	/** FULL SIZE FILE ========================================================================== */
+	/** ----------------------------------------------------------------------------------------- */
+
+	/**
+	 * Get the URL of the media’s full size file.
+	 *
+	 * @since  1.9.7
+	 * @access public
+	 * @author Grégory Viguier
+	 *
 	 * @return string|bool The file URL. False on failure.
 	 */
-	public function get_original_url() {
+	public function get_fullsize_url() {
 		if ( ! $this->is_valid() ) {
 			return false;
 		}
@@ -172,15 +199,15 @@ class NGG extends \Imagify\Media\AbstractMedia {
 	}
 
 	/**
-	 * Get the original media's path.
+	 * Get the path to the media’s full size file, even if the file doesn't exist.
 	 *
-	 * @since  1.9
+	 * @since  1.9.7
 	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return string|bool The file path. False on failure.
 	 */
-	public function get_raw_original_path() {
+	public function get_raw_fullsize_path() {
 		if ( ! $this->is_valid() ) {
 			return false;
 		}
@@ -357,18 +384,18 @@ class NGG extends \Imagify\Media\AbstractMedia {
 			$sizes = $this->get_media_files();
 		}
 
-		return $sizes && $this->get_raw_original_path();
+		return $sizes && ! empty( $this->image->imagePath );
 	}
 
 	/**
-	 * Get the list of the files of this media, including the original file.
+	 * Get the list of the files of this media, including the full size file.
 	 *
 	 * @since  1.9
 	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return array {
-	 *     An array with the size names as keys ('full' is used for the original file), and arrays of data as values:
+	 *     An array with the size names as keys ('full' is used for the full size file), and arrays of data as values:
 	 *
 	 *     @type string $size      The size name.
 	 *     @type string $path      Absolute path to the file.
@@ -383,9 +410,9 @@ class NGG extends \Imagify\Media\AbstractMedia {
 			return [];
 		}
 
-		$original_path = $this->get_raw_original_path();
+		$fullsize_path = $this->get_raw_fullsize_path();
 
-		if ( ! $original_path ) {
+		if ( ! $fullsize_path ) {
 			return [];
 		}
 
@@ -393,7 +420,7 @@ class NGG extends \Imagify\Media\AbstractMedia {
 		$all_sizes  = [
 			'full' => [
 				'size'      => 'full',
-				'path'      => $original_path,
+				'path'      => $fullsize_path,
 				'width'     => $dimensions['width'],
 				'height'    => $dimensions['height'],
 				'mime-type' => $this->get_mime_type(),
@@ -499,7 +526,7 @@ class NGG extends \Imagify\Media\AbstractMedia {
 		$data    = [
 			'width'  => $dimensions['width'],
 			'height' => $dimensions['height'],
-			'md5'    => md5_file( $this->get_raw_original_path() ),
+			'md5'    => md5_file( $this->get_raw_fullsize_path() ),
 		];
 
 		foreach ( $data as $k => $v ) {

--- a/inc/3rd-party/nextgen-gallery/classes/Media/NGG.php
+++ b/inc/3rd-party/nextgen-gallery/classes/Media/NGG.php
@@ -180,7 +180,7 @@ class NGG extends \Imagify\Media\AbstractMedia {
 	/**
 	 * Get the URL of the media’s full size file.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *
@@ -201,7 +201,7 @@ class NGG extends \Imagify\Media\AbstractMedia {
 	/**
 	 * Get the path to the media’s full size file, even if the file doesn't exist.
 	 *
-	 * @since  1.9.7
+	 * @since  1.9.8
 	 * @access public
 	 * @author Grégory Viguier
 	 *

--- a/inc/3rd-party/nextgen-gallery/inc/common/attachments.php
+++ b/inc/3rd-party/nextgen-gallery/inc/common/attachments.php
@@ -164,7 +164,7 @@ function _imagify_ngg_media_library_imported_image_data( $image, $attachment ) {
 		$wp_webp_data      = $wp_data->get_size_data( $webp_size_name );
 
 		// Get the path to the webp image if it exists.
-		$wp_full_path_webp = $wp_process->get_file()->get_path_to_webp();
+		$wp_full_path_webp = $wp_process->get_fullsize_file()->get_path_to_webp();
 
 		if ( $wp_full_path_webp && ! $filesystem->exists( $wp_full_path_webp ) ) {
 			$wp_full_path_webp = false;
@@ -202,7 +202,7 @@ function _imagify_ngg_media_library_imported_image_data( $image, $attachment ) {
 		if ( $wp_full_path_webp && $wp_webp_data ) {
 			// We have the file and the data.
 			// Copy the file.
-			$ngg_full_file      = new File( $ngg_media->get_raw_original_path() );
+			$ngg_full_file      = new File( $ngg_media->get_raw_fullsize_path() );
 			$ngg_full_path_webp = $ngg_full_file->get_path_to_webp(); // Destination.
 
 			if ( $ngg_full_path_webp ) {

--- a/inc/3rd-party/regenerate-thumbnails/classes/Main.php
+++ b/inc/3rd-party/regenerate-thumbnails/classes/Main.php
@@ -237,7 +237,7 @@ class Main extends \Imagify_Regenerate_Thumbnails_Deprecated {
 		 * The optimized full-sized file is kept and renamed, and will be put back in place at the end of the optimization process.
 		 */
 		$filesystem    = \Imagify_Filesystem::get_instance();
-		$file_path     = $media->get_raw_original_path();
+		$file_path     = $media->get_raw_fullsize_path();
 		$tmp_file_path = static::get_temporary_file_path( $file_path );
 
 		if ( $filesystem->exists( $file_path ) ) {
@@ -258,7 +258,7 @@ class Main extends \Imagify_Regenerate_Thumbnails_Deprecated {
 	 * @param int $media_id Media ID.
 	 */
 	protected function put_optimized_file_back( $media_id ) {
-		$file_path     = $this->get_process( $media_id )->get_media()->get_raw_original_path();
+		$file_path     = $this->get_process( $media_id )->get_media()->get_raw_fullsize_path();
 		$tmp_file_path = static::get_temporary_file_path( $file_path );
 		$filesystem    = \Imagify_Filesystem::get_instance();
 

--- a/inc/admin/media.php
+++ b/inc/admin/media.php
@@ -88,7 +88,7 @@ function _imagify_add_actions_to_media_list_row( $actions, $post ) {
 	$actions['imagify-compare'] = Imagify_Views::get_instance()->get_template( 'button/compare-images', [
 		'url'          => get_edit_post_link( $media->get_id() ) . '#imagify-compare',
 		'backup_url'   => $media->get_backup_url(),
-		'original_url' => $media->get_original_url(),
+		'original_url' => $media->get_fullsize_url(),
 		'media_id'     => $media->get_id(),
 		'width'        => $dimensions['width'],
 		'height'       => $dimensions['height'],

--- a/inc/classes/class-imagify-custom-folders.php
+++ b/inc/classes/class-imagify-custom-folders.php
@@ -194,7 +194,7 @@ class Imagify_Custom_Folders {
 		}
 
 		if ( ! $args['file_path'] && $args['file_id'] ) {
-			$args['file_path'] = $process->get_media()->get_original_path();
+			$args['file_path'] = $process->get_media()->get_fullsize_path();
 		}
 
 		if ( ! $args['backup_path'] && $args['file_path'] ) {
@@ -254,7 +254,7 @@ class Imagify_Custom_Folders {
 
 		$filesystem = imagify_get_filesystem();
 		$media      = $process->get_media();
-		$file_path  = $media->get_original_path();
+		$file_path  = $media->get_fullsize_path();
 		$mime_type  = $filesystem->get_mime_type( $file_path );
 		$is_image   = $mime_type && strpos( $mime_type, 'image/' ) === 0;
 		$webp_path  = $is_image ? imagify_path_to_webp( $file_path ) : false;

--- a/inc/classes/class-imagify-files-list-table.php
+++ b/inc/classes/class-imagify-files-list-table.php
@@ -526,9 +526,9 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	public function column_title( $item ) {
 		$item  = $this->maybe_set_item_folder( $item );
 		$media = $item->process->get_media();
-		$url   = $media->get_original_url();
+		$url   = $media->get_fullsize_url();
 		$base  = ! empty( $item->folder_path ) ? Imagify_Files_Scan::remove_placeholder( $item->folder_path ) : '';
-		$title = $this->filesystem->make_path_relative( $media->get_original_path(), $base );
+		$title = $this->filesystem->make_path_relative( $media->get_fullsize_path(), $base );
 
 		list( $mime ) = explode( '/', $media->get_mime_type() );
 
@@ -946,7 +946,7 @@ class Imagify_Files_List_Table extends WP_List_Table {
 			return;
 		}
 
-		$file_path = $media->get_original_path();
+		$file_path = $media->get_fullsize_path();
 
 		if ( ! $file_path ) {
 			return;
@@ -963,7 +963,7 @@ class Imagify_Files_List_Table extends WP_List_Table {
 		echo $this->views->get_template( 'button/compare-images', [
 			'url'          => $backup_url,
 			'backup_url'   => $backup_url,
-			'original_url' => $media->get_original_url(),
+			'original_url' => $media->get_fullsize_url(),
 			'media_id'     => $media->get_id(),
 			'width'        => $dimensions['width'],
 			'height'       => $dimensions['height'],

--- a/inc/common/attachments.php
+++ b/inc/common/attachments.php
@@ -58,3 +58,12 @@ function imagify_add_webp_type( $ext2type ) {
 	}
 	return $ext2type;
 }
+
+/**
+ * Set WP’s "big images threshold" to Imagify’s resizing value.
+ *
+ * @since  1.9.8
+ * @since  WP 5.3
+ * @author Grégory Viguier
+ */
+add_filter( 'big_image_size_threshold', [ imagify_get_context( 'wp' ), 'get_resizing_threshold' ], IMAGIFY_INT_MAX );

--- a/inc/deprecated/Traits/Media/CustomFoldersDeprecatedTrait.php
+++ b/inc/deprecated/Traits/Media/CustomFoldersDeprecatedTrait.php
@@ -1,0 +1,44 @@
+<?php
+namespace Imagify\Deprecated\Traits\Media;
+
+defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
+
+/**
+ * Trait containing deprecated methods of the class \Imagify\Media\CustomFolders.
+ *
+ * @since  1.9.7
+ * @author Grégory Viguier
+ */
+trait CustomFoldersDeprecatedTrait {
+
+	/**
+	 * Get the original media's URL.
+	 *
+	 * @since  1.9
+	 * @since  1.9.7 Deprecated
+	 * @access public
+	 * @author Grégory Viguier
+	 * @deprecated
+	 *
+	 * @return string|bool The file URL. False on failure.
+	 */
+	public function get_original_url() {
+		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '1.9.7', '( new \Imagify\Media\CustomFolders( $id ) )->get_fullsize_url()' );
+
+		if ( ! $this->is_valid() ) {
+			return false;
+		}
+
+		if ( $this->get_cdn() ) {
+			return $this->get_cdn()->get_file_url();
+		}
+
+		$row = $this->get_row();
+
+		if ( ! $row || empty( $row['path'] ) ) {
+			return false;
+		}
+
+		return \Imagify_Files_Scan::remove_placeholder( $row['path'], 'url' );
+	}
+}

--- a/inc/deprecated/Traits/Media/CustomFoldersDeprecatedTrait.php
+++ b/inc/deprecated/Traits/Media/CustomFoldersDeprecatedTrait.php
@@ -6,7 +6,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 /**
  * Trait containing deprecated methods of the class \Imagify\Media\CustomFolders.
  *
- * @since  1.9.7
+ * @since  1.9.8
  * @author Grégory Viguier
  */
 trait CustomFoldersDeprecatedTrait {
@@ -15,7 +15,7 @@ trait CustomFoldersDeprecatedTrait {
 	 * Get the original media's URL.
 	 *
 	 * @since  1.9
-	 * @since  1.9.7 Deprecated
+	 * @since  1.9.8 Deprecated
 	 * @access public
 	 * @author Grégory Viguier
 	 * @deprecated
@@ -23,7 +23,7 @@ trait CustomFoldersDeprecatedTrait {
 	 * @return string|bool The file URL. False on failure.
 	 */
 	public function get_original_url() {
-		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '1.9.7', '( new \Imagify\Media\CustomFolders( $id ) )->get_fullsize_url()' );
+		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '1.9.8', '( new \Imagify\Media\CustomFolders( $id ) )->get_fullsize_url()' );
 
 		if ( ! $this->is_valid() ) {
 			return false;

--- a/inc/deprecated/Traits/Media/NGGDeprecatedTrait.php
+++ b/inc/deprecated/Traits/Media/NGGDeprecatedTrait.php
@@ -6,7 +6,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 /**
  * Trait containing deprecated methods of the class \Imagify\Media\NGG.
  *
- * @since  1.9.7
+ * @since
  * @author Grégory Viguier
  */
 trait NGGDeprecatedTrait {
@@ -15,7 +15,7 @@ trait NGGDeprecatedTrait {
 	 * Get the original media's URL.
 	 *
 	 * @since  1.9
-	 * @since  1.9.7 Deprecated
+	 * @since   Deprecated
 	 * @access public
 	 * @author Grégory Viguier
 	 * @deprecated
@@ -23,7 +23,7 @@ trait NGGDeprecatedTrait {
 	 * @return string|bool The file URL. False on failure.
 	 */
 	public function get_original_url() {
-		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '1.9.7', '( new \Imagify\Media\NGG( $id ) )->get_fullsize_url()' );
+		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '', '( new \Imagify\Media\NGG( $id ) )->get_fullsize_url()' );
 
 		if ( ! $this->is_valid() ) {
 			return false;

--- a/inc/deprecated/Traits/Media/NGGDeprecatedTrait.php
+++ b/inc/deprecated/Traits/Media/NGGDeprecatedTrait.php
@@ -1,0 +1,38 @@
+<?php
+namespace Imagify\Deprecated\Traits\Media;
+
+defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
+
+/**
+ * Trait containing deprecated methods of the class \Imagify\Media\NGG.
+ *
+ * @since  1.9.7
+ * @author Grégory Viguier
+ */
+trait NGGDeprecatedTrait {
+
+	/**
+	 * Get the original media's URL.
+	 *
+	 * @since  1.9
+	 * @since  1.9.7 Deprecated
+	 * @access public
+	 * @author Grégory Viguier
+	 * @deprecated
+	 *
+	 * @return string|bool The file URL. False on failure.
+	 */
+	public function get_original_url() {
+		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '1.9.7', '( new \Imagify\Media\NGG( $id ) )->get_fullsize_url()' );
+
+		if ( ! $this->is_valid() ) {
+			return false;
+		}
+
+		if ( $this->get_cdn() ) {
+			return $this->get_cdn()->get_file_url();
+		}
+
+		return ! empty( $this->image->imageURL ) ? $this->image->imageURL : false;
+	}
+}

--- a/inc/deprecated/Traits/Media/NoopDeprecatedTrait.php
+++ b/inc/deprecated/Traits/Media/NoopDeprecatedTrait.php
@@ -1,0 +1,30 @@
+<?php
+namespace Imagify\Deprecated\Traits\Media;
+
+defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
+
+/**
+ * Trait containing deprecated methods of the class \Imagify\Media\Noop.
+ *
+ * @since  1.9.7
+ * @author Grégory Viguier
+ */
+trait NoopDeprecatedTrait {
+
+	/**
+	 * Get the original media's URL.
+	 *
+	 * @since  1.9
+	 * @since  1.9.7 Deprecated
+	 * @access public
+	 * @author Grégory Viguier
+	 * @deprecated
+	 *
+	 * @return string|bool The file URL. False on failure.
+	 */
+	public function get_original_url() {
+		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '1.9.7', '( new \Imagify\Media\Noop( $id ) )->get_fullsize_url()' );
+
+		return false;
+	}
+}

--- a/inc/deprecated/Traits/Media/NoopDeprecatedTrait.php
+++ b/inc/deprecated/Traits/Media/NoopDeprecatedTrait.php
@@ -6,7 +6,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 /**
  * Trait containing deprecated methods of the class \Imagify\Media\Noop.
  *
- * @since  1.9.7
+ * @since
  * @author Grégory Viguier
  */
 trait NoopDeprecatedTrait {
@@ -15,7 +15,7 @@ trait NoopDeprecatedTrait {
 	 * Get the original media's URL.
 	 *
 	 * @since  1.9
-	 * @since  1.9.7 Deprecated
+	 * @since   Deprecated
 	 * @access public
 	 * @author Grégory Viguier
 	 * @deprecated
@@ -23,7 +23,7 @@ trait NoopDeprecatedTrait {
 	 * @return string|bool The file URL. False on failure.
 	 */
 	public function get_original_url() {
-		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '1.9.7', '( new \Imagify\Media\Noop( $id ) )->get_fullsize_url()' );
+		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '', '( new \Imagify\Media\Noop( $id ) )->get_fullsize_url()' );
 
 		return false;
 	}

--- a/inc/deprecated/Traits/Media/WPDeprecatedTrait.php
+++ b/inc/deprecated/Traits/Media/WPDeprecatedTrait.php
@@ -6,7 +6,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 /**
  * Trait containing deprecated methods of the class \Imagify\Media\WP.
  *
- * @since  1.9.7
+ * @since
  * @author Grégory Viguier
  */
 trait WPDeprecatedTrait {
@@ -15,7 +15,7 @@ trait WPDeprecatedTrait {
 	 * Get the original media's URL.
 	 *
 	 * @since  1.9
-	 * @since  1.9.7 Deprecated
+	 * @since   Deprecated
 	 * @access public
 	 * @author Grégory Viguier
 	 * @deprecated
@@ -23,7 +23,7 @@ trait WPDeprecatedTrait {
 	 * @return string|bool The file URL. False on failure.
 	 */
 	public function get_original_url() {
-		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '1.9.7', '( new \Imagify\Media\WP( $id ) )->get_fullsize_url()' );
+		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '', '( new \Imagify\Media\WP( $id ) )->get_fullsize_url()' );
 
 		if ( ! $this->is_valid() ) {
 			return false;

--- a/inc/deprecated/Traits/Media/WPDeprecatedTrait.php
+++ b/inc/deprecated/Traits/Media/WPDeprecatedTrait.php
@@ -1,0 +1,40 @@
+<?php
+namespace Imagify\Deprecated\Traits\Media;
+
+defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
+
+/**
+ * Trait containing deprecated methods of the class \Imagify\Media\WP.
+ *
+ * @since  1.9.7
+ * @author Grégory Viguier
+ */
+trait WPDeprecatedTrait {
+
+	/**
+	 * Get the original media's URL.
+	 *
+	 * @since  1.9
+	 * @since  1.9.7 Deprecated
+	 * @access public
+	 * @author Grégory Viguier
+	 * @deprecated
+	 *
+	 * @return string|bool The file URL. False on failure.
+	 */
+	public function get_original_url() {
+		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '1.9.7', '( new \Imagify\Media\WP( $id ) )->get_fullsize_url()' );
+
+		if ( ! $this->is_valid() ) {
+			return false;
+		}
+
+		if ( $this->get_cdn() ) {
+			return $this->get_cdn()->get_file_url();
+		}
+
+		$url = wp_get_attachment_url( $this->id );
+
+		return $url ? $url : false;
+	}
+}

--- a/inc/deprecated/Traits/Optimization/Process/AbstractProcessDeprecatedTrait.php
+++ b/inc/deprecated/Traits/Optimization/Process/AbstractProcessDeprecatedTrait.php
@@ -1,0 +1,44 @@
+<?php
+namespace Imagify\Deprecated\Traits\Optimization\Process;
+
+defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
+
+/**
+ * Trait containing deprecated methods of the class \Imagify\Optimization\Process\AbstractProcess.
+ *
+ * @since  1.9.7
+ * @author Grégory Viguier
+ */
+trait AbstractProcessDeprecatedTrait {
+
+	/**
+	 * Get the File instance.
+	 *
+	 * @since  1.9
+	 * @since  1.9.7 Deprecated
+	 * @access public
+	 * @author Grégory Viguier
+	 * @deprecated
+	 *
+	 * @return File|false
+	 */
+	public function get_file() {
+		$full_class = get_class( $this );
+		$class_name = explode( '\\', trim( $full_class, '\\' ) );
+		$class_name = end( $class_name );
+
+		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '1.9.7', '( new \Imagify\Optimization\Process\\' . $class_name . '( $id ) )->get_fullsize_file()' );
+
+		if ( isset( $this->file ) ) {
+			return $this->file;
+		}
+
+		$this->file = false;
+
+		if ( $this->get_media() ) {
+			$this->file = new File( $this->get_media()->get_raw_fullsize_path() );
+		}
+
+		return $this->file;
+	}
+}

--- a/inc/deprecated/Traits/Optimization/Process/AbstractProcessDeprecatedTrait.php
+++ b/inc/deprecated/Traits/Optimization/Process/AbstractProcessDeprecatedTrait.php
@@ -6,7 +6,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 /**
  * Trait containing deprecated methods of the class \Imagify\Optimization\Process\AbstractProcess.
  *
- * @since  1.9.7
+ * @since
  * @author Grégory Viguier
  */
 trait AbstractProcessDeprecatedTrait {
@@ -15,7 +15,7 @@ trait AbstractProcessDeprecatedTrait {
 	 * Get the File instance.
 	 *
 	 * @since  1.9
-	 * @since  1.9.7 Deprecated
+	 * @since   Deprecated
 	 * @access public
 	 * @author Grégory Viguier
 	 * @deprecated
@@ -27,7 +27,7 @@ trait AbstractProcessDeprecatedTrait {
 		$class_name = explode( '\\', trim( $full_class, '\\' ) );
 		$class_name = end( $class_name );
 
-		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '1.9.7', '( new \Imagify\Optimization\Process\\' . $class_name . '( $id ) )->get_fullsize_file()' );
+		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '', '( new \Imagify\Optimization\Process\\' . $class_name . '( $id ) )->get_fullsize_file()' );
 
 		if ( isset( $this->file ) ) {
 			return $this->file;

--- a/inc/functions/admin-ui.php
+++ b/inc/functions/admin-ui.php
@@ -124,7 +124,7 @@ function get_imagify_attachment_optimization_text( $process ) {
 		if ( ! $is_library_page ) {
 			$output .= '<input id="imagify-original-src" type="hidden" value="' . esc_url( $media->get_backup_url() ) . '">';
 			$output .= '<input id="imagify-original-size" type="hidden" value="' . $data->get_original_size() . '">';
-			$output .= '<input id="imagify-full-src" type="hidden" value="' . esc_url( $media->get_original_url() ) . '">';
+			$output .= '<input id="imagify-full-src" type="hidden" value="' . esc_url( $media->get_fullsize_url() ) . '">';
 
 			if ( $media->is_image() ) {
 				$dimensions = $media->get_dimensions();

--- a/inc/functions/i18n.php
+++ b/inc/functions/i18n.php
@@ -164,7 +164,7 @@ function get_imagify_localize_script_translations( $context ) {
 					if ( $media->is_image() ) {
 						$dimensions = $media->get_dimensions();
 						$image = [
-							'src'    => $media->get_original_url(),
+							'src'    => $media->get_fullsize_url(),
 							'width'  => $dimensions['width'],
 							'height' => $dimensions['height'],
 						];

--- a/views/part-settings-library.php
+++ b/views/part-settings-library.php
@@ -6,17 +6,19 @@ $options     = Imagify_Options::get_instance();
 $option_name = $options->get_option_name();
 ?>
 <div class="<?php echo imagify_can_optimize_custom_folders() ? 'imagify-col' : ''; ?>">
-	<h3 class="imagify-options-subtitle"><?php _e( 'Media Library', 'imagify' ); ?></h3>
+	<h3 class="imagify-options-subtitle"><?php esc_html_e( 'Media Library', 'imagify' ); ?></h3>
 
 	<p class="imagify-setting-line">
 		<?php
-		$settings->field_checkbox( array(
-			'option_name' => 'resize_larger',
-			'label'       => __( 'Resize larger images', 'imagify' ),
-			'attributes'  => array(
-				'aria-describedby' => 'describe-resize_larger',
-			),
-		) );
+		$settings->field_checkbox(
+			[
+				'option_name' => 'resize_larger',
+				'label'       => __( 'Resize larger images', 'imagify' ),
+				'attributes'  => [
+					'aria-describedby' => 'describe-resize_larger',
+				],
+			]
+		);
 		?>
 
 		<span class="imagify-options-line">
@@ -26,7 +28,7 @@ $option_name = $options->get_option_name();
 			$resize_larger_w = $options->get( 'resize_larger_w' );
 			printf(
 				/* translators: 1 is a text input for a number of pixels (don't use %d). */
-				__( 'to maximum %s pixels width', 'imagify' ),
+				esc_html__( 'to maximum %s pixels width', 'imagify' ),
 				'<input type="number" id="imagify_resize_larger_w" min="' . $max_sizes['width'] . '" name="' . $option_name . '[resize_larger_w]" value="' . ( $resize_larger_w ? $resize_larger_w : '' ) . '" size="5">'
 			);
 			?>
@@ -38,9 +40,17 @@ $option_name = $options->get_option_name();
 			<?php
 			printf(
 				/* translators: 1 is a number of pixels. */
-				__( 'This option is recommended to reduce larger images. You can save up to 80%% after resizing. The new width should not be less than your largest thumbnail width, which is actually %dpx.', 'imagify' ),
+				esc_html__( 'This option is recommended to reduce larger images. You can save up to 80%% after resizing. The new width should not be less than your largest thumbnail width, which is actually %dpx.', 'imagify' ),
 				$max_sizes['width']
 			);
+			echo ' ';
+
+			if ( function_exists( 'wp_get_original_image_path' ) ) {
+				// WP 5.3+.
+				echo '<strong>' . esc_html__( 'Resizing is done on upload or during optimization.', 'imagify' ) . '</strong>';
+			} else {
+				esc_html_e( 'Resizing is done only during optimization.', 'imagify' );
+			}
 			?>
 		</span>
 	</p>
@@ -49,23 +59,23 @@ $option_name = $options->get_option_name();
 
 		<div class="imagify-divider"></div>
 
-		<h4 class="imagify-h4-like"><?php _e( 'Files optimization', 'imagify' ); ?></h4>
+		<h4 class="imagify-h4-like"><?php esc_html_e( 'Files optimization', 'imagify' ); ?></h4>
 
 		<p>
-			<?php _e( 'You can choose to optimize different image sizes created by WordPress here.', 'imagify' ); ?>
+			<?php esc_html_e( 'You can choose to optimize different image sizes created by WordPress here.', 'imagify' ); ?>
 		</p>
 
 		<p>
 			<?php
 			printf(
 				/* translators: 1 is a "bold" tag start, 2 is the "bold" tag end. */
-				__( 'The %1$soriginal size%2$s is %1$sautomatically optimized%2$s by Imagify.', 'imagify' ),
+				esc_html__( 'The %1$soriginal size%2$s is %1$sautomatically optimized%2$s by Imagify.', 'imagify' ),
 				'<strong>', '</strong>'
 			);
 			?>
 			<br>
 			<span class="imagify-success">
-				<?php _e( 'Remember each additional image size will affect your Imagify monthly usage!', 'imagify' ); ?>
+				<?php esc_html_e( 'Remember each additional image size will affect your Imagify monthly usage!', 'imagify' ); ?>
 			</span>
 		</p>
 
@@ -73,12 +83,14 @@ $option_name = $options->get_option_name();
 		/**
 		 * Disallowed thumbnail sizes.
 		 */
-		$settings->field_checkbox_list( array(
-			'option_name'   => 'disallowed-sizes',
-			'legend'        => __( 'Choose the sizes to optimize', 'imagify' ),
-			'values'        => Imagify_Settings::get_thumbnail_sizes(),
-			'reverse_check' => true,
-		) );
+		$settings->field_checkbox_list(
+			[
+				'option_name'   => 'disallowed-sizes',
+				'legend'        => __( 'Choose the sizes to optimize', 'imagify' ),
+				'values'        => Imagify_Settings::get_thumbnail_sizes(),
+				'reverse_check' => true,
+			]
+		);
 		?>
 
 	<?php endif; ?>


### PR DESCRIPTION
WP 5.3 will resize images on upload. This PR adds compatibility with this new process.
Basically, a new concept is introduced: the full size file is not the original file anymore. So, we need to provide methods handling both files, without breaking other contexts (custom files, NGG) where they are the same file.
This also deals with change in the name of the full size file: `my-image.jpg` will become `my-image-resized-2560.jpg` after WP's resizing (it may also become `my-image-rotated.jpg` if rotated without resizing).
Compatibility with AS3 and NGG have been updated.