### PR TITLE
Fix: WP 5.7 Cover Blocks not displaying correctly with webp/picture tags enabled

### DIFF
--- a/classes/Webp/Picture/Display.php
+++ b/classes/Webp/Picture/Display.php
@@ -193,6 +193,17 @@ class Display {
 		 * @param array $data       Data built from the originale <img> tag. See $this->process_image().
 		 */
 		$attributes = apply_filters( 'imagify_picture_attributes', $attributes, $image );
+		
+		/**
+		 * Remove Gutenberg specific attributes from picture tag, leave them on img tag.
+		 * Optional: $attributes['class'] = 'imagify-webp-cover-wrapper'; for website admin styling ease.
+		 */
+		if ( ! empty( $image['attributes']['class'] ) && strpos( $image['attributes']['class'], 'wp-block-cover__image-background' ) !== false ) {
+        	unset( $attributes['style'] );
+			unset( $attributes['class'] );
+			unset( $attributes['data-object-fit'] );
+			unset( $attributes['data-object-position'] );
+		}
 
 		$output = '<picture' . $this->build_attributes( $attributes ) . ">\n";
 		/**
@@ -289,14 +300,28 @@ class Display {
 	 * @return string       A <img> tag.
 	 */
 	protected function build_img_tag( $image ) {
-		$to_remove = [
-			'class'  => '',
-			'id'     => '',
-			'style'  => '',
-			'title'  => '',
-		];
+		
+		/**
+		 * Gutenberg fix.
+		 * Check for the 'wp-block-cover__image-background' class on the original image, and leave that class and style attributes if found.
+		 */
+		if ( ! empty( $image['attributes']['class'] ) && strpos( $image['attributes']['class'], 'wp-block-cover__image-background' ) !== false ) {
+        	$to_remove = [
+				'id'     => '',
+				'title'  => '',
+			];
 
-		$attributes = array_diff_key( $image['attributes'], $to_remove );
+			$attributes = array_diff_key( $image['attributes'], $to_remove );
+    	} else {
+			$to_remove = [
+				'class'  => '',
+				'id'     => '',
+				'style'  => '',
+				'title'  => '',
+			];
+
+			$attributes = array_diff_key( $image['attributes'], $to_remove );
+		}
 
 		/**
 		 * Filter the attributes to be added to the <img> tag.


### PR DESCRIPTION
Add overrides specific to cover blocks in Gutenberg to fix #546 

This is test on default themes and 1 custom made theme, no issues appear to be found. THis fix prevents the need for front end CSS or JS to be loaded, and instead uses your built in filters and functions to correctly process cover blocks.