### PR TITLE
Fix #537 Stop replacing images already nested inside picture tags

### DIFF
--- a/classes/Webp/Picture/Display.php
+++ b/classes/Webp/Picture/Display.php
@@ -32,6 +32,14 @@ class Display {
 	protected $filesystem;
 
 	/**
+	 * Pre-existing picture tags extracted html.
+	 *
+	 * @var array
+	 * @since 1.10.0
+	 */
+	private $picture_tags;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since  1.9
@@ -148,7 +156,7 @@ class Display {
 			$content = str_replace( $image['tag'], $tag, $content );
 		}
 
-		return $content;
+		return $this->reinsert_picture_tags( $content );
 	}
 
 	/**
@@ -164,13 +172,35 @@ class Display {
 	 * @return string HTML content without pre-existing <picture> tags.
 	 */
 	private function remove_picture_tags( $html ) {
-		$replace = preg_replace( '#<picture[^>]*>.*?<\/picture\s*>#mis', '', $html );
+		return preg_replace_callback(
+			'#<picture[^>]*>.*?<\/picture\s*>#mis',
+			function( $matches ) {
+				$this->picture_tags[] = $matches[0];
+				return '<!--imagify-picture-tag-placeholder-->';
+			},
+			$html
+		);
+	}
 
-		if ( null === $replace ) {
-			return $html;
-		}
-
-		return $replace;
+	/**
+	 * Re-insert pre-existing <picture> tags back to their original positions.
+	 *
+	 * Used in conjunction with remove_picture_tags() to re-construct HTML after having replaced non-nested images.
+	 *
+	 * @since 1.10.0
+	 *
+	 * @param string $html Content of the page without pre-existing <picture> tags.
+	 *
+	 * @return string HTML content with pre-existing <picture> tags re-inserted.
+	 */
+	private function reinsert_picture_tags( $html ) {
+		return preg_replace_callback(
+			'#<!--imagify-picture-tag-placeholder-->#mis',
+			function() {
+					return array_shift( $this->picture_tags );
+			},
+			$html
+		);
 	}
 
 	/** ----------------------------------------------------------------------------------------- */

