### PR TITLE
Optimize initialization of the Admin Ajax Post hooks

### DIFF
--- a/inc/classes/class-imagify-admin-ajax-post.php
+++ b/inc/classes/class-imagify-admin-ajax-post.php
@@ -125,19 +125,24 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * @author Grégory Viguier
 	 */
 	public function init() {
-		if ( wp_doing_ajax() ) {
-			// Actions triggered only on admin ajax.
-			$actions = array_merge( $this->ajax_post_actions, $this->ajax_only_actions );
+		$doing_ajax = wp_doing_ajax();
 
-			foreach ( $actions as $action ) {
+		foreach ( $this->ajax_post_actions as $action ) {
+			if ( $doing_ajax ) {
+				add_action( 'wp_ajax_' . $action, array( $this, $action . '_callback' ) );
+			}
+			add_action( 'admin_post_' . $action, array( $this, $action . '_callback' ) );
+		}
+
+		// Actions triggered only on admin ajax.
+		if ( $doing_ajax ) {
+			foreach ( $this->ajax_only_actions as $action ) {
 				add_action( 'wp_ajax_' . $action, array( $this, $action . '_callback' ) );
 			}
 		}
 
 		// Actions triggered on both admin ajax and admin post.
-		$actions = array_merge( $this->ajax_post_actions, $this->post_only_actions );
-
-		foreach ( $actions as $action ) {
+		foreach ( $this->post_only_actions as $action ) {
 			add_action( 'admin_post_' . $action, array( $this, $action . '_callback' ) );
 		}
 	}

--- a/inc/classes/class-imagify-admin-ajax-post.php
+++ b/inc/classes/class-imagify-admin-ajax-post.php
@@ -142,7 +142,7 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 			}
 		}
 
-		// Actions triggered on both admin ajax and admin post.
+		// Actions triggered on admin post.
 		foreach ( $this->post_only_actions as $action ) {
 			add_action( 'admin_post_' . $action, array( $this, $action . '_callback' ) );
 		}

--- a/inc/classes/class-imagify-admin-ajax-post.php
+++ b/inc/classes/class-imagify-admin-ajax-post.php
@@ -128,10 +128,11 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 		$doing_ajax = wp_doing_ajax();
 
 		foreach ( $this->ajax_post_actions as $action ) {
+			$action_callback = "{$action}_callback";
 			if ( $doing_ajax ) {
-				add_action( 'wp_ajax_' . $action, array( $this, $action . '_callback' ) );
+				add_action( 'wp_ajax_' . $action, array( $this, $action_callback ) );
 			}
-			add_action( 'admin_post_' . $action, array( $this, $action . '_callback' ) );
+			add_action( 'admin_post_' . $action, array( $this, $action_callback ) );
 		}
 
 		// Actions triggered only on admin ajax.


### PR DESCRIPTION
This PR optimizes the `init` method for registering callbacks for the admin Ajax post hooks.

Micro-Optimizations:

- Eliminates the 2 instances of merging arrays
    - saves memory as `array_merge()` creates a new array
    - saves processing time as `array_merge()` iterates over each element in the second array to create a new array
- Eliminates the double iteration of the actions in the `$ajax_post_actions` property. Replaces with a single loop to register the callbacks for both use cases.

## Analysis

This PR runs faster and takes less memory.

- Runs faster by 0.000283ms
- Time Complexity O(370) as compared to the original O(532)
- Space Complexity O(1) as compared to the original O(40)

### Benchmarking

Running my microprofiler, this PR results in following processing time micro-improvements:

- In normal plugin init process (not doing Ajax): 0.000283ms improvement
- When doing Ajax: 0.007015ms improvement

#### Results when not doing Ajax, i.e. normal initialization startup state

```shell
-------------------------
MICRO PROFILER REPORT:
-------------------------

PHP version:        7.3.2
Sample Size:        100,000 (per function)
Time Increments:    milliseconds, where 1 ms equals 0.001 second.

  --------------------------------   -------------   -------------   -------------
| Name                             | Result        |  Avg Time     | Baseline
|                                  | (ms)          |  (ms)         | (ms)
| -------------------------------- | ------------- | ------------- | -------------
| Imagify_Admin_Ajax_Post::init    |    -0.000283  |      0.061542 |      0.061825
 --------------------------------   -------------   -------------   -------------
```

#### Results when doing Ajax

```shell
-------------------------
MICRO PROFILER REPORT:
-------------------------

PHP version:        7.3.2
Sample Size:        100,000 (per function)
Time Increments:    milliseconds, where 1 ms equals 0.001 second.

  --------------------------------   -------------   -------------   -------------
| Name                             | Result        |  Avg Time     | Baseline
|                                  | (ms)          |  (ms)         | (ms)
| -------------------------------- | ------------- | ------------- | -------------
| Imagify_Admin_Ajax_Post::init    |    -0.007015  |      0.189416 |      0.196431
 --------------------------------   -------------   -------------   -------------
```

### Time and Space Complexities Big-O Analysis

This PR is slightly more efficient with time and space. It runs 162 less operations and 39 less space.

|  Code Versions  | Time Complexity | Space Complexity
| -- | -- | --
| This PR |  O(370) | O(1)
| Original |  O(532) | O(40)

This ignores the O(n) of `wp_doing_ajax()`.

#### New Version (this PR)

Time Complexity O(370) and Space Complexity O(1)

Notes:

- `add_action` is O(16), but is dependent upon WordPress

```php
public function init() { // Time Complexity O(370) and Space Complexity O(1)
	$doing_ajax = wp_doing_ajax();                                                      // O(n) Time, where n is the number of callbacks hooked into the filter event within WordPress.

	foreach ( $this->ajax_post_actions as $action ) {                                   // O(370) = (1 foreach + 36 from the block) x 10 iterations.
		$action_callback = "{$action}_callback";                                            // O(1)
		if ( $doing_ajax ) {                                                                // O(1)
			add_action( 'wp_ajax_' . $action, array( $this, $action_callback ) );           // O(17) = 1 concat + 16 is dependent upon WordPress.
		}
		add_action( 'admin_post_' . $action, array( $this, $action_callback ) );            // O(17) = 1 concat + 16 is dependent upon WordPress.
	}

	// Actions triggered only on admin ajax.
	if ( $doing_ajax ) {                                                                // O(1)
		foreach ( $this->ajax_only_actions as $action ) {                               // O(342) (1 foreach + 18 block) x 18 iterations.
			add_action( 'wp_ajax_' . $action, array( $this, $action . '_callback' ) );      // O(18) = 2 concats + 16 is dependent upon WordPress.
		}
	}
	// Actions triggered on both admin ajax and admin post.
	foreach ( $this->post_only_actions as $action ) {                                   // O(38) = (1 foreach + 18 block) x 2 iterations.
		add_action( 'admin_post_' . $action, array( $this, $action . '_callback' ) );       // O(18) = 2 concats + 16 is dependent upon WordPress.
	}
}
```

#### Big-O for the Original Version

Time Complexity O(532) and Space Complexity O(40).

Notes:

- `array_merge` Big-O time is `O(∑ array_i, i != 1)`
- `add_action` has about O(16), but is dependent upon WordPress

```php
public function init() {  // Time Complexity O(532) and Space Complexity O(40)
	if ( wp_doing_ajax() ) {                                                            // O(n), where n is the number of callbacks hooked into the filter event within WordPress.
		// Actions triggered only on admin ajax.
		$actions = array_merge( $this->ajax_post_actions, $this->ajax_only_actions );   // O(28) Space + O(18) Time: number of elements = 10 + 18 = 28.

		foreach ( $actions as $action ) {                                               // O(532) = (1 foreach 18 block) x 28 iterations.
			add_action( 'wp_ajax_' . $action, array( $this, $action . '_callback' ) );      // O(18) = 2 concats + 16 is dependent upon WordPress.
		}
	}

	// Actions triggered on both admin ajax and admin post.
	$actions = array_merge( $this->ajax_post_actions, $this->post_only_actions );       // O(12) Space + O(2) Time: number of elements = 10 + 2 = 12.

	foreach ( $actions as $action ) {                                                   // O(228)= (1 foreach + 18 block) x 12 iterations.
		add_action( 'admin_post_' . $action, array( $this, $action . '_callback' ) );       // O(18) = 2 concats + 16 is dependent upon WordPress.
	}
}
```

## TODO

- [x] Do a time complexity analysis
- [x] Do a space complexity analysis