### PR TITLE
Fixes #609 conflict with wp cloudflare super page cache

### DIFF
--- a/inc/3rd-party/3rd-party.php
+++ b/inc/3rd-party/3rd-party.php
@@ -12,6 +12,7 @@ require IMAGIFY_PATH . 'inc/3rd-party/nextgen-gallery/nextgen-gallery.php';
 require IMAGIFY_PATH . 'inc/3rd-party/regenerate-thumbnails/regenerate-thumbnails.php';
 require IMAGIFY_PATH . 'inc/3rd-party/screets-lc.php';
 require IMAGIFY_PATH . 'inc/3rd-party/wp-real-media-library.php';
+require IMAGIFY_PATH . 'inc/3rd-party/wp-cloudflare-super-page-cache.php';
 require IMAGIFY_PATH . 'inc/3rd-party/wp-rocket/wp-rocket.php';
 require IMAGIFY_PATH . 'inc/3rd-party/yoast-seo.php';
 require IMAGIFY_PATH . 'inc/3rd-party/WooCommerce/class-woocommerce.php';

--- a/inc/3rd-party/wp-cloudflare-super-page-cache.php
+++ b/inc/3rd-party/wp-cloudflare-super-page-cache.php
@@ -1,14 +1,14 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin uh?' );
 
