### PR TITLE
Fixes #493: compatibility with plugin "Enable Media Replace" broken with WP 5.3

### DIFF
--- a/inc/3rd-party/enable-media-replace/classes/Main.php
+++ b/inc/3rd-party/enable-media-replace/classes/Main.php
@@ -106,8 +106,8 @@ class Main extends Imagify_Enable_Media_Replace_Deprecated {
 	/** ----------------------------------------------------------------------------------------- */
 
 	/**
-	 * Delete previous backup file. This is done after the images have been already replaced by Enable Media Replace.
-	 * It will prevent having a backup file not corresponding to the current images.
+	 * Delete previous backup file and webp files.
+	 * This is done after the images have been already replaced by Enable Media Replace.
 	 *
 	 * @since 1.8.4
 	 *
@@ -121,12 +121,13 @@ class Main extends Imagify_Enable_Media_Replace_Deprecated {
 		$filesystem = Imagify_Filesystem::get_instance();
 
 		if ( $filesystem->exists( $this->old_backup_path ) ) {
+			// Delete old backup file.
 			$filesystem->delete( $this->old_backup_path );
 			$this->old_backup_path = false;
 		}
 
-		if ( $this->old_webp_paths ) {
-			// If the files have been renamed, delete old webp files.
+		if ( ! empty( $this->old_webp_paths ) ) {
+			// Delete old webp files.
 			$this->old_webp_paths = array_filter( $this->old_webp_paths, [ $filesystem, 'exists' ] );
 			array_map( [ $filesystem, 'delete' ], $this->old_webp_paths );
 			$this->old_webp_paths = [];

--- a/inc/3rd-party/enable-media-replace/classes/Main.php
+++ b/inc/3rd-party/enable-media-replace/classes/Main.php
@@ -1,89 +1,69 @@
 <?php
 namespace Imagify\ThirdParty\EnableMediaReplace;
 
+use Imagify_Filesystem;
+
 defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
 /**
  * Compat class for Enable Media Replace plugin.
  *
- * @since  1.6.9
- * @author Grégory Viguier
+ * @since 1.6.9
  */
 class Main extends \Imagify_Enable_Media_Replace_Deprecated {
 	use \Imagify\Traits\InstanceGetterTrait;
 
 	/**
-	 * Class version.
-	 *
-	 * @var    string
-	 * @since  1.6.9
-	 * @author Grégory Viguier
-	 */
-	const VERSION = '2.1';
-
-	/**
 	 * The media ID.
 	 *
-	 * @var    int
-	 * @since  1.9
-	 * @access protected
-	 * @author Grégory Viguier
+	 * @var   int
+	 * @since 1.9
 	 */
 	protected $media_id;
 
 	/**
 	 * The process instance for the current attachment.
 	 *
-	 * @var    ProcessInterface
-	 * @since  1.9
-	 * @access protected
-	 * @author Grégory Viguier
+	 * @var   ProcessInterface
+	 * @since 1.9
 	 */
 	protected $process;
 
 	/**
 	 * The path to the old backup file.
 	 *
-	 * @var    string
-	 * @since  1.6.9
-	 * @access protected
-	 * @author Grégory Viguier
+	 * @var   string
+	 * @since 1.6.9
 	 */
 	protected $old_backup_path;
 
 	/**
 	 * List of paths to the old webp files.
 	 *
-	 * @var    array
-	 * @since  1.9.8
-	 * @access protected
-	 * @author Grégory Viguier
+	 * @var   array
+	 * @since 1.9.8
 	 */
 	protected $old_webp_paths = [];
 
 	/**
 	 * Launch the hooks before the files and data are replaced.
 	 *
-	 * @since  1.6.9
-	 * @author Grégory Viguier
+	 * @since 1.6.9
+	 * @since 1.9.10 The parameter changed from boolean to array. The method doesn’t return anything.
 	 *
-	 * @param  bool $unfiltered Whether to allow filters when retrieving the file path.
-	 * @return bool             The same value.
+	 * @param array $args An array containing the post ID.
 	 */
-	public function init( $unfiltered = true ) {
-		$this->media_id = (int) filter_input( INPUT_POST, 'ID' );
-		$this->media_id = max( 0, $this->media_id );
+	public function init( $args = [] ) {
+		if ( is_array( $args ) && ! empty( $args['post_id'] ) ) {
+			$this->media_id = $args['post_id'];
+		} else {
+			// Backward compatibility.
+			$this->media_id = (int) filter_input( INPUT_POST, 'ID' );
+			$this->media_id = max( 0, $this->media_id );
 
-		if ( ! $this->media_id || empty( $_FILES['userfile']['tmp_name'] ) ) {
-			$this->media_id = 0;
-			return $unfiltered;
-		}
-
-		$tmp_name = wp_unslash( $_FILES['userfile']['tmp_name'] );
-
-		if ( ! is_uploaded_file( $tmp_name ) ) {
-			$this->media_id = 0;
-			return $unfiltered;
+			if ( ! $this->media_id ) {
+				return;
+			}
 		}
 
 		// Store the old backup file path.
@@ -91,14 +71,14 @@ class Main extends \Imagify_Enable_Media_Replace_Deprecated {
 
 		if ( ! $this->process ) {
 			$this->media_id = 0;
-			return $unfiltered;
+			return;
 		}
 
 		$this->old_backup_path = $this->process->get_media()->get_backup_path();
 
 		if ( ! $this->old_backup_path ) {
 			$this->media_id = 0;
-			return $unfiltered;
+			return;
 		}
 
 		// Store the old backup file path.
@@ -106,8 +86,6 @@ class Main extends \Imagify_Enable_Media_Replace_Deprecated {
 		// Delete the old backup file.
 		add_action( 'imagify_before_auto_optimization',         [ $this, 'delete_backup' ] );
 		add_action( 'imagify_not_optimized_attachment_updated', [ $this, 'delete_backup' ] );
-
-		return $unfiltered;
 	}
 
 
@@ -118,9 +96,7 @@ class Main extends \Imagify_Enable_Media_Replace_Deprecated {
 	/**
 	 * When the user chooses to change the file name, store the old backup file path. This path will be used later to delete the file.
 	 *
-	 * @since  1.6.9
-	 * @access public
-	 * @author Grégory Viguier
+	 * @since 1.6.9
 	 *
 	 * @param  string $new_filename The new file name.
 	 * @param  string $current_path The current file path.
@@ -166,9 +142,7 @@ class Main extends \Imagify_Enable_Media_Replace_Deprecated {
 	 * Delete previous backup file. This is done after the images have been already replaced by Enable Media Replace.
 	 * It will prevent having a backup file not corresponding to the current images.
 	 *
-	 * @since  1.8.4
-	 * @access public
-	 * @author Grégory Viguier
+	 * @since 1.8.4
 	 *
 	 * @param int $media_id The attachment ID.
 	 */
@@ -177,7 +151,7 @@ class Main extends \Imagify_Enable_Media_Replace_Deprecated {
 			return;
 		}
 
-		$filesystem = \Imagify_Filesystem::get_instance();
+		$filesystem = Imagify_Filesystem::get_instance();
 
 		if ( $filesystem->exists( $this->old_backup_path ) ) {
 			$filesystem->delete( $this->old_backup_path );
@@ -200,9 +174,7 @@ class Main extends \Imagify_Enable_Media_Replace_Deprecated {
 	/**
 	 * Get the optimization process corresponding to the current media.
 	 *
-	 * @since  1.9
-	 * @author Grégory Viguier
-	 * @access protected
+	 * @since 1.9
 	 *
 	 * @return ProcessInterface|bool False if invalid.
 	 */

--- a/inc/3rd-party/enable-media-replace/classes/Main.php
+++ b/inc/3rd-party/enable-media-replace/classes/Main.php
@@ -1,6 +1,8 @@
 <?php
 namespace Imagify\ThirdParty\EnableMediaReplace;
 
+use Imagify\Traits\InstanceGetterTrait;
+use Imagify_Enable_Media_Replace_Deprecated;
 use Imagify_Filesystem;
 
 defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
@@ -10,8 +12,8 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
  *
  * @since 1.6.9
  */
-class Main extends \Imagify_Enable_Media_Replace_Deprecated {
-	use \Imagify\Traits\InstanceGetterTrait;
+class Main extends Imagify_Enable_Media_Replace_Deprecated {
+	use InstanceGetterTrait;
 
 	/**
 	 * The media ID.

--- a/inc/3rd-party/enable-media-replace/classes/Main.php
+++ b/inc/3rd-party/enable-media-replace/classes/Main.php
@@ -91,12 +91,8 @@ class Main extends Imagify_Enable_Media_Replace_Deprecated {
 		 * - Do not rename the files: the thumbnails may still get new names because of the suffix containing the image dimensions, which may differ (for example when thumbnails are scaled, not cropped).
 		 * In this last case, the thumbnails with the old dimensions are removed from the drive and from the WP’s post meta, so there is no need of keeping orphan webp files that would stay on the drive for ever, even after the attachment is deleted from WP.
 		 */
-		$media_files = $this->process->get_media()->get_media_files();
-
-		if ( $media_files ) {
-			foreach ( $media_files as $media_file ) {
-				$this->old_webp_paths[] = imagify_path_to_webp( $media_file['path'] );
-			}
+		foreach ( $this->process->get_media()->get_media_files() as $media_file ) {
+			$this->old_webp_paths[] = imagify_path_to_webp( $media_file['path'] );
 		}
 
 		// Delete the old backup file and old webp files.

--- a/inc/3rd-party/enable-media-replace/enable-media-replace.php
+++ b/inc/3rd-party/enable-media-replace/enable-media-replace.php
@@ -5,6 +5,6 @@ if ( function_exists( 'enable_media_replace' ) || class_exists( '\\EnableMediaRe
 
 	class_alias( '\\Imagify\\ThirdParty\\EnableMediaReplace\\Main', '\\Imagify_Enable_Media_Replace' );
 
-	add_filter( 'emr_unfiltered_get_attached_file', [ \Imagify\ThirdParty\EnableMediaReplace\Main::get_instance(), 'init' ] );
+	add_filter( 'wp_handle_replace', [ \Imagify\ThirdParty\EnableMediaReplace\Main::get_instance(), 'init' ] );
 
 endif;

--- a/inc/classes/class-imagify-auto-optimization.php
+++ b/inc/classes/class-imagify-auto-optimization.php
@@ -1,4 +1,7 @@
 <?php
+
+use Imagify\Traits\InstanceGetterTrait;
+
 defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
 /**
@@ -6,19 +9,16 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
  * This occurs when a new image is uploaded, and when an optimized image is worked with (resized, etc).
  * The process will work only if wp_update_attachment_metadata() is used.
  *
- * @since  1.8.4
- * @author Grégory Viguier
+ * @since 1.8.4
  */
 class Imagify_Auto_Optimization {
-	use \Imagify\Traits\InstanceGetterTrait;
+	use InstanceGetterTrait;
 
 	/**
 	 * An array containing the IDs (as keys) of attachments just being uploaded.
 	 *
-	 * @var    array
-	 * @since  1.8.4
-	 * @access protected
-	 * @author Grégory Viguier
+	 * @var   array
+	 * @since 1.8.4
 	 */
 	protected $uploads = [];
 
@@ -26,49 +26,39 @@ class Imagify_Auto_Optimization {
 	 * An array containing the IDs (as keys) of attachments that must be optimized automatically.
 	 * The values tell if the attachment is a new upload.
 	 *
-	 * @var    array
-	 * @since  1.8.4
-	 * @access protected
-	 * @author Grégory Viguier
+	 * @var   array
+	 * @since 1.8.4
 	 */
 	protected $attachments = [];
 
 	/**
 	 * The ID of the attachment that failed to be uploaded.
 	 *
-	 * @var    int
-	 * @since  1.9.8
-	 * @access protected
-	 * @author Grégory Viguier
+	 * @var   int
+	 * @since 1.9.8
 	 */
 	protected $upload_failure_id = 0;
 
 	/**
 	 * Used to prevent an auto-optimization locally.
 	 *
-	 * @var    array
-	 * @since  1.8.4
-	 * @access private
-	 * @author Grégory Viguier
+	 * @var   array
+	 * @since 1.8.4
 	 */
 	private static $prevented = [];
 
 	/**
 	 * Used to prevent an auto-optimization internally.
 	 *
-	 * @var    array
-	 * @since  1.9.8
-	 * @access private
-	 * @author Grégory Viguier
+	 * @var   array
+	 * @since 1.9.8
 	 */
 	private static $prevented_internally = [];
 
 	/**
 	 * Init.
 	 *
-	 * @since  1.8.4
-	 * @access public
-	 * @author Grégory Viguier
+	 * @since 1.8.4
 	 */
 	public function init() {
 		global $wp_version;
@@ -98,19 +88,17 @@ class Imagify_Auto_Optimization {
 	/**
 	 * Remove the hooks.
 	 *
-	 * @since  1.8.4
-	 * @access public
-	 * @author Grégory Viguier
+	 * @since 1.8.4
 	 */
 	public function remove_hooks() {
 		$prio = IMAGIFY_INT_MAX - 30;
 
 		// Automatic optimization tunel.
-		remove_action( 'add_attachment',                                 [ $this, 'store_upload_ids' ], $prio );
-		remove_filter( 'wp_update_attachment_metadata',                  [ $this, 'store_ids_to_optimize' ], $prio );
-		remove_action( 'updated_post_meta',                              [ $this, 'do_auto_optimization_after_meta_update' ], $prio );
-		remove_action( 'added_post_meta',                                [ $this, 'do_auto_optimization_after_meta_update' ], $prio );
-		remove_action( 'deleted_post_meta',                              [ $this, 'unset_optimization' ], $prio );
+		remove_action( 'add_attachment',                [ $this, 'store_upload_ids' ], $prio );
+		remove_filter( 'wp_update_attachment_metadata', [ $this, 'store_ids_to_optimize' ], $prio );
+		remove_action( 'updated_post_meta',             [ $this, 'do_auto_optimization_after_meta_update' ], $prio );
+		remove_action( 'added_post_meta',               [ $this, 'do_auto_optimization_after_meta_update' ], $prio );
+		remove_action( 'deleted_post_meta',             [ $this, 'unset_optimization' ], $prio );
 
 		if ( version_compare( $wp_version, '5.3-alpha1' ) >= 0 ) {
 			// WP 5.3+.
@@ -135,10 +123,8 @@ class Imagify_Auto_Optimization {
 	 * Store the ID of attachments that just have been uploaded.
 	 * We use those IDs to tell the difference later in `wp_update_attachment_metadata()`.
 	 *
-	 * @since  1.8.4
-	 * @access public
-	 * @see    $this->store_ids_to_optimize()
-	 * @author Grégory Viguier
+	 * @since 1.8.4
+	 * @see   $this->store_ids_to_optimize()
 	 *
 	 * @param int $attachment_id Current attachment ID.
 	 */
@@ -154,10 +140,8 @@ class Imagify_Auto_Optimization {
 	 * - It's a new upload and auto-optimization is enabled.
 	 * - It's not a new upload (it is regenerated) and the attachment is already optimized.
 	 *
-	 * @since  1.8.4
-	 * @access public
-	 * @see    $this->store_upload_ids()
-	 * @author Grégory Viguier
+	 * @since 1.8.4
+	 * @see   $this->store_upload_ids()
 	 *
 	 * @param  array $metadata      An array of attachment meta data.
 	 * @param  int   $attachment_id Current attachment ID.
@@ -187,8 +171,7 @@ class Imagify_Auto_Optimization {
 				/**
 				 * Fires when a new attachment is uploaded but auto-optimization is disabled.
 				 *
-				 * @since  1.8.4
-				 * @author Grégory Viguier
+				 * @since 1.8.4
 				 *
 				 * @param int   $attachment_id Attachment ID.
 				 * @param array $metadata      An array of attachment meta data.
@@ -201,8 +184,7 @@ class Imagify_Auto_Optimization {
 			/**
 			 * Allow to prevent automatic optimization for a specific attachment.
 			 *
-			 * @since  1.6.12
-			 * @author Grégory Viguier
+			 * @since 1.6.12
 			 *
 			 * @param bool  $optimize      True to optimize, false otherwise.
 			 * @param int   $attachment_id Attachment ID.
@@ -232,8 +214,7 @@ class Imagify_Auto_Optimization {
 				/**
 				 * Fires when an attachment is updated but not optimized yet.
 				 *
-				 * @since  1.8.4
-				 * @author Grégory Viguier
+				 * @since 1.8.4
 				 *
 				 * @param int   $attachment_id Attachment ID.
 				 * @param array $metadata      An array of attachment meta data.
@@ -246,8 +227,7 @@ class Imagify_Auto_Optimization {
 			/**
 			 * Allow to prevent automatic reoptimization for a specific attachment.
 			 *
-			 * @since  1.8.4
-			 * @author Grégory Viguier
+			 * @since 1.8.4
 			 *
 			 * @param bool  $optimize      True to optimize, false otherwise.
 			 * @param int   $attachment_id Attachment ID.
@@ -270,8 +250,7 @@ class Imagify_Auto_Optimization {
 		/**
 		 * Triggered after a media auto-optimization init.
 		 *
-		 * @since  1.9.8
-		 * @author Grégory Viguier
+		 * @since 1.9.8
 		 *
 		 * @param int  $attachment_id The media ID.
 		 * @param bool $is_new_upload True if it's a new upload. False otherwize.
@@ -284,10 +263,8 @@ class Imagify_Auto_Optimization {
 	/**
 	 * Launch auto optimization immediately after the post meta '_wp_attachment_metadata' is added or updated.
 	 *
-	 * @since  1.9
-	 * @since  1.9 Previously named do_auto_optimization().
-	 * @access public
-	 * @author Grégory Viguier
+	 * @since 1.9
+	 * @since 1.9 Previously named do_auto_optimization().
 	 *
 	 * @param int    $meta_id       ID of the metadata entry.
 	 * @param int    $attachment_id Current attachment ID.
@@ -316,10 +293,8 @@ class Imagify_Auto_Optimization {
 	/**
 	 * Launch auto optimization immediately after the post meta '_wp_attachment_metadata' is added or updated.
 	 *
-	 * @since  1.8.4
-	 * @since  1.9.8 Changed signature.
-	 * @access public
-	 * @author Grégory Viguier
+	 * @since 1.8.4
+	 * @since 1.9.8 Changed signature.
 	 *
 	 * @param int  $attachment_id The media ID.
 	 * @param bool $is_new_upload True if it's a new upload. False otherwize.
@@ -330,8 +305,7 @@ class Imagify_Auto_Optimization {
 		/**
 		 * Fires before an attachment auto-optimization is triggered.
 		 *
-		 * @since  1.8.4
-		 * @author Grégory Viguier
+		 * @since 1.8.4
 		 *
 		 * @param int  $attachment_id The attachment ID.
 		 * @param bool $is_new_upload True if it's a new upload. False otherwize.
@@ -341,8 +315,7 @@ class Imagify_Auto_Optimization {
 		/**
 		 * Triggered before a media is auto-optimized.
 		 *
-		 * @since  1.8.4
-		 * @author Grégory Viguier
+		 * @since 1.8.4
 		 *
 		 * @param int  $attachment_id The media ID.
 		 * @param bool $is_new_upload True if it's a new upload. False otherwize.
@@ -391,8 +364,7 @@ class Imagify_Auto_Optimization {
 		/**
 		 * Triggered after a media auto-optimization is launched.
 		 *
-		 * @since  1.8.4
-		 * @author Grégory Viguier
+		 * @since 1.8.4
 		 *
 		 * @param int  $attachment_id The media ID.
 		 * @param bool $is_new_upload True if it's a new upload. False otherwize.
@@ -403,9 +375,7 @@ class Imagify_Auto_Optimization {
 	/**
 	 * Remove the attachment ID from the $attachments property if the post meta '_wp_attachment_metadata' is deleted.
 	 *
-	 * @since  1.8.4
-	 * @access public
-	 * @author Grégory Viguier
+	 * @since 1.8.4
 	 *
 	 * @param int    $meta_ids      An array of deleted metadata entry IDs.
 	 * @param int    $attachment_id Current attachment ID.
@@ -427,11 +397,9 @@ class Imagify_Auto_Optimization {
 	/**
 	 * With WP 5.3+, prevent auto-optimization inside wp_generate_attachment_metadata() because it triggers a wp_update_attachment_metadata() for each thumbnail size.
 	 *
-	 * @since  1.9.8
-	 * @access public
-	 * @see    wp_generate_attachment_metadata()
-	 * @see    wp_create_image_subsizes()
-	 * @author Grégory Viguier
+	 * @since 1.9.8
+	 * @see   wp_generate_attachment_metadata()
+	 * @see   wp_create_image_subsizes()
 	 *
 	 * @param  int    $threshold     The threshold value in pixels. Default 2560.
 	 * @param  array  $imagesize     Indexed array of the image width and height (in that order).
@@ -447,10 +415,8 @@ class Imagify_Auto_Optimization {
 	/**
 	 * With WP 5.3+, allow auto-optimization back after wp_generate_attachment_metadata().
 	 *
-	 * @since  1.9.8
-	 * @access public
-	 * @see    $this->prevent_auto_optimization_when_generating_thumbnails()
-	 * @author Grégory Viguier
+	 * @since 1.9.8
+	 * @see   $this->prevent_auto_optimization_when_generating_thumbnails()
 	 *
 	 * @param  array  $metadata      An array of attachment meta data.
 	 * @param  int    $attachment_id Current attachment ID.
@@ -475,11 +441,9 @@ class Imagify_Auto_Optimization {
 	/**
 	 * With WP 5.3+, prevent auto-optimization when WP tries to create thumbnails after an upload error, because it triggers wp_update_attachment_metadata() for each thumbnail size.
 	 *
-	 * @since  1.9.8
-	 * @access public
-	 * @see    wp_ajax_media_create_image_subsizes()
-	 * @see    wp_update_image_subsizes()
-	 * @author Grégory Viguier
+	 * @since 1.9.8
+	 * @see   wp_ajax_media_create_image_subsizes()
+	 * @see   wp_update_image_subsizes()
 	 */
 	public function prevent_auto_optimization_when_recovering_from_upload_failure() {
 		if ( ! check_ajax_referer( 'media-form', false, false ) ) {
@@ -515,10 +479,8 @@ class Imagify_Auto_Optimization {
 	/**
 	 * Maybe launch auto-optimization after recovering from an upload failure, when all thumbnails are created.
 	 *
-	 * @since  1.9.8
-	 * @access public
-	 * @see    wp_ajax_media_create_image_subsizes()
-	 * @author Grégory Viguier
+	 * @since 1.9.8
+	 * @see   wp_ajax_media_create_image_subsizes()
 	 *
 	 * @param  string $content Buffer’s content.
 	 * @return string          Buffer’s content.
@@ -569,10 +531,8 @@ class Imagify_Auto_Optimization {
 	 *     wp_update_attachment_metadata( $attachment_id );
 	 *     Imagify_Auto_Optimization::allow_optimization( $attachment_id );
 	 *
-	 * @since  1.8.4
-	 * @since  1.9.8 Prevents/Allows can stack.
-	 * @access public
-	 * @author Grégory Viguier
+	 * @since 1.8.4
+	 * @since 1.9.8 Prevents/Allows can stack.
 	 *
 	 * @param int $attachment_id Current attachment ID.
 	 */
@@ -591,10 +551,8 @@ class Imagify_Auto_Optimization {
 	 *     wp_update_attachment_metadata( $attachment_id );
 	 *     Imagify_Auto_Optimization::allow_optimization( $attachment_id );
 	 *
-	 * @since  1.8.4
-	 * @since  1.9.8 Prevents/Allows can stack.
-	 * @access public
-	 * @author Grégory Viguier
+	 * @since 1.8.4
+	 * @since 1.9.8 Prevents/Allows can stack.
 	 *
 	 * @param int $attachment_id Current attachment ID.
 	 */
@@ -612,9 +570,7 @@ class Imagify_Auto_Optimization {
 	/**
 	 * Tell if an auto-optimization is prevented locally.
 	 *
-	 * @since  1.8.4
-	 * @access public
-	 * @author Grégory Viguier
+	 * @since 1.8.4
 	 *
 	 * @param  int $attachment_id Current attachment ID.
 	 * @return bool
@@ -626,9 +582,7 @@ class Imagify_Auto_Optimization {
 	/**
 	 * Prevent an auto-optimization internally.
 	 *
-	 * @since  1.9.8
-	 * @access protected
-	 * @author Grégory Viguier
+	 * @since 1.9.8
 	 *
 	 * @param int $attachment_id Current attachment ID.
 	 */
@@ -639,9 +593,7 @@ class Imagify_Auto_Optimization {
 	/**
 	 * Allow an auto-optimization internally.
 	 *
-	 * @since  1.9.8
-	 * @access protected
-	 * @author Grégory Viguier
+	 * @since 1.9.8
 	 *
 	 * @param int $attachment_id Current attachment ID.
 	 */

--- a/inc/deprecated/classes/class-imagify-auto-optimization-deprecated.php
+++ b/inc/deprecated/classes/class-imagify-auto-optimization-deprecated.php
@@ -6,7 +6,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
  *
  * @since 1.9.10
  */
-class Imagify_Auto_Optimization_Deprecated {
+abstract class Imagify_Auto_Optimization_Deprecated {
 
 	/**
 	 * With WP 5.3+, prevent auto-optimization inside wp_generate_attachment_metadata() because it triggers a wp_update_attachment_metadata() for each thumbnail size.

--- a/inc/deprecated/classes/class-imagify-enable-media-replace-deprecated.php
+++ b/inc/deprecated/classes/class-imagify-enable-media-replace-deprecated.php
@@ -4,8 +4,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 /**
  * Compat class for Enable Media Replace plugin.
  *
- * @since  1.8.4
- * @author Grégory Viguier
+ * @since 1.8.4
  * @deprecated
  */
 class Imagify_Enable_Media_Replace_Deprecated {
@@ -13,11 +12,9 @@ class Imagify_Enable_Media_Replace_Deprecated {
 	/**
 	 * The attachment ID.
 	 *
-	 * @var    int
-	 * @since  1.6.9
-	 * @since  1.9 Deprecated
-	 * @access protected
-	 * @author Grégory Viguier
+	 * @var   int
+	 * @since 1.6.9
+	 * @since 1.9 Deprecated
 	 * @deprecated
 	 */
 	protected $attachment_id;
@@ -25,11 +22,9 @@ class Imagify_Enable_Media_Replace_Deprecated {
 	/**
 	 * The attachment.
 	 *
-	 * @var    Imagify_Attachment
-	 * @since  1.6.9
-	 * @since  1.9 Deprecated
-	 * @access protected
-	 * @author Grégory Viguier
+	 * @var   Imagify_Attachment
+	 * @since 1.6.9
+	 * @since 1.9 Deprecated
 	 * @deprecated
 	 */
 	protected $attachment;
@@ -38,11 +33,9 @@ class Imagify_Enable_Media_Replace_Deprecated {
 	 * Tell if the attachment has data.
 	 * No data means not processed by Imagify, or restored.
 	 *
-	 * @var    bool
-	 * @since  1.8.4
-	 * @since  1.9 Deprecated
-	 * @access protected
-	 * @author Grégory Viguier
+	 * @var   bool
+	 * @since 1.8.4
+	 * @since 1.9 Deprecated
 	 * @deprecated
 	 */
 	protected $attachment_has_data;
@@ -50,11 +43,9 @@ class Imagify_Enable_Media_Replace_Deprecated {
 	/**
 	 * Filesystem object.
 	 *
-	 * @var    object Imagify_Filesystem
-	 * @since  1.7.1
-	 * @since  1.8.4 Deprecated
-	 * @author Grégory Viguier
-	 * @access protected
+	 * @var   object Imagify_Filesystem
+	 * @since 1.7.1
+	 * @since 1.8.4 Deprecated
 	 * @deprecated
 	 */
 	protected $filesystem;
@@ -63,11 +54,9 @@ class Imagify_Enable_Media_Replace_Deprecated {
 	 * Optimize the attachment files if the old ones were also optimized.
 	 * Delete the old backup file.
 	 *
-	 * @since  1.6.9
-	 * @since  1.8.4 Deprecated
-	 * @author Grégory Viguier
-	 * @see    $this->store_old_backup_path()
-	 * @access protected
+	 * @since 1.6.9
+	 * @since 1.8.4 Deprecated.
+	 * @see   $this->store_old_backup_path()
 	 * @deprecated
 	 *
 	 * @param  string $return_url The URL the user will be redirected to.
@@ -121,12 +110,59 @@ class Imagify_Enable_Media_Replace_Deprecated {
 	}
 
 	/**
+	 * When the user chooses to change the file name, store the old backup file path. This path will be used later to delete the file.
+	 *
+	 * @since 1.6.9
+	 * @since 1.9.10 Deprecated.
+	 * @deprecated
+	 *
+	 * @param  string $new_filename The new file name.
+	 * @param  string $current_path The current file path.
+	 * @param  int    $post_id      The attachment ID.
+	 * @return string               The same file name.
+	 */
+	public function store_old_backup_path( $new_filename, $current_path, $post_id ) {
+		_deprecated_function( get_class( $this ) . '::' . __FUNCTION__ . '()', '1.9.10' );
+
+		if ( ! $this->media_id || $post_id !== $this->media_id ) {
+			return $new_filename;
+		}
+
+		$this->get_process();
+
+		if ( ! $this->process ) {
+			$this->media_id = 0;
+			return $new_filename;
+		}
+
+		$media       = $this->process->get_media();
+		$backup_path = $media->get_backup_path();
+
+		if ( $backup_path ) {
+			$this->old_backup_path = $backup_path;
+
+			// Keep track of existing webp files.
+			$media_files = $media->get_media_files();
+
+			if ( $media_files ) {
+				foreach ( $media_files as $media_file ) {
+					$this->old_webp_paths[] = imagify_path_to_webp( $media_file['path'] );
+				}
+			}
+		} else {
+			$this->media_id        = 0;
+			$this->old_backup_path = false;
+			$this->old_webp_paths  = [];
+		}
+
+		return $new_filename;
+	}
+
+	/**
 	 * Get the attachment.
 	 *
-	 * @since  1.6.9
-	 * @since  1.9 Deprecated
-	 * @author Grégory Viguier
-	 * @access protected
+	 * @since 1.6.9
+	 * @since 1.9 Deprecated.
 	 * @deprecated
 	 *
 	 * @return object A Imagify_Attachment object (or any class extending it).


### PR DESCRIPTION
This fixes our compatibility with the plugin "Enable Media Replace". It was broken since EMR updated its code to adapt to WordPress 5.3’s new upload process.

Sum up:
- Use the hook `'wp_handle_replace'` to initiate the class, instead of `'emr_unfiltered_get_attached_file'`.
- Removed some `if` statements and tests in `init()` that are not needed anymore.
- The old webp file paths are stored in `init()` now: like explained in the DocBlock, this prevents some orphan files from being kept indefinitely when the user chooses not to rename the files.
- Deprecate the method `store_old_backup_path()`, as it is not needed anymore: the old backup path is already correct and the old webp file paths are stored in `init()`.

Fixes #493.

Tests done locally. I will explain the procedure to the QA team.