### PR TITLE
Fix #511 - Remove old coupon code and related text

### DIFF
--- a/views/notice-wp-rocket.php
+++ b/views/notice-wp-rocket.php
@@ -2,7 +2,6 @@
 defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
 $dismiss_url  = get_imagify_admin_url( 'dismiss-notice', 'wp-rocket' );
-$coupon_code  = 'IMAGIFY20';
 $wprocket_url = imagify_get_wp_rocket_url();
 ?>
 <div class="updated imagify-rkt-notice">
@@ -14,16 +13,7 @@ $wprocket_url = imagify_get_wp_rocket_url();
 	<p class="imagify-rkt-msg">
 		<?php
 		esc_html_e( 'Discover the best caching plugin to speed up your website.', 'imagify' );
-		echo '<br>';
-		printf(
-			/* translators: 1 is a "bold" tag start, 2 is a pourcentage, 3 is the "bold" tag end, 4 is a coupon code. */
-			esc_html__( '%1$sGet %2$s off%3$s with this coupon code: %4$s', 'imagify' ),
-			'<strong>', '20%', '</strong>', $coupon_code
-		);
 		?>
-	</p>
-	<p class="imagify-rkt-coupon">
-		<span class="imagify-rkt-coupon-code"><?php echo $coupon_code; ?></span>
 	</p>
 	<p class="imagify-rkt-cta">
 		<a target="_blank" href="<?php echo esc_url( $wprocket_url ); ?>" class="button button-primary tgm-plugin-update-modal"><?php esc_html_e( 'Get WP Rocket now', 'imagify' ); ?></a>


### PR DESCRIPTION
Closes #511 

Remove the old coupon code and related text, leaving only the Logo, intro WPRocket text and "get now" button.