### PR TITLE
Closes #421: No width/height attributes on <picture> tags

### DIFF
--- a/classes/Webp/Picture/Display.php
+++ b/classes/Webp/Picture/Display.php
@@ -168,6 +168,8 @@ class Display {
 	protected function build_picture_tag( $image ) {
 		$to_remove = [
 			'alt'              => '',
+			'height'           => '',
+			'width'            => '',
 			'data-lazy-src'    => '',
 			'data-src'         => '',
 			'src'              => '',
@@ -290,11 +292,9 @@ class Display {
 	protected function build_img_tag( $image ) {
 		$to_remove = [
 			'class'  => '',
-			'height' => '',
 			'id'     => '',
 			'style'  => '',
 			'title'  => '',
-			'width'  => '',
 		];
 
 		$attributes = array_diff_key( $image['attributes'], $to_remove );


### PR DESCRIPTION
Moved the width and height attributes from the `<picture>` tags to the `<img>` tags, so the markup is valid.