### PR TITLE
Fix #573 - PHP Notice when user has no image count

### DIFF
--- a/inc/classes/class-imagify-cron-rating.php
+++ b/inc/classes/class-imagify-cron-rating.php
@@ -103,7 +103,7 @@ class Imagify_Cron_Rating extends Imagify_Abstract_Cron {
 
 		$user = get_imagify_user();
 
-		if ( ! is_wp_error( $user ) && (int) $user->image_count > 100 ) {
+		if ( ! is_wp_error( $user ) && isset( $user->image_count ) && (int) $user->image_count > 100 ) {
 			set_site_transient( 'imagify_user_images_count', $user->image_count );
 		}
 	}


### PR DESCRIPTION
Closes #573 
Per grooming, just adds the isset() check.