### PR TITLE
Fix/586 remove WP Rocket banner when plugin installed (but inactive)

### DIFF
--- a/inc/classes/class-imagify-notices.php
+++ b/inc/classes/class-imagify-notices.php
@@ -608,7 +608,9 @@ class Imagify_Notices extends Imagify_Notices_Deprecated {
 			return $display;
 		}
 
-		if ( defined( 'WP_ROCKET_VERSION' ) || self::notice_is_dismissed( 'wp-rocket' ) ) {
+		$plugins = get_plugins();
+
+		if ( isset( $plugins['wp-rocket/wp-rocket.php'] ) || self::notice_is_dismissed( 'wp-rocket' ) ) {
 			return $display;
 		}
 

--- a/views/page-settings.php
+++ b/views/page-settings.php
@@ -8,11 +8,12 @@ $hidden_class = Imagify_Requirements::is_api_key_valid() ? '' : ' hidden';
 $lang         = imagify_get_current_lang_in( array( 'de', 'es', 'fr', 'it' ) );
 
 /* Ads notice */
+$plugins = get_plugins();
 $notice  = 'wp-rocket';
 $user_id = get_current_user_id();
 $notices = get_user_meta( $user_id, '_imagify_ignore_ads', true );
 $notices = $notices && is_array( $notices ) ? array_flip( $notices ) : array();
-$wrapper_class = isset( $notices[ $notice ] ) || defined( 'WP_ROCKET_VERSION' ) ? 'imagify-have-rocket' : 'imagify-dont-have-rocket';
+$wrapper_class = isset( $notices[ $notice ] ) || isset( $plugins['wp-rocket/wp-rocket.php'] ) ? 'imagify-have-rocket' : 'imagify-dont-have-rocket';
 ?>
 <div class="wrap imagify-settings <?php echo $wrapper_class; ?> imagify-clearfix">
 

--- a/views/part-rocket-ad.php
+++ b/views/part-rocket-ad.php
@@ -30,8 +30,8 @@ $dismiss_url      = wp_nonce_url( admin_url( 'admin-post.php?action=imagify_dism
 
 		<p class="imagify-sidebar-description">
 			<?php
-			/* translators: 1 is a "bold" tag opening, 2 is the "bold" tag closing. Please use a non-breaking space for WP Rocket. */
-			printf( __( 'WP Rocket is a %1$sspeed optimization plugin for WordPress%2$s helping you to implement a variety of speed-boosting features to your WordPress site.', 'imagify' ), '<strong>', '</strong>' );
+			/* translators: 1 is a "bold" tag opening, 2 is the "bold" tag closing. Please use a non-breaking space for WP Rocket. */
+			printf( __( 'WP Rocket is a %1$sspeed optimization plugin for WordPress%2$s helping you to implement a variety of speed-boosting features to your WordPress site.', 'imagify' ), '<strong>', '</strong>' );
 			?>
 		</p>
 

--- a/views/part-rocket-ad.php
+++ b/views/part-rocket-ad.php
@@ -1,8 +1,10 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
-if ( defined( 'WP_ROCKET_VERSION' ) ) {
-	return '';
+$plugins = get_plugins();
+
+if( isset( $plugins['wp-rocket/wp-rocket.php'] ) ) {
+    return '';
 }
 
 $notice  = 'wp-rocket';

--- a/views/part-rocket-ad.php
+++ b/views/part-rocket-ad.php
@@ -3,8 +3,8 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
 $plugins = get_plugins();
 
-if( isset( $plugins['wp-rocket/wp-rocket.php'] ) ) {
-    return '';
+if ( isset( $plugins['wp-rocket/wp-rocket.php'] ) ) {
+	return '';
 }
 
 $notice  = 'wp-rocket';


### PR DESCRIPTION
Closes #586 

Hide WP Rocket Banner when plugin is installed but not active.

Changed files:

- [views/page-settings.php](https://github.com/wp-media/imagify-plugin/blob/88e39cf23b75b2e63f253e6e6fcd996e4986935b/views/page-settings.php#L16) to keep `imagify-have-rocket` CSS class so the main column has 100% width
- [views/page-rocket-ad.php](https://github.com/wp-media/imagify-plugin/blob/88e39cf23b75b2e63f253e6e6fcd996e4986935b/views/part-rocket-ad.php#L4-L8) to check if plugin exists (active or not)