### PR TITLE
Branch 1.9.8.1

### DIFF
--- a/classes/Webp/Picture/Display.php
+++ b/classes/Webp/Picture/Display.php
@@ -240,6 +240,10 @@ class Display {
 			}
 		}
 
+		if ( empty( $attributes[ $srcset_source ] ) ) {
+			$attributes[ $srcset_source ][] = $image['src']['webp_url'];
+		}
+
 		$attributes[ $srcset_source ] = implode( ', ', $attributes[ $srcset_source ] );
 
 		foreach ( [ 'data-lazy-srcset', 'data-srcset', 'srcset' ] as $srcset_attr ) {

--- a/imagify.php
+++ b/imagify.php
@@ -3,7 +3,7 @@
  * Plugin Name: Imagify
  * Plugin URI: https://wordpress.org/plugins/imagify/
  * Description: Dramaticaly reduce image file sizes without losing quality, make your website load faster, boost your SEO and save money on your bandwidth using Imagify, the new most advanced image optimization tool.
- * Version: 1.9.8
+ * Version: 1.9.8.1
  * Requires PHP: 5.4
  * Author: WP Media
  * Author URI: https://wp-media.me/
@@ -20,7 +20,7 @@
 defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
 // Imagify defines.
-define( 'IMAGIFY_VERSION',        '1.9.8' );
+define( 'IMAGIFY_VERSION',        '1.9.8.1' );
 define( 'IMAGIFY_SLUG',           'imagify' );
 define( 'IMAGIFY_FILE',           __FILE__ );
 define( 'IMAGIFY_PATH',           realpath( plugin_dir_path( IMAGIFY_FILE ) ) . '/' );

--- a/inc/3rd-party/amazon-s3-and-cloudfront/amazon-s3-and-cloudfront.php
+++ b/inc/3rd-party/amazon-s3-and-cloudfront/amazon-s3-and-cloudfront.php
@@ -23,6 +23,11 @@ function imagify_load_as3cf_compat() {
 			return false;
 		}
 
+		if ( version_compare( $version, '2.3' ) >= 0 ) {
+			// A new version that removes a punlic method.
+			return false;
+		}
+
 		return true;
 	}
 
@@ -36,6 +41,11 @@ function imagify_load_as3cf_compat() {
 
 		if ( ! function_exists( 'amazon_web_services_init' ) && version_compare( $version, '1.6' ) < 0 ) {
 			// Old version, plugin Amazon Web Services is required.
+			return false;
+		}
+
+		if ( version_compare( $version, '2.3' ) >= 0 ) {
+			// A new version that removes a punlic method.
 			return false;
 		}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "imagify",
 	"description": "Imagify Image Optimizer. Dramatically reduce image file sizes without losing quality, make your website load faster, boost your SEO and save money on your bandwidth.",
-	"version": "1.9.8",
+	"version": "1.9.8.1",
 	"homepage": "https://wordpress.org/plugins/imagify/",
 	"license": "GPL-2.0",
 	"private": true,

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wp_media, GregLone
 Tags: optimize images, images, optimize, performance, webp
 Requires at least: 4.0.0
 Tested up to: 5.3
-Stable tag: 1.9.8
+Stable tag: 1.9.8.1
 
 Optimize images in one click: reduce image file sizes, convert WebP, keep your images beautiful… and boost your loading time and your SEO!
 
@@ -153,6 +153,10 @@ When the plugin is disabled, your existing images remain optimized. Backups of t
 4. Other Media Page
 
 == Changelog ==
+= 1.9.8.1 - 2019/11/15 =
+* Fix: webp image not showing when using the `<picture>` method and the original `<img/>` does not have a `srcset` attribute.
+* Fix: a fatal error with WP Offload Media 2.3.
+
 = 1.9.8 - 2019/11/11 =
 * Improvement: compatibility with WordPress 5.3!
 * New: among other things, WordPress 5.3 automatically resizes large images on upload, using a predefined threshold value that can be changed only by filter (no setting fields are provided). Imagify’s "Resize larger images" setting field is now used to tweak this threshold.


### PR DESCRIPTION
* Fixes #455: webp image not showing when using the `<picture>` method and the original `<img/>` does not have a `srcset` attribute.
* Fixes #456: a fatal error with WP Offload Media 2.3.