### PR TITLE
Prevent php notices

### DIFF
--- a/classes/Imagifybeat/Actions.php
+++ b/classes/Imagifybeat/Actions.php
@@ -157,7 +157,15 @@ class Actions {
 
 			if ( $optim_data->is_optimized() ) {
 				// Successfully optimized.
-				$full_size_data              = $optim_data->get_size_data();
+				$full_size_data                = $optim_data->get_size_data();
+				$full_size_data                = array_merge(
+					[
+						'original_size'  => 0,
+						'optimized_size' => 0,
+						'percent'        => 0,
+					],
+					$full_size_data
+				);
 				$response[ $imagifybeat_id ][] = [
 					'mediaID'                  => $media_atts['media_id'],
 					'context'                  => $media_atts['context'],

--- a/imagify.php
+++ b/imagify.php
@@ -12,7 +12,7 @@
  * Text Domain: imagify
  * Domain Path: languages
  *
- * Copyright 2020 WP Media
+ * Copyright 2019 WP Media
  *
  * @package WP-Media\Imagify\WordPress-Plugin
  */

--- a/imagify.php
+++ b/imagify.php
@@ -12,7 +12,7 @@
  * Text Domain: imagify
  * Domain Path: languages
  *
- * Copyright 2019 WP Media
+ * Copyright 2020 WP Media
  *
  * @package WP-Media\Imagify\WordPress-Plugin
  */


### PR DESCRIPTION
Since `get_size_data()` can return an empty array, make sure the array keys are set before using them.