-add_action( 'admin_enqueue_scripts', function($hook_suffix) {
+add_action( 'admin_enqueue_scripts', function( $hook_suffix ) {
 	if (
 		! is_admin()
 		||
 		'media_page_imagify-bulk-optimization' !== $hook_suffix
 		||
 		! class_exists( 'SWCFPC_Backend' )
-	){
+	) {
 		return;
 	}
 

--- a/inc/3rd-party/wp-cloudflare-super-page-cache.php
+++ b/inc/3rd-party/wp-cloudflare-super-page-cache.php
@@ -1,0 +1,53 @@
+<?php
+defined( 'ABSPATH' ) || die( 'Cheatin uh?' );
+
+if ( defined( 'SWCFPC_PLUGIN_PATH' ) ) :
+
+	/**
+	 * Prevent WP Cloudflare Super Page Cache to use its outdated version of SweetAlert where we need ours, and to mess with our CSS styles.
+	 */
+	add_action( 'current_screen', 'imagify_wpcspc_init' );
+	/**
+	 * Dequeue all WP Cloudflare Super Page Cache's styles and scripts where we use ours.
+	 *
+	 * @since  1.10.2
+	 * @author Marko Nikolic
+	 */
+	function imagify_wpcspc_init() {
+		static $done = false;
+
+		if ( $done ) {
+			return;
+		}
+		$done = true;
+
+		if ( ! class_exists( 'SWCFPC_Backend' ) ) {
+			return;
+		}
+
+
+
+		if ( imagify_is_screen( 'bulk' ) ) {
+			// We display a page that uses SweetAlert.
+			imagify_wpcspc_dequeue();
+			return;
+		}
+
+	}
+
+	/**
+	 * Prevent WP Cloudflare Super Page Cache to enqueue its styles and scripts.
+	 *
+	 * @since  1.10.2
+	 * @author Marko Nikolic
+	 */
+	function imagify_wpcspc_dequeue() {
+		
+		// $instance = SWCFPC_Backend::getInstance(); // This is the part I need to find out
+		$instance = new SWCFPC_Backend('SW_CLOUDFLARE_PAGECACHE'); // This is the part I need to find out
+
+		remove_action( 'admin_enqueue_scripts', [ $instance, 'load_custom_wp_admin_styles_and_script' ], 0 );
+		
+	}
+
+endif;

--- a/inc/3rd-party/wp-cloudflare-super-page-cache.php
+++ b/inc/3rd-party/wp-cloudflare-super-page-cache.php
@@ -7,7 +7,7 @@ add_action( 'admin_enqueue_scripts', function( $hook_suffix ) {
 		'media_page_imagify-bulk-optimization',
 		'settings_page_imagify',
 		'media_page_imagify-files',
-		'nextgen-gallery_page_imagify-ngg-bulk-optimization'
+		'nextgen-gallery_page_imagify-ngg-bulk-optimization',
 	);
 
 	if (
@@ -15,7 +15,7 @@ add_action( 'admin_enqueue_scripts', function( $hook_suffix ) {
 		||
 		! class_exists( 'SWCFPC_Backend' )
 		||
-		! in_array( $hook_suffix , $imagify_admin_pages, true )
+		! in_array( $hook_suffix, $imagify_admin_pages, true )
 	) {
 		return;
 	}

--- a/inc/3rd-party/wp-cloudflare-super-page-cache.php
+++ b/inc/3rd-party/wp-cloudflare-super-page-cache.php
@@ -2,15 +2,24 @@
 defined( 'ABSPATH' ) || die( 'Cheatin uh?' );
 
 add_action( 'admin_enqueue_scripts', function( $hook_suffix ) {
+
+	$imagify_admin_pages = array(
+		'media_page_imagify-bulk-optimization',
+		'settings_page_imagify',
+		'media_page_imagify-files',
+		'nextgen-gallery_page_imagify-ngg-bulk-optimization'
+	);
+
 	if (
 		! is_admin()
 		||
-		'media_page_imagify-bulk-optimization' !== $hook_suffix
-		||
 		! class_exists( 'SWCFPC_Backend' )
+		||
+		! in_array( $hook_suffix , $imagify_admin_pages, true )
 	) {
 		return;
 	}
 
 	wp_deregister_script( 'swcfpc_sweetalert_js' );
+
 }, 100 );

--- a/inc/3rd-party/wp-cloudflare-super-page-cache.php
+++ b/inc/3rd-party/wp-cloudflare-super-page-cache.php
@@ -1,53 +1,16 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin uh?' );
 
-if ( defined( 'SWCFPC_PLUGIN_PATH' ) ) :
-
-	/**
-	 * Prevent WP Cloudflare Super Page Cache to use its outdated version of SweetAlert where we need ours, and to mess with our CSS styles.
-	 */
-	add_action( 'current_screen', 'imagify_wpcspc_init' );
-	/**
-	 * Dequeue all WP Cloudflare Super Page Cache's styles and scripts where we use ours.
-	 *
-	 * @since  1.10.2
-	 * @author Marko Nikolic
-	 */
-	function imagify_wpcspc_init() {
-		static $done = false;
-
-		if ( $done ) {
-			return;
-		}
-		$done = true;
-
-		if ( ! class_exists( 'SWCFPC_Backend' ) ) {
-			return;
-		}
-
-
-
-		if ( imagify_is_screen( 'bulk' ) ) {
-			// We display a page that uses SweetAlert.
-			imagify_wpcspc_dequeue();
-			return;
-		}
-
+add_action( 'admin_enqueue_scripts', function($hook_suffix) {
+	if (
+		! is_admin()
+		||
+		'media_page_imagify-bulk-optimization' !== $hook_suffix
+		||
+		! class_exists( 'SWCFPC_Backend' )
+	){
+		return;
 	}
 
-	/**
-	 * Prevent WP Cloudflare Super Page Cache to enqueue its styles and scripts.
-	 *
-	 * @since  1.10.2
-	 * @author Marko Nikolic
-	 */
-	function imagify_wpcspc_dequeue() {
-		
-		// $instance = SWCFPC_Backend::getInstance(); // This is the part I need to find out
-		$instance = new SWCFPC_Backend('SW_CLOUDFLARE_PAGECACHE'); // This is the part I need to find out
-
-		remove_action( 'admin_enqueue_scripts', [ $instance, 'load_custom_wp_admin_styles_and_script' ], 0 );
-		
-	}
-
-endif;
+	wp_deregister_script( 'swcfpc_sweetalert_js' );
+}, 100 );


### PR DESCRIPTION
closes #609 

When both Imagify and [WP Cloudflare Super Page Cache](https://wordpress.org/plugins/wp-cloudflare-page-cache/) plugins are enabled at the same time, the Bulk Optimization will not start when "Imagif'em All' is pressed. This was due to the fact they both used the same Sweet Alert script and this caused a conflict.

This fixes that conflict by checking if the WP Cloudflare Super Page Cache Sweet Alert script is enqueued, and if so, it dequeues it.