### PR TITLE
[i18n] Fix typos on translatable strings

### DIFF
--- a/assets/js/pricing-modal.js
+++ b/assets/js/pricing-modal.js
@@ -199,7 +199,7 @@
 			$offer.find('.imagify-approx-nb').text(quo * 5);
 
 			if ('monthly' === type) {
-				// Additionnal price.
+				// Additional price.
 				$offer.find('.imagify-price-add-data').text('$' + add);
 			}
 

--- a/inc/functions/i18n.php
+++ b/inc/functions/i18n.php
@@ -40,7 +40,7 @@ function get_imagify_localize_script_translations( $context ) {
 					'saveApiKeyTitle'             => __( 'Connect to Imagify!', 'imagify' ),
 					'saveApiKeyText'              => __( 'Paste your API key below:', 'imagify' ),
 					'saveApiKeyConfirmButtonText' => __( 'Connect me', 'imagify' ),
-					'ApiKeyErrorEmpty'            => __( 'You need to specify your api key!', 'imagify' ),
+					'ApiKeyErrorEmpty'            => __( 'You need to specify your API key!', 'imagify' ),
 					'ApiKeyCheckSuccessTitle'     => __( 'Congratulations!', 'imagify' ),
 					'ApiKeyCheckSuccessText'      => __( 'Your API key is valid. You can now configure the Imagify settings to optimize your images.', 'imagify' ),
 				],

--- a/views/modal-payment.php
+++ b/views/modal-payment.php
@@ -287,7 +287,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 										<?php
 										printf(
 											/* translators: %s is a formatted price. */
-											__( '%s per<br>additionnal Gb', 'imagify' ),
+											__( '%s per<br>additional Gb', 'imagify' ),
 											'<span class="imagify-price-add-data"></span>'
 										);
 										?>

--- a/views/modal-payment.php
+++ b/views/modal-payment.php
@@ -281,7 +281,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 										</span>
 									</span>
 
-									<span class="imagify-recommend" aria-hidden="true"><?php esc_html_e( 'we recommend for you', 'imagify' ); ?></span>
+									<span class="imagify-recommend" aria-hidden="true"><?php esc_html_e( 'We recommend for you', 'imagify' ); ?></span>
 
 									<p class="imagify-price-complement">
 										<?php
@@ -342,7 +342,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 										<span class="imagify-dollars">$</span>
 										<span class="imagify-number-block"></span>
 									</span>
-									<span class="imagify-recommend"><?php esc_html_e( 'we recommend for you', 'imagify' ); ?></span>
+									<span class="imagify-recommend"><?php esc_html_e( 'We recommend for you', 'imagify' ); ?></span>
 								</div><!-- .imagify-col-price -->
 
 								<div class="imagify-col-other-actions">


### PR DESCRIPTION
Fix some typos in translatable strings, and in some cases allowing to merge with similar already existent strings, reducing the translators work load and avoid inconsistenies.

- [x] Fix lowercase `api` -> `API`  (for consistency with the rest of the plugin strings)
- [x] Fix `additionnal` -> `additional`
- [x] Fix `we recommend...` -> `We recommend...`  (First letter uppercase and merge to similar existent string)

