### PR TITLE
fix phpcs 7.4 errors

### DIFF
--- a/classes/Webp/Picture/Display.php
+++ b/classes/Webp/Picture/Display.php
@@ -193,13 +193,13 @@ class Display {
 		 * @param array $data       Data built from the originale <img> tag. See $this->process_image().
 		 */
 		$attributes = apply_filters( 'imagify_picture_attributes', $attributes, $image );
-		
+
 		/**
 		 * Remove Gutenberg specific attributes from picture tag, leave them on img tag.
 		 * Optional: $attributes['class'] = 'imagify-webp-cover-wrapper'; for website admin styling ease.
 		 */
 		if ( ! empty( $image['attributes']['class'] ) && strpos( $image['attributes']['class'], 'wp-block-cover__image-background' ) !== false ) {
-        	unset( $attributes['style'] );
+			unset( $attributes['style'] );
 			unset( $attributes['class'] );
 			unset( $attributes['data-object-fit'] );
 			unset( $attributes['data-object-position'] );
@@ -300,19 +300,18 @@ class Display {
 	 * @return string       A <img> tag.
 	 */
 	protected function build_img_tag( $image ) {
-		
 		/**
 		 * Gutenberg fix.
 		 * Check for the 'wp-block-cover__image-background' class on the original image, and leave that class and style attributes if found.
 		 */
 		if ( ! empty( $image['attributes']['class'] ) && strpos( $image['attributes']['class'], 'wp-block-cover__image-background' ) !== false ) {
-        	$to_remove = [
+			$to_remove = [
 				'id'     => '',
 				'title'  => '',
 			];
 
 			$attributes = array_diff_key( $image['attributes'], $to_remove );
-    	} else {
+		} else {
 			$to_remove = [
 				'class'  => '',
 				'id'     => '',

--- a/inc/classes/class-imagify-abstract-cron.php
+++ b/inc/classes/class-imagify-abstract-cron.php
@@ -262,7 +262,7 @@ abstract class Imagify_Abstract_Cron {
 	 * @return int Timestamp.
 	 */
 	public static function get_next_timestamp( $event_time = '00:00' ) {
-		$current_time_int = (int) date( 'Gis' );
+		$current_time_int = (int) gmdate( 'Gis' );
 		$event_time_int   = (int) str_replace( ':', '', $event_time . '00' );
 		$event_time       = explode( ':', $event_time );
 		$event_hour       = (int) $event_time[0];
@@ -271,7 +271,7 @@ abstract class Imagify_Abstract_Cron {
 
 		if ( $event_time_int <= $current_time_int ) {
 			// The event time is passed, we need to schedule the event tomorrow.
-			return mktime( $event_hour, $event_minute, 0, (int) date( 'n' ), (int) date( 'j' ) + 1 ) - $offset;
+			return mktime( $event_hour, $event_minute, 0, (int) gmdate( 'n' ), (int) gmdate( 'j' ) + 1 ) - $offset;
 		}
 
 		// We haven't passed the event time yet, schedule the event today.

--- a/inc/functions/compat.php
+++ b/inc/functions/compat.php
@@ -56,7 +56,7 @@ if ( ! function_exists( 'wp_json_encode' ) ) :
 		}
 
 		// Prepare the data for JSON serialization.
-		$args[0] = _wp_json_prepare_data( $data );
+		$args[0] = $data;
 
 		$json = @call_user_func_array( 'json_encode', $args );
 
@@ -77,57 +77,6 @@ if ( ! function_exists( 'wp_json_encode' ) ) :
 	}
 endif;
 
-if ( ! function_exists( '_wp_json_prepare_data' ) ) :
-	/**
-	 * Prepares response data to be serialized to JSON.
-	 *
-	 * This supports the JsonSerializable interface for PHP 5.2-5.3 as well.
-	 *
-	 * @since  1.6.5
-	 * @since  WP 4.4.0
-	 * @access private
-	 *
-	 * @param  mixed $data Native representation.
-	 * @return bool|int|float|null|string|array Data ready for `json_encode()`.
-	 */
-	function _wp_json_prepare_data( $data ) {
-		if ( ! defined( 'WP_JSON_SERIALIZE_COMPATIBLE' ) || WP_JSON_SERIALIZE_COMPATIBLE === false ) {
-			return $data;
-		}
-
-		switch ( gettype( $data ) ) {
-			case 'boolean':
-			case 'integer':
-			case 'double':
-			case 'string':
-			case 'NULL':
-				// These values can be passed through.
-				return $data;
-
-			case 'array':
-				// Arrays must be mapped in case they also return objects.
-				return array_map( '_wp_json_prepare_data', $data );
-
-			case 'object':
-				// If this is an incomplete object (__PHP_Incomplete_Class), bail.
-				if ( ! is_object( $data ) ) {
-					return null;
-				}
-
-				if ( $data instanceof JsonSerializable ) {
-					$data = $data->jsonSerialize();
-				} else {
-					$data = get_object_vars( $data );
-				}
-
-				// Now, pass the array (or whatever was returned from jsonSerialize through).
-				return _wp_json_prepare_data( $data );
-
-			default:
-				return null;
-		}
-	}
-endif;
 
 if ( ! function_exists( '_wp_json_sanity_check' ) ) :
 	/**

--- a/views/part-discount-banner.php
+++ b/views/part-discount-banner.php
@@ -9,7 +9,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 			/* translators: %1$s is a formatted percentage, %2$s is a subscription plan name. */
 			__( '%1$s OFF on %2$s subscriptions', 'imagify' ),
 			'<span class="imagify-promotion-number"></span>',
-			'<span class="imagify-promotion-plan-name"></span>',
+			'<span class="imagify-promotion-plan-name"></span>'
 		);
 		?>
 	</p>


### PR DESCRIPTION
i fixed all phpcs errors for php 7.4
also I removed _wp_json_prepare_data function
because it is deprecated from WordPress version 5.3
it was handling a case in PHP 5.2 and 5.3, Imagify plugin requires PHP 5.4 to work so there is no need for it
and it is removed from the WPcore  2years ago
https://core.trac.wordpress.org/ticket/47699

Also, the WordPress min requirement is PHP version is 5.6.2 and I think we should make  Imagify plugin require ph 5.6 or 5.8 to work to keep up with WordPress.
https://wordpress.org/about/requirements/

`Note: If you are in a legacy environment where you only have older PHP or MySQL versions, WordPress also works with PHP 5.6.20+ and MySQL 5.0+, but these versions have reached official End Of Life and as such may expose your site to security vulnerabilities.`
