### PR TITLE
Compatibility with WP 5.3: save upload progress after each thumbnail

### DIFF
--- a/inc/3rd-party/enable-media-replace/enable-media-replace.php
+++ b/inc/3rd-party/enable-media-replace/enable-media-replace.php
@@ -1,7 +1,7 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
-if ( function_exists( 'enable_media_replace' ) ) :
+if ( function_exists( 'enable_media_replace' ) || class_exists( '\\EnableMediaReplace\\EnableMediaReplacePlugin' ) ) :
 
 	class_alias( '\\Imagify\\ThirdParty\\EnableMediaReplace\\Main', '\\Imagify_Enable_Media_Replace' );
 

--- a/inc/3rd-party/regenerate-thumbnails/classes/Main.php
+++ b/inc/3rd-party/regenerate-thumbnails/classes/Main.php
@@ -57,6 +57,11 @@ class Main extends \Imagify_Regenerate_Thumbnails_Deprecated {
 			return;
 		}
 
+		if ( function_exists( 'wp_get_original_image_path' ) ) {
+			// Nothing to do with WP 5.3+, auto-optimization does everything by itself \o/.
+			return;
+		}
+
 		add_filter( 'rest_dispatch_request',                [ $this, 'maybe_init_attachment' ], 4, 4 );
 		add_filter( 'wp_generate_attachment_metadata',      [ $this, 'launch_async_optimization' ], IMAGIFY_INT_MAX - 30, 2 );
 		add_action( 'imagify_after_' . static::HOOK_SUFFIX, [ $this, 'after_regenerate_thumbnails' ], 8, 2 );


### PR DESCRIPTION
WP now uses `wp_update_attachment_metadata()` after each thumbnail creation instead of one call after all thumbnails are created.
Since Imagify uses a hook in this function to launch the auto-optimization, this change would break the process.
This PR prevents the multiple optimisations and keeps the previous behaviour in Imagify.
This also updates the compatibility with the "Regenerate Thumbnails" and "Enable Media Replace" plugins.
This also adds compatibility with "Enable Media Replace" plugin 3.3.