### PR TITLE
Add filter tag 'imagify_process_webp_content'

### DIFF
--- a/classes/Webp/Picture/Display.php
+++ b/classes/Webp/Picture/Display.php
@@ -51,6 +51,7 @@ class Display {
 	 */
 	public function init() {
 		add_action( 'template_redirect', [ $this, 'start_content_process' ], -1000 );
+		add_filter( 'imagify_process_webp_content', [ $this, 'process_content' ] );
 	}
 
 	/** ----------------------------------------------------------------------------------------- */
@@ -148,7 +149,8 @@ class Display {
 			$content = str_replace( $image['tag'], $tag, $content );
 		}
 
-		return $content;    }
+		return $content;
+	}
 
 	/**
 	 * Remove pre-existing <picture> tags.


### PR DESCRIPTION
This adds a filter tag `imagify_process_webp_content` that filters given HTML using the webp picture tag display's `process_content()`.

The use case for this is when users or other themes/plugins may add or modify HTML after the `template_redirect` hook (where Imagify removes images and replaces images with picture tag elements). For example, a plugin may do some page post-processing that gets a WooCommerce image with WC's `get_image()` so they have the image html tag, but the want to insert it into the page as an imagify picture tag with webp images.

This does not change any functionality other than to make the picture tag replacement into html available to 3rd parties.

Use would be like:
```
$html_with_webp_pic_tags = apply_filters( 'imagify_process_webp_content', $my_html );
```
