### PR TITLE
Compatibility with WP 5.3: improved auto-rotate process by handling more cases

### DIFF
--- a/classes/Optimization/File.php
+++ b/classes/Optimization/File.php
@@ -173,7 +173,7 @@ class File {
 	/** ----------------------------------------------------------------------------------------- */
 
 	/**
-	 * Resize an image if it is bigger than the maximum width provided.
+	 * Resize (and rotate) an image if it is bigger than the maximum width provided.
 	 *
 	 * @since  1.9
 	 * @access public
@@ -226,14 +226,43 @@ class File {
 			$orientation = isset( $exif['Orientation'] ) ? (int) $exif['Orientation'] : 1;
 
 			switch ( $orientation ) {
+				case 2:
+					// Flip horizontally.
+					$editor->flip( true, false );
+					break;
 				case 3:
-					$editor->rotate( 180 );
+					// Rotate 180 degrees or flip horizontally and vertically.
+					// Flipping seems faster/uses less resources.
+					$editor->flip( true, true );
+					break;
+				case 4:
+					// Flip vertically.
+					$editor->flip( false, true );
+					break;
+				case 5:
+					// Rotate 90 degrees counter-clockwise and flip vertically.
+					$result = $editor->rotate( 90 );
+
+					if ( ! is_wp_error( $result ) ) {
+						$editor->flip( false, true );
+					}
 					break;
 				case 6:
-					$editor->rotate( -90 );
+					// Rotate 90 degrees clockwise (270 counter-clockwise).
+					$editor->rotate( 270 );
+					break;
+				case 7:
+					// Rotate 90 degrees counter-clockwise and flip horizontally.
+					$result = $editor->rotate( 90 );
+
+					if ( ! is_wp_error( $result ) ) {
+						$editor->flip( true, false );
+					}
 					break;
 				case 8:
+					// Rotate 90 degrees counter-clockwise.
 					$editor->rotate( 90 );
+					break;
 			}
 		}
 


### PR DESCRIPTION
WP 5.3 now automatically rotates the uploaded images, according their `Orientation` EXIF data. This feature already exists in Imagify.
Since WP creates new files upon rotating, the new files won't have the same EXIF, so Imagify won't try to rotate an image that already has been rotated.
This PR’s aim is to simply improve Imagify’s rotating process, basically by copying what WP is doing.
The PR also includes an improvement about the resizing threshold.