### PR TITLE
Fix #565 - Array Flip fails on non-string item

### DIFF
--- a/inc/classes/class-imagify-admin-ajax-post.php
+++ b/inc/classes/class-imagify-admin-ajax-post.php
@@ -454,7 +454,7 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 		imagify_check_nonce( 'imagify-bulk-optimize' );
 
 		$folder_types = filter_input( INPUT_GET, 'types', FILTER_SANITIZE_STRING, FILTER_REQUIRE_ARRAY );
-		$folder_types = is_array( $folder_types ) ? array_filter( $folder_types ) : [];
+		$folder_types = is_array( $folder_types ) ? array_filter( $folder_types, 'is_string' ) : [];
 
 		if ( ! $folder_types ) {
 			imagify_die( __( 'Invalid request', 'imagify' ) );


### PR DESCRIPTION
Closes #565 

Per grooming / discussion on 565: adds a check for is_string before flipping.