### PR TITLE
Add filter to unset acceptable mime types

### DIFF
--- a/inc/functions/attachments.php
+++ b/inc/functions/attachments.php
@@ -11,14 +11,14 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
  * @return array        The mime types.
  */
 function imagify_get_mime_types( $type = null ) {
-	$mimes = array();
-
 	$accepted_mime_types = array(
 		'jpg|jpeg|jpe',
 		'png',
 		'gif',
 		'pdf'
 	);
+
+	$mimes = array();
 
 	if ( 'not-image' !== $type ) {
 		$mimes = array(
@@ -32,7 +32,14 @@ function imagify_get_mime_types( $type = null ) {
 		$mimes['pdf'] = 'application/pdf';
 	}
 
-	$mimes = apply_filters( 'imagify_mime_types', $mimes );
+	$mimes     = apply_filters( 'imagify_mime_types', $mimes );
+	$mime_keys = array_keys( $mimes );
+
+	foreach ( $mime_keys as $mime_key ) {
+		if ( ! in_array( $mime_key, $accepted_mime_types ) ) {
+			unset( $mimes[ $mime_key ] );
+		}
+	}
 
 	return $mimes;
 }

--- a/inc/functions/attachments.php
+++ b/inc/functions/attachments.php
@@ -13,6 +13,13 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 function imagify_get_mime_types( $type = null ) {
 	$mimes = array();
 
+	$accepted_mime_types = array(
+		'jpg|jpeg|jpe',
+		'png',
+		'gif',
+		'pdf'
+	);
+
 	if ( 'not-image' !== $type ) {
 		$mimes = array(
 			'jpg|jpeg|jpe' => 'image/jpeg',

--- a/inc/functions/attachments.php
+++ b/inc/functions/attachments.php
@@ -25,6 +25,8 @@ function imagify_get_mime_types( $type = null ) {
 		$mimes['pdf'] = 'application/pdf';
 	}
 
+	$mimes = apply_filters( 'imagify_mime_types', $mimes );
+
 	return $mimes;
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -153,6 +153,9 @@ When the plugin is disabled, your existing images remain optimized. Backups of t
 4. Other Media Page
 
 == Changelog ==
+= 1.9.8 - 2019/10/24 =
+* Improvement: add filter, imagify_mime_types, to set/unset accepted mime types
+
 = 1.9.7 - 2019/10/08 =
 * Improvement: prevent greedy antiviruses from crashing the website by renaming our highly dangerous php file with a ".suspected" suffix.
 * Improvement: on the settings page, display the "Save & Go to Bulk Optimizer" button only if the user has the ability to bulk optimize.

--- a/readme.txt
+++ b/readme.txt
@@ -154,7 +154,7 @@ When the plugin is disabled, your existing images remain optimized. Backups of t
 
 == Changelog ==
 = 1.9.8 - 2019/10/24 =
-* Improvement: add filter, imagify_mime_types, to set/unset accepted mime types
+* Improvement: add filter, imagify_mime_types, to unset accepted mime types
 
 = 1.9.7 - 2019/10/08 =
 * Improvement: prevent greedy antiviruses from crashing the website by renaming our highly dangerous php file with a ".suspected" suffix.


### PR DESCRIPTION
Add filter to unset acceptable mime types and validate passed mime types to be within a fix set.

**Usage**

```
add_filter( 'imagify_mime_types', 'customize_imagify_mime_types' );

function customize_imagify_mime_types( $mimes ) {
    unset( $mimes['gif'] );

    return $mimes;
}
```

**Linked issue -- #438**