### PR TITLE
Fix #564 - Improve filter for Imagify Notices

### DIFF
--- a/inc/classes/class-imagify-notices.php
+++ b/inc/classes/class-imagify-notices.php
@@ -872,7 +872,7 @@ class Imagify_Notices extends Imagify_Notices_Deprecated {
 		 *
 		 * @param array $notice_ids An array of notice "IDs".
 		 */
-		return apply_filters( 'imagify_notices', self::$notice_ids );
+		return (array) apply_filters( 'imagify_notices', self::$notice_ids );
 	}
 
 	/**

--- a/inc/classes/class-imagify-notices.php
+++ b/inc/classes/class-imagify-notices.php
@@ -861,7 +861,10 @@ class Imagify_Notices extends Imagify_Notices_Deprecated {
 	 * Get all notice IDs.
 	 *
 	 * @since  1.6.10
+	 * @since  1.10 Cast return value to array.
 	 * @author Grégory Viguier
+	 *
+	 * @return array The filtered notice ids.
 	 */
 	protected function get_notice_ids() {
 		/**


### PR DESCRIPTION
Closes #564 

Per grooming notes, there is already a filter. It is suggested adding a cast to array before returning from `get_notice_ids()`.

The filter/method has been around since 1.6 without the cast, but the filters @param has indicated that an array is expected.