### PR TITLE
Fix/618 more info documentation contact links 404

### DIFF
--- a/imagify.php
+++ b/imagify.php
@@ -29,6 +29,9 @@ define( 'IMAGIFY_URL',            plugin_dir_url( IMAGIFY_FILE ) );
 define( 'IMAGIFY_ASSETS_IMG_URL', IMAGIFY_URL . 'assets/images/' );
 define( 'IMAGIFY_MAX_BYTES',      5242880 );
 define( 'IMAGIFY_INT_MAX',        PHP_INT_MAX - 30 );
+if ( ! defined( 'IMAGIFY_SITE_DOMAIN' ) ) {
+	define( 'IMAGIFY_SITE_DOMAIN', 'https://imagify.io' );
+}
 if ( ! defined( 'IMAGIFY_APP_DOMAIN' ) ) {
 	define( 'IMAGIFY_APP_DOMAIN',     'https://app.imagify.io' );
 }

--- a/inc/functions/common.php
+++ b/inc/functions/common.php
@@ -223,7 +223,7 @@ function imagify_can_optimize_custom_folders() {
  * @return string The URL.
  */
 function imagify_get_external_url( $target, $query_args = array() ) {
-	$site_url = IMAGIFY_APP_DOMAIN . '/';
+	$site_url = IMAGIFY_SITE_DOMAIN . '/';
 	$app_url  = IMAGIFY_APP_DOMAIN . '/#/';
 
 	switch ( $target ) {


### PR DESCRIPTION
closes #618 

This is a fix for many 404 links throughout the plugin interface.

Was caused by `IMAGIFY_APP_API_URL` constant defined as `https://app.imagify.io` in `imagify.php` being used for URLs that needed to point to `https://imagify.io` instead.

Created a new constant named `IMAGIFY_SITE_DOMAIN` defined as `https://imagify.io` which is now used in `inc/functions/common.php` to set proper URLs for documentation and contact us links.