### PR TITLE
Fixes #455: Empty `srcset` attribute on `<source/>` tags

### DIFF
--- a/classes/Webp/Picture/Display.php
+++ b/classes/Webp/Picture/Display.php
@@ -240,6 +240,10 @@ class Display {
 			}
 		}
 
+		if ( empty( $attributes[ $srcset_source ] ) ) {
+			$attributes[ $srcset_source ][] = $image['src']['webp_url'];
+		}
+
 		$attributes[ $srcset_source ] = implode( ', ', $attributes[ $srcset_source ] );
 
 		foreach ( [ 'data-lazy-srcset', 'data-srcset', 'srcset' ] as $srcset_attr ) {


### PR DESCRIPTION
Make sure the `srcset` attribute on `<source>` tag is not empty.
If the original `<img/>` tag does not contain a `srcset` attribute, the original image URL is added to the `<source/>`’s `srcset` attribute.