--- a/classes/Webp/Picture/Display.php
+++ b/classes/Webp/Picture/Display.php
@@ -32,14 +32,6 @@ class Display {
 	protected $filesystem;
 
 	/**
-	 * Pre-existing picture tags extracted html.
-	 *
-	 * @var array
-	 * @since 1.10.0
-	 */
-	private $picture_tags = [];
-
-	/**
 	 * Constructor.
 	 *
 	 * @since  1.9
@@ -144,10 +136,10 @@ class Display {
 	 * @return string
 	 */
 	public function process_content( $content ) {
-		$content = $this->remove_picture_tags( $content );
-		$images = $this->get_images( $content );
+		$html_no_picture_tags= $this->remove_picture_tags( $content );
+		$images = $this->get_images( $html_no_picture_tags );
 
-		if ( ! $images ) {
+		if ( ! $images ) { return 'no images';
 			return $content;
 		}
 
@@ -156,8 +148,7 @@ class Display {
 			$content = str_replace( $image['tag'], $tag, $content );
 		}
 
-		return $this->reinsert_picture_tags( $content );
-	}
+		return $content;	}
 
 	/**
 	 * Remove pre-existing <picture> tags.
@@ -172,39 +163,13 @@ class Display {
 	 * @return string HTML content without pre-existing <picture> tags.
 	 */
 	private function remove_picture_tags( $html ) {
-		return preg_replace_callback(
-			'#<picture[^>]*>.*?<\/picture\s*>#mis',
-			function( $matches ) {
-				$this->picture_tags[] = $matches[0];
-				return '<!--imagify-picture-tag-placeholder-->';
-			},
-			$html
-		);
-	}
+		$replace = preg_replace( '#<picture[^>]*>.*?<\/picture\s*>#mis', '', $html );
 
-	/**
-	 * Re-insert pre-existing <picture> tags back to their original positions.
-	 *
-	 * Used in conjunction with remove_picture_tags() to re-construct HTML after having replaced non-nested images.
-	 *
-	 * @since 1.10.0
-	 *
-	 * @param string $html Content of the page without pre-existing <picture> tags.
-	 *
-	 * @return string HTML content with pre-existing <picture> tags re-inserted.
-	 */
-	private function reinsert_picture_tags( $html ) {
-		if ( empty( $this->picture_tags ) ) {
+		if ( null === $replace ) {
 			return $html;
 		}
 
-		return preg_replace_callback(
-			'#<!--imagify-picture-tag-placeholder-->#mis',
-			function() {
-					return array_shift( $this->picture_tags );
-			},
-			$html
-		);
+		return $replace;
 	}
 
 	/** ----------------------------------------------------------------------------------------- */

--- a/classes/Webp/Picture/Display.php
+++ b/classes/Webp/Picture/Display.php
@@ -136,6 +136,7 @@ class Display {
 	 * @return string
 	 */
 	public function process_content( $content ) {
+		$content = $this->remove_picture_tags( $content );
 		$images = $this->get_images( $content );
 
 		if ( ! $images ) {
@@ -148,6 +149,28 @@ class Display {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Remove pre-existing <picture> tags.
+	 *
+	 * We shouldn't replace images already nested inside picture tags
+	 * that are already in the page.
+	 *
+	 * @since 1.10.0
+	 *
+	 * @param string $html Content of the page.
+	 *
+	 * @return string HTML content without pre-existing <picture> tags.
+	 */
+	private function remove_picture_tags( $html ) {
+		$replace = preg_replace( '#<picture[^>]*>.*?<\/picture\s*>#mis', '', $html );
+
+		if ( null === $replace ) {
+			return $html;
+		}
+
+		return $replace;
 	}
 
 	/** ----------------------------------------------------------------------------------------- */

--- a/classes/Webp/Picture/Display.php
+++ b/classes/Webp/Picture/Display.php
@@ -136,10 +136,10 @@ class Display {
 	 * @return string
 	 */
 	public function process_content( $content ) {
-		$html_no_picture_tags= $this->remove_picture_tags( $content );
+		$html_no_picture_tags = $this->remove_picture_tags( $content );
 		$images = $this->get_images( $html_no_picture_tags );
 
-		if ( ! $images ) { return 'no images';
+		if ( ! $images ) {
 			return $content;
 		}
 
@@ -148,7 +148,7 @@ class Display {
 			$content = str_replace( $image['tag'], $tag, $content );
 		}
 
-		return $content;	}
+		return $content;    }
 
 	/**
 	 * Remove pre-existing <picture> tags.

--- a/classes/Webp/Picture/Display.php
+++ b/classes/Webp/Picture/Display.php
@@ -37,7 +37,7 @@ class Display {
 	 * @var array
 	 * @since 1.10.0
 	 */
-	private $picture_tags;
+	private $picture_tags = [];
 
 	/**
 	 * Constructor.
@@ -194,6 +194,10 @@ class Display {
 	 * @return string HTML content with pre-existing <picture> tags re-inserted.
 	 */
 	private function reinsert_picture_tags( $html ) {
+		if ( empty( $this->picture_tags ) ) {
+			return $html;
+		}
+
 		return preg_replace_callback(
 			'#<!--imagify-picture-tag-placeholder-->#mis',
 			function() {


### PR DESCRIPTION
Closes #537

Starting out adding a remove_picture_tags() method, per grooming notes.

~However, we cannot remove them without later putting them back at the end of the process, since we're calling `process_content()` inside of `ob_start()`. When we flush the buffer without putting the removed things back, they'll be missing from the page!~

~To remedy this, we'll use `preg_replace_callback()` in the remove part to make a placeholder comment in the html where we've removed a tag and store all the picture tags we've removed; then we can `preg_replace_callback()` again in a `reinsert_picture_tags()` method to swap the original picture tag back in at each placeholder.~