### PR TITLE
Closes #663 Smart compression in the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Normal compression is a "lossless" optimization. This means there is no loss of 
 
 ### Is the EXIF data of images removed?
 
-By default EXIF data is removed. It is however possible to keep it by enabling the option.
+EXIF data is not removed.
 
 ### Will the original images be deleted?
 

--- a/classes/Context/AbstractContext.php
+++ b/classes/Context/AbstractContext.php
@@ -1,8 +1,6 @@
 <?php
 namespace Imagify\Context;
 
-defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
-
 /**
  * Abstract used for contexts.
  *
@@ -16,7 +14,6 @@ abstract class AbstractContext implements ContextInterface {
 	 *
 	 * @var    string
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $context;
@@ -26,7 +23,6 @@ abstract class AbstractContext implements ContextInterface {
 	 *
 	 * @var    bool
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $is_network_wide = false;
@@ -39,7 +35,6 @@ abstract class AbstractContext implements ContextInterface {
 	 *     - 'image' to allow only images.
 	 *     - 'not-image' to allow only pdf files.
 	 * @since  1.9
-	 * @access protected
 	 * @see    imagify_get_mime_types()
 	 * @author Grégory Viguier
 	 */
@@ -58,7 +53,6 @@ abstract class AbstractContext implements ContextInterface {
 	 *     @type string $name   The size name.
 	 * }
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $thumbnail_sizes;
@@ -68,26 +62,14 @@ abstract class AbstractContext implements ContextInterface {
 	 *
 	 * @var    bool
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $can_backup;
 
 	/**
-	 * Tell if the optimization process is allowed to keep exif in this context.
-	 *
-	 * @var    bool
-	 * @since  1.9
-	 * @access protected
-	 * @author Grégory Viguier
-	 */
-	protected $can_keep_exif;
-
-	/**
 	 * Get the context "short name".
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return string
@@ -100,7 +82,6 @@ abstract class AbstractContext implements ContextInterface {
 	 * Tell if the context is network-wide.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -113,7 +94,6 @@ abstract class AbstractContext implements ContextInterface {
 	 * Get the type of files this context allows.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @see    imagify_get_mime_types()
 	 * @author Grégory Viguier
 	 *
@@ -130,7 +110,6 @@ abstract class AbstractContext implements ContextInterface {
 	 * Get the thumbnail sizes for this context, except the full size.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return array {
@@ -151,7 +130,6 @@ abstract class AbstractContext implements ContextInterface {
 	 * Tell if the optimization process is allowed resize in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -164,7 +142,6 @@ abstract class AbstractContext implements ContextInterface {
 	 * Tell if the optimization process is allowed to backup in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -174,23 +151,9 @@ abstract class AbstractContext implements ContextInterface {
 	}
 
 	/**
-	 * Tell if the optimization process is allowed to keep exif in this context.
-	 *
-	 * @since  1.9
-	 * @access public
-	 * @author Grégory Viguier
-	 *
-	 * @return bool
-	 */
-	public function can_keep_exif() {
-		return $this->can_keep_exif;
-	}
-
-	/**
 	 * Tell if the current user is allowed to operate Imagify in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $describer Capacity describer. See $this->get_capacity() for possible values. Can also be a "real" user capacity.
@@ -205,7 +168,6 @@ abstract class AbstractContext implements ContextInterface {
 	 * Tell if a user is allowed to operate Imagify in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  int|\WP_User $user_id   A user ID or \WP_User object. Fallback to the current user ID.
@@ -276,7 +238,6 @@ abstract class AbstractContext implements ContextInterface {
 	 * Filter a user capacity used to operate Imagify in this context.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $capacity  The user capacity.

--- a/classes/Context/ContextInterface.php
+++ b/classes/Context/ContextInterface.php
@@ -1,8 +1,6 @@
 <?php
 namespace Imagify\Context;
 
-defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
-
 /**
  * Interface to use for contexts.
  *
@@ -15,7 +13,6 @@ interface ContextInterface {
 	 * Get the main Instance.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @return object Main instance.
@@ -26,7 +23,6 @@ interface ContextInterface {
 	 * Get the context "short name".
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return string
@@ -37,7 +33,6 @@ interface ContextInterface {
 	 * Tell if the context is network-wide.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -48,7 +43,6 @@ interface ContextInterface {
 	 * Get the type of files this context allows.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @see    imagify_get_mime_types()
 	 * @author Grégory Viguier
 	 *
@@ -63,7 +57,6 @@ interface ContextInterface {
 	 * Get the thumbnail sizes for this context, except the full size.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return array {
@@ -83,7 +76,6 @@ interface ContextInterface {
 	 * 0 means to not resize.
 	 *
 	 * @since  1.9.8
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return int
@@ -94,7 +86,6 @@ interface ContextInterface {
 	 * Tell if the optimization process is allowed resize in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -105,7 +96,6 @@ interface ContextInterface {
 	 * Tell if the optimization process is allowed to backup in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -113,21 +103,9 @@ interface ContextInterface {
 	public function can_backup();
 
 	/**
-	 * Tell if the optimization process is allowed to keep exif in this context.
-	 *
-	 * @since  1.9
-	 * @access public
-	 * @author Grégory Viguier
-	 *
-	 * @return bool
-	 */
-	public function can_keep_exif();
-
-	/**
 	 * Tell if the current user is allowed to operate Imagify in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $describer Capacity describer. See $this->get_capacity() for possible values. Can also be a "real" user capacity.
@@ -140,7 +118,6 @@ interface ContextInterface {
 	 * Tell if a user is allowed to operate Imagify in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  int    $user_id   A user ID.
@@ -155,7 +132,6 @@ interface ContextInterface {
 	 *
 	 * @since  1.9
 	 * @since  1.9 The describer 'auto-optimize' is not used anymore.
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $describer Capacity describer. Possible values are like 'manage', 'bulk-optimize', 'manual-optimize', 'auto-optimize'.

--- a/classes/Context/CustomFolders.php
+++ b/classes/Context/CustomFolders.php
@@ -1,7 +1,7 @@
 <?php
 namespace Imagify\Context;
 
-defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
+use \Imagify\Traits\InstanceGetterTrait;
 
 /**
  * Context class used for the custom folders.
@@ -10,14 +10,13 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
  * @author Grégory Viguier
  */
 class CustomFolders extends AbstractContext {
-	use \Imagify\Traits\InstanceGetterTrait;
+	use InstanceGetterTrait;
 
 	/**
 	 * Context "short name".
 	 *
 	 * @var    string
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $context = 'custom-folders';
@@ -35,7 +34,6 @@ class CustomFolders extends AbstractContext {
 	 *     @type string $name   The size name.
 	 * }
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	protected $thumbnail_sizes = [];
@@ -45,7 +43,6 @@ class CustomFolders extends AbstractContext {
 	 * 0 means to not resize.
 	 *
 	 * @since  1.9.8
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return int
@@ -58,7 +55,6 @@ class CustomFolders extends AbstractContext {
 	 * Tell if the optimization process is allowed to backup in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -74,29 +70,9 @@ class CustomFolders extends AbstractContext {
 	}
 
 	/**
-	 * Tell if the optimization process is allowed to keep exif in this context.
-	 *
-	 * @since  1.9
-	 * @access public
-	 * @author Grégory Viguier
-	 *
-	 * @return bool
-	 */
-	public function can_keep_exif() {
-		if ( isset( $this->can_keep_exif ) ) {
-			return $this->can_keep_exif;
-		}
-
-		$this->can_keep_exif = get_imagify_option( 'exif' );
-
-		return $this->can_keep_exif;
-	}
-
-	/**
 	 * Get user capacity to operate Imagify in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $describer Capacity describer. Possible values are like 'manage', 'bulk-optimize', 'manual-optimize', 'auto-optimize'.

--- a/classes/Context/Noop.php
+++ b/classes/Context/Noop.php
@@ -1,7 +1,7 @@
 <?php
 namespace Imagify\Context;
 
-defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
+use \Imagify\Traits\InstanceGetterTrait;
 
 /**
  * Fallback class for contexts.
@@ -10,13 +10,12 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
  * @author Grégory Viguier
  */
 class Noop implements ContextInterface {
-	use \Imagify\Traits\InstanceGetterTrait;
+	use InstanceGetterTrait;
 
 	/**
 	 * Get the context "short name".
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return string
@@ -29,7 +28,6 @@ class Noop implements ContextInterface {
 	 * Tell if the context is network-wide.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -42,7 +40,6 @@ class Noop implements ContextInterface {
 	 * Get the type of files this context allows.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @see    imagify_get_mime_types()
 	 * @author Grégory Viguier
 	 *
@@ -59,7 +56,6 @@ class Noop implements ContextInterface {
 	 * Get the thumbnail sizes for this context, except the full size.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return array {
@@ -81,7 +77,6 @@ class Noop implements ContextInterface {
 	 * 0 means to not resize.
 	 *
 	 * @since  1.9.8
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return int
@@ -91,10 +86,21 @@ class Noop implements ContextInterface {
 	}
 
 	/**
+	 * Tell if the optimization process is allowed resize in this context.
+	 *
+	 * @since  1.9
+	 * @author Grégory Viguier
+	 *
+	 * @return bool
+	 */
+	public function can_resize() {
+		return false;
+	}
+
+	/**
 	 * Tell if the optimization process is allowed to backup in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -104,23 +110,9 @@ class Noop implements ContextInterface {
 	}
 
 	/**
-	 * Tell if the optimization process is allowed to keep exif in this context.
-	 *
-	 * @since  1.9
-	 * @access public
-	 * @author Grégory Viguier
-	 *
-	 * @return bool
-	 */
-	public function can_keep_exif() {
-		return true;
-	}
-
-	/**
 	 * Tell if the current user is allowed to operate Imagify in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $describer Capacity describer. See $this->get_capacity() for possible values. Can also be a "real" user capacity.
@@ -135,7 +127,6 @@ class Noop implements ContextInterface {
 	 * Tell if a user is allowed to operate Imagify in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  int    $user_id   A user ID.
@@ -151,7 +142,6 @@ class Noop implements ContextInterface {
 	 * Get user capacity to operate Imagify in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $describer Capacity describer. Possible values are like 'manage', 'bulk-optimize', 'manual-optimize', 'auto-optimize'.

--- a/classes/Context/WP.php
+++ b/classes/Context/WP.php
@@ -1,8 +1,6 @@
 <?php
 namespace Imagify\Context;
 
-defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
-
 /**
  * Context class used for the WP media library.
  *
@@ -17,7 +15,6 @@ class WP extends AbstractContext {
 	 *
 	 * @var    string
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $context = 'wp';
@@ -27,7 +24,6 @@ class WP extends AbstractContext {
 	 *
 	 * @var    int
 	 * @since  1.9.8
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $resizing_threshold;
@@ -36,7 +32,6 @@ class WP extends AbstractContext {
 	 * Get the thumbnail sizes for this context, except the full size.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return array {
@@ -64,7 +59,6 @@ class WP extends AbstractContext {
 	 * 0 means to not resize.
 	 *
 	 * @since  1.9.8
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return int
@@ -87,7 +81,6 @@ class WP extends AbstractContext {
 	 * Tell if the optimization process is allowed to backup in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -103,29 +96,9 @@ class WP extends AbstractContext {
 	}
 
 	/**
-	 * Tell if the optimization process is allowed to keep exif in this context.
-	 *
-	 * @since  1.9
-	 * @access public
-	 * @author Grégory Viguier
-	 *
-	 * @return bool
-	 */
-	public function can_keep_exif() {
-		if ( isset( $this->can_keep_exif ) ) {
-			return $this->can_keep_exif;
-		}
-
-		$this->can_keep_exif = get_imagify_option( 'exif' );
-
-		return $this->can_keep_exif;
-	}
-
-	/**
 	 * Get user capacity to operate Imagify in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $describer Capacity describer. Possible values are like 'manage', 'bulk-optimize', 'manual-optimize', 'auto-optimize'.

--- a/classes/Optimization/File.php
+++ b/classes/Optimization/File.php
@@ -3,8 +3,6 @@ namespace Imagify\Optimization;
 
 use Imagify_Requirements;
 
-defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
-
 /**
  * A generic optimization class focussed on the file itself.
  *
@@ -18,7 +16,6 @@ class File {
 	 *
 	 * @var    string
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $path;
@@ -28,7 +25,6 @@ class File {
 	 *
 	 * @var    bool
 	 * @since  1.9
-	 * @access protected
 	 * @see    $this->is_image()
 	 * @author Grégory Viguier
 	 */
@@ -39,7 +35,6 @@ class File {
 	 *
 	 * @var    array
 	 * @since  1.9
-	 * @access protected
 	 * @see    $this->get_file_type()
 	 * @author Grégory Viguier
 	 */
@@ -50,7 +45,6 @@ class File {
 	 *
 	 * @var    \Imagify_Filesystem
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $filesystem;
@@ -60,7 +54,6 @@ class File {
 	 *
 	 * @var    \WP_Image_Editor_Imagick|\WP_Image_Editor_GD|WP_Error.
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $editor;
@@ -70,7 +63,6 @@ class File {
 	 *
 	 * @var    array
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $options = [];
@@ -79,7 +71,6 @@ class File {
 	 * The constructor.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $file_path Absolute path to the file.
@@ -93,7 +84,6 @@ class File {
 	 * Tell if the file is valid.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -106,7 +96,6 @@ class File {
 	 * Tell if the file can be processed.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool|WP_Error
@@ -178,7 +167,6 @@ class File {
 	 * Resize (and rotate) an image if it is bigger than the maximum width provided.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 * @author Remy Perona
 	 *
@@ -301,7 +289,6 @@ class File {
 	 * Warning: If the destination file already exists, it will be overwritten.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  array $destination {
@@ -386,7 +373,6 @@ class File {
 	 *
 	 * @since  1.9
 	 * @since  1.9.8 Added $backup_source argument.
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $backup_path   The backup path.
@@ -444,7 +430,6 @@ class File {
 	 * Optimize a file with Imagify.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  array $args         {
@@ -453,7 +438,6 @@ class File {
 	 *     @type bool   $backup             False to prevent backup. True to follow the user's setting. A backup can't be forced.
 	 *     @type string $backup_path        If a backup must be done, this is the path to use. Default is the backup path used for the WP Media Library.
 	 *     @type int    $optimization_level The optimization level (2=ultra, 1=aggressive, 0=normal).
-	 *     @type bool   $keep_exif          To keep exif data or not.
 	 *     @type string $convert            Set to 'webp' to convert the image to WebP.
 	 *     @type string $context            The context.
 	 *     @type int    $original_size      The file size, sent to the API.
@@ -466,7 +450,6 @@ class File {
 			'backup_path'        => null,
 			'backup_source'      => null,
 			'optimization_level' => 0,
-			'keep_exif'          => true,
 			'convert'            => '',
 			'context'            => 'wp',
 			'original_size'      => 0,
@@ -519,7 +502,7 @@ class File {
 			'normal'        => 0 === $args['optimization_level'],
 			'aggressive'    => 1 === $args['optimization_level'],
 			'ultra'         => 2 === $args['optimization_level'],
-			'keep_exif'     => $args['keep_exif'],
+			'keep_exif'     => true,
 			'original_size' => $args['original_size'],
 			'context'       => $args['context'],
 		];
@@ -596,7 +579,6 @@ class File {
 	 * Get an image editor instance (WP_Image_Editor_Imagick, WP_Image_Editor_GD).
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @return WP_Image_Editor_Imagick|WP_Image_Editor_GD|WP_Error
@@ -631,7 +613,6 @@ class File {
 	 * Get the image editor methods we will use.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @return array
@@ -666,7 +647,6 @@ class File {
 	 * Check if a file exceeds the weight limit (> 5mo).
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -685,7 +665,6 @@ class File {
 	 * Tell if the current file is supported for a given context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @see    imagify_get_mime_types()
 	 * @author Grégory Viguier
 	 *
@@ -700,7 +679,6 @@ class File {
 	 * Tell if the file is an image.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -719,7 +697,6 @@ class File {
 	 * Tell if the file is a pdf.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -732,7 +709,6 @@ class File {
 	 * Get the file mime type.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return string
@@ -745,7 +721,6 @@ class File {
 	 * Get the file extension.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return string|null
@@ -758,7 +733,6 @@ class File {
 	 * Get the file path.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return string
@@ -771,7 +745,6 @@ class File {
 	 * Replace the file extension by WebP.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return string|bool The file path on success. False if not an image or on failure.
@@ -793,7 +766,6 @@ class File {
 	 * Rejects "path/to/.webp" files.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -806,7 +778,6 @@ class File {
 	 * Get the file mime type + file extension.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @see    wp_check_filetype()
 	 * @author Grégory Viguier
 	 *
@@ -838,7 +809,6 @@ class File {
 	 * If the media is an image, get its width and height.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return array
@@ -863,7 +833,6 @@ class File {
 	 * Get a plugin’s option.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $option_name The option nme.

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -1,11 +1,10 @@
 <?php
 namespace Imagify\Optimization\Process;
 
+use Imagify\Deprecated\Traits\Optimization\Process\AbstractProcessDeprecatedTrait;
 use Imagify\Job\MediaOptimization;
 use Imagify\Optimization\Data\DataInterface;
 use Imagify\Optimization\File;
-
-defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
 /**
  * Abstract class used to optimize medias.
@@ -14,7 +13,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
  * @author Grégory Viguier
  */
 abstract class AbstractProcess implements ProcessInterface {
-	use \Imagify\Deprecated\Traits\Optimization\Process\AbstractProcessDeprecatedTrait;
+	use AbstractProcessDeprecatedTrait;
 
 	/**
 	 * The suffix used in the thumbnail size name.
@@ -49,7 +48,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 *
 	 * @var    DataInterface
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $data;
@@ -59,7 +57,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 *
 	 * @var    array
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $data_format = [
@@ -76,7 +73,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 *
 	 * @var    File
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $file;
@@ -86,7 +82,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 *
 	 * @var    Imagify_Filesystem
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $filesystem;
@@ -96,7 +91,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 *
 	 * @var    array
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $options = [];
@@ -105,7 +99,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * The constructor.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @see    self::constructor_accepts()
 	 * @author Grégory Viguier
 	 *
@@ -129,7 +122,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Tell if the given entry can be accepted in the constructor.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  mixed $id Whatever.
@@ -150,7 +142,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Get the data instance.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return DataInterface|false
@@ -163,7 +154,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Get the media instance.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return MediaInterface|false
@@ -180,7 +170,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Get the File instance of the original file.
 	 *
 	 * @since  1.9.8
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return File|false
@@ -203,7 +192,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Get the File instance of the full size file.
 	 *
 	 * @since  1.9.8
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return File|false
@@ -226,7 +214,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Tell if the current media is valid.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -239,7 +226,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Tell if the current user is allowed to operate Imagify in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $describer Capacity describer. See \Imagify\Context\ContextInterface->get_capacity() for possible values. Can also be a "real" user capacity.
@@ -264,7 +250,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Optimize a media files.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  int   $optimization_level The optimization level (0=normal, 1=aggressive, 2=ultra).
@@ -311,7 +296,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Re-optimize a media files with a different level.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  int   $optimization_level The optimization level (0=normal, 1=aggressive, 2=ultra).
@@ -356,7 +340,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Optimize several file sizes by pushing tasks into the queue.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @see    MediaOptimization->task_before()
 	 * @see    MediaOptimization->task_after()
 	 * @author Grégory Viguier
@@ -479,7 +462,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Optimize one file with Imagify directly.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $size               The media size.
@@ -683,7 +665,7 @@ abstract class AbstractProcess implements ProcessInterface {
 						'backup_source'      => 'full' === $thumb_size ? $media->get_original_path() : null,
 						'optimization_level' => $optimization_level,
 						'convert'            => $webp ? 'webp' : '',
-						'keep_exif'          => $this->can_keep_exif( $size ),
+						'keep_exif'          => true,
 						'context'            => $media->get_context(),
 						'original_size'      => $response['file_size'],
 					] );
@@ -740,7 +722,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Compare the file size of a file and its WebP version: if the WebP version is heavier than the non-WebP file, delete it.
 	 *
 	 * @since  1.9.4
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  array $args {
@@ -850,7 +831,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Restore the media files from the backup file.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool|WP_Error True on success. A \WP_Error instance on failure.
@@ -963,7 +943,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Restore the thumbnails.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @return bool|WP_Error True on success. A \WP_Error instance on failure.
@@ -992,7 +971,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Delete the backup file.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function delete_backup() {
@@ -1022,7 +1000,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Create a temporary copy of a size file.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $size  The image size name.
@@ -1172,7 +1149,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Get the path to a temporary copy of a size file.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $size  The image size name.
@@ -1212,7 +1188,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Maybe resize an image.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $size   The size name.
@@ -1322,7 +1297,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Tell if a size should be resized.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $size The size name.
@@ -1350,7 +1324,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Tell if a size should be backuped.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $size The size name.
@@ -1369,29 +1342,6 @@ abstract class AbstractProcess implements ProcessInterface {
 		return $this->get_media()->get_context_instance()->can_backup();
 	}
 
-	/**
-	 * Tell if a size should keep exif.
-	 *
-	 * @since  1.9
-	 * @access protected
-	 * @author Grégory Viguier
-	 *
-	 * @param  string $size The size name.
-	 * @return bool
-	 */
-	protected function can_keep_exif( $size ) {
-		if ( ! $this->is_valid() ) {
-			return false;
-		}
-
-		if ( 'full' !== $size && 'full' . static::WEBP_SUFFIX !== $size ) {
-			// We keep exif only on the main file and its WebP version.
-			return false;
-		}
-
-		return $this->get_media()->get_context_instance()->can_keep_exif();
-	}
-
 
 	/** ----------------------------------------------------------------------------------------- */
 	/** WEBP ==================================================================================== */
@@ -1401,7 +1351,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Generate WebP images if they are missing.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool|WP_Error True if successfully launched. A \WP_Error instance on failure.
@@ -1459,7 +1408,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 *
 	 * @since  1.9
 	 * @since  1.9.6 Return WP_Error or true.
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  bool $keep_full Set to true to keep the full size.
@@ -1518,7 +1466,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 *
 	 * @since  1.9
 	 * @since  1.9.6 Return WP_Error or true.
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $file_path Path to the non-WebP file.
@@ -1582,7 +1529,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Tell if a thumbnail size is an "Imagify WebP" size.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $size_name The size name.
@@ -1606,7 +1552,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Tell if the media has WebP versions.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return bool
@@ -1637,7 +1582,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Make sure the file is an image before using this method.
 	 *
 	 * @since  1.9.5
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param string $file_path Path to the file.
@@ -1684,7 +1628,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Tell if a process is running for this media.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return string|bool The action if locked ('optimizing' or 'restoring'). False if not locked.
@@ -1710,7 +1653,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Set the running status to "running" for 10 minutes.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param string $action The action performed behind this lock: 'optimizing' or 'restoring'.
@@ -1733,7 +1675,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Unset the running status.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function unlock() {
@@ -1752,7 +1693,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Get the name of the transient that stores the lock status.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @return string|bool The name on success. False on failure.
@@ -1775,7 +1715,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Validate the lock action.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $action The action performed behind this lock: 'optimizing' or 'restoring'.
@@ -1804,7 +1743,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Tell if a size already has optimization data.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $size The size name.
@@ -1820,7 +1758,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Update the optimization data for a size.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  object $response The API response.
@@ -1919,7 +1856,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Get a plugin’s option.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $option_name The option nme.
@@ -1940,7 +1876,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * If not provided (false, null), fallback to the level set in the plugin's settings.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  mixed $optimization_level The optimization level.

--- a/imagify.php
+++ b/imagify.php
@@ -3,7 +3,7 @@
  * Plugin Name: Imagify
  * Plugin URI: https://wordpress.org/plugins/imagify/
  * Description: Dramatically reduce image file sizes without losing quality, make your website load faster, boost your SEO and save money on your bandwidth using Imagify, the new most advanced image optimization tool.
- * Version: 1.10
+ * Version: 2.0
  * Requires at least: 5.3
  * Requires PHP: 7.0
  * Author: WP Media
@@ -21,7 +21,7 @@
 defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
 // Imagify defines.
-define( 'IMAGIFY_VERSION',        '1.10' );
+define( 'IMAGIFY_VERSION',        '2.0' );
 define( 'IMAGIFY_SLUG',           'imagify' );
 define( 'IMAGIFY_FILE',           __FILE__ );
 define( 'IMAGIFY_PATH',           realpath( plugin_dir_path( IMAGIFY_FILE ) ) . '/' );

--- a/inc/3rd-party/nextgen-gallery/classes/Context/NGG.php
+++ b/inc/3rd-party/nextgen-gallery/classes/Context/NGG.php
@@ -1,7 +1,8 @@
 <?php
 namespace Imagify\ThirdParty\NGG\Context;
 
-defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
+use Imagify\Context\AbstractContext;
+use Imagify\Traits\InstanceGetterTrait;
 
 /**
  * Context class used for the WP media library.
@@ -9,15 +10,14 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
  * @since  1.9
  * @author Grégory Viguier
  */
-class NGG extends \Imagify\Context\AbstractContext {
-	use \Imagify\Traits\InstanceGetterTrait;
+class NGG extends AbstractContext {
+	use InstanceGetterTrait;
 
 	/**
 	 * Context "short name".
 	 *
 	 * @var    string
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $context = 'ngg';
@@ -30,7 +30,6 @@ class NGG extends \Imagify\Context\AbstractContext {
 	 *     - 'image' to allow only images.
 	 *     - 'not-image' to allow only pdf files.
 	 * @since  1.9
-	 * @access protected
 	 * @see    imagify_get_mime_types()
 	 * @author Grégory Viguier
 	 */
@@ -49,7 +48,6 @@ class NGG extends \Imagify\Context\AbstractContext {
 	 *     @type string $name   The size name.
 	 * }
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	protected $thumbnail_sizes = [];
@@ -59,27 +57,15 @@ class NGG extends \Imagify\Context\AbstractContext {
 	 *
 	 * @var    bool
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $can_backup = true;
-
-	/**
-	 * Tell if the optimization process is allowed to keep exif in this context.
-	 *
-	 * @var    bool
-	 * @since  1.9
-	 * @access protected
-	 * @author Grégory Viguier
-	 */
-	protected $can_keep_exif = true;
 
 	/**
 	 * Get images max width for this context. This is used when resizing.
 	 * 0 means to not resize.
 	 *
 	 * @since  1.9.8
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return int
@@ -92,7 +78,6 @@ class NGG extends \Imagify\Context\AbstractContext {
 	 * Get user capacity to operate Imagify in this context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $describer Capacity describer. Possible values are like 'manage', 'bulk-optimize', 'manual-optimize', 'auto-optimize'.

--- a/inc/classes/class-imagify-files-list-table.php
+++ b/inc/classes/class-imagify-files-list-table.php
@@ -33,7 +33,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 *
 	 * @var    array
 	 * @since  1.7
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $folders = array();
@@ -43,7 +42,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 *
 	 * @var    object Imagify_Filesystem
 	 * @since  1.7.1
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $filesystem;
@@ -53,7 +51,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 *
 	 * @var    object Imagify_Views
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $views;
@@ -62,7 +59,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Constructor.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param array $args An associative array of arguments.
@@ -85,7 +81,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Prepares the list of items for displaying.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function prepare_items() {
@@ -233,7 +228,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Message to be displayed when there are no items.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function no_items() {
@@ -302,7 +296,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Display views.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function views() {
@@ -420,7 +413,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Get an associative array ( option_name => option_title ) with the list of bulk actions available on this table.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return array
@@ -436,7 +428,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * 'internal-name' => 'Title'
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return array
@@ -462,7 +453,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * The second format will make the initial sorting order be descending.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return array
@@ -480,7 +470,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Get a column contents.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $column The column "name": "cb", "title", "optimization_level", etc.
@@ -501,7 +490,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Handles the checkbox column output.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param object $item The current item. It must contain at least a $process property.
@@ -518,7 +506,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Handles the title column output.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param object $item The current item. It must contain at least a $process property.
@@ -569,7 +556,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Handles the parent folder column output.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param object $item The current item. It must contain at least a $process property.
@@ -605,7 +591,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Handles the optimization data column output.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param object $item The current item. It must contain at least a $process property.
@@ -658,7 +643,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Handles the status column output.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param object $item The current item. It must contain at least a $process property.
@@ -694,7 +678,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Handles the optimization level column output.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param object $item The current item. It must contain at least a $process property.
@@ -711,7 +694,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Handles the actions column output.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param object $item The current item. It must contain at least a $process property.
@@ -749,7 +731,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Prints a button to optimize the file.
 	 *
 	 * @since  1.7
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param object $item The current item. It must contain at least a $process property.
@@ -778,7 +759,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Prints a button to retry to optimize the file.
 	 *
 	 * @since  1.7
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param object $item The current item. It must contain at least a $process property.
@@ -810,7 +790,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Prints buttons to re-optimize the file to other levels.
 	 *
 	 * @since  1.7
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param object $item The current item. It must contain at least a $process property.
@@ -836,20 +815,18 @@ class Imagify_Files_List_Table extends WP_List_Table {
 		$data        = [];
 		$url_args    = [ 'attachment_id' => $media->get_id() ];
 
-		foreach ( [ 2, 1, 0 ] as $level ) {
-			/**
-			 * Display a link if:
-			 * - the level is lower than the one used to optimize the media,
-			 * - or, the level is higher and the media is not already optimized.
-			 */
-			if ( $media_level < $level || ( $media_level > $level && ! $is_already_optimized ) ) {
-				$url_args['optimization_level'] = $level;
-				$data['optimization_level']     = $level;
-				$data['url']                    = get_imagify_admin_url( 'reoptimize-file', $url_args );
+		if ( $media_level < 1 ) {
+			$url_args['optimization_level'] = 2;
+			$data['optimization_level']     = 2;
+			$data['url']                    = get_imagify_admin_url( 'reoptimize-file', $url_args );
 
-				echo $this->views->get_template( 'button/re-optimize', $data );
-				echo '<br/>';
-			}
+			echo $this->views->get_template( 'button/re-optimize', $data );
+		} elseif ( $media_level > 0 ) {
+			$url_args['optimization_level'] = 0;
+			$data['optimization_level']     = 0;
+			$data['url']                    = get_imagify_admin_url( 'reoptimize-file', $url_args );
+
+			echo $this->views->get_template( 'button/re-optimize', $data );
 		}
 	}
 
@@ -857,7 +834,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Prints a button to generate WebP versions if they are missing.
 	 *
 	 * @since  1.7
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param object $item The current item. It must contain at least a $process property.
@@ -874,7 +850,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Prints a button to delete WebP versions when the status is "already_optimized".
 	 *
 	 * @since  1.9.6
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param object $item The current item. It must contain at least a $process property.
@@ -891,7 +866,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Prints a button to restore the file.
 	 *
 	 * @since  1.7
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param object $item The current item. It must contain at least a $process property.
@@ -915,7 +889,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Prints a button to check if the file has been modified or not.
 	 *
 	 * @since  1.7
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param object $item The current item. It must contain at least a $process property.
@@ -933,7 +906,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Prints a button for the comparison tool (before / after optimization).
 	 *
 	 * @since  1.7
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param object $item The current item. It must contain at least a $process property.
@@ -981,7 +953,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * It may happen if the $item doesn't come from the prepare() method.
 	 *
 	 * @since  1.7
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  object $item The current item. It must contain at least a $process property.
@@ -1018,7 +989,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Get the name of the default primary column.
 	 *
 	 * @since  1.7
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @return string Name of the default primary column, in this case, 'title'.
@@ -1031,7 +1001,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Get a list of CSS classes for the WP_List_Table table tag.
 	 *
 	 * @since  1.7
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @return array List of CSS classes for the table tag.
@@ -1044,7 +1013,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Allow to save the screen options when submitted by the user.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  bool|int $status Screen option value. Default false to skip.
@@ -1064,7 +1032,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Get the requested folder filter.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return string
@@ -1084,7 +1051,6 @@ class Imagify_Files_List_Table extends WP_List_Table {
 	 * Get the requested status filter.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @return string

--- a/inc/classes/class-imagify-options.php
+++ b/inc/classes/class-imagify-options.php
@@ -1,5 +1,4 @@
 <?php
-defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
 /**
  * Class that handles the plugin options.
@@ -21,7 +20,6 @@ class Imagify_Options extends Imagify_Abstract_Options {
 	 *
 	 * @var    string
 	 * @since  1.7
-	 * @access protected
 	 */
 	protected $identifier = 'settings';
 
@@ -32,7 +30,6 @@ class Imagify_Options extends Imagify_Abstract_Options {
 	 *
 	 * @var    array
 	 * @since  1.7
-	 * @access protected
 	 */
 	protected $default_values = array(
 		'api_key'             => '',
@@ -45,7 +42,6 @@ class Imagify_Options extends Imagify_Abstract_Options {
 		'display_webp'        => 0,
 		'display_webp_method' => 'picture',
 		'cdn_url'             => '',
-		'exif'                => 0,
 		'disallowed-sizes'    => array(),
 		'admin_bar_menu'      => 0,
 		'partner_links'       => 0,
@@ -57,7 +53,6 @@ class Imagify_Options extends Imagify_Abstract_Options {
 	 *
 	 * @var    array
 	 * @since  1.7
-	 * @access protected
 	 */
 	protected $reset_values = array(
 		'optimization_level' => 1,
@@ -73,7 +68,6 @@ class Imagify_Options extends Imagify_Abstract_Options {
 	 *
 	 * @var    object
 	 * @since  1.7
-	 * @access protected
 	 */
 	protected static $_instance;
 
@@ -83,7 +77,6 @@ class Imagify_Options extends Imagify_Abstract_Options {
 	 *
 	 * @since  1.7
 	 * @author Grégory Viguier
-	 * @access protected
 	 */
 	protected function __construct() {
 		if ( defined( 'IMAGIFY_API_KEY' ) && IMAGIFY_API_KEY ) {
@@ -119,7 +112,6 @@ class Imagify_Options extends Imagify_Abstract_Options {
 	 *
 	 * @since  1.7
 	 * @author Grégory Viguier
-	 * @access public
 	 *
 	 * @return object Main instance.
 	 */
@@ -141,7 +133,6 @@ class Imagify_Options extends Imagify_Abstract_Options {
 	 *
 	 * @since  1.7
 	 * @author Grégory Viguier
-	 * @access public
 	 *
 	 * @param  string $key     The option key.
 	 * @param  mixed  $value   The value.
@@ -171,7 +162,6 @@ class Imagify_Options extends Imagify_Abstract_Options {
 			case 'resize_larger':
 			case 'convert_to_webp':
 			case 'display_webp':
-			case 'exif':
 			case 'admin_bar_menu':
 			case 'partner_links':
 				return 1;
@@ -233,7 +223,6 @@ class Imagify_Options extends Imagify_Abstract_Options {
 	 *
 	 * @since  1.7
 	 * @author Grégory Viguier
-	 * @access public
 	 *
 	 * @param  string $values The option value.
 	 * @return array

--- a/inc/classes/class-imagify-options.php
+++ b/inc/classes/class-imagify-options.php
@@ -33,7 +33,7 @@ class Imagify_Options extends Imagify_Abstract_Options {
 	 */
 	protected $default_values = array(
 		'api_key'             => '',
-		'optimization_level'  => 0,
+		'optimization_level'  => 2,
 		'auto_optimize'       => 0,
 		'backup'              => 0,
 		'resize_larger'       => 0,
@@ -55,7 +55,7 @@ class Imagify_Options extends Imagify_Abstract_Options {
 	 * @since  1.7
 	 */
 	protected $reset_values = array(
-		'optimization_level' => 1,
+		'optimization_level' => 2,
 		'auto_optimize'      => 1,
 		'backup'             => 1,
 		'convert_to_webp'    => 1,

--- a/inc/functions/admin-ui.php
+++ b/inc/functions/admin-ui.php
@@ -232,20 +232,18 @@ function get_imagify_attachment_reoptimize_link( $process ) {
 		];
 	}
 
-	foreach ( [ 2, 1, 0 ] as $level ) {
-		/**
-		 * Display a link if:
-		 * - the level is lower than the one used to optimize the media,
-		 * - or, the level is higher and the media is not already optimized.
-		 */
-		if ( $media_level < $level || ( $media_level > $level && ! $is_already_optimized ) ) {
-			$url_args['optimization_level'] = $level;
-			$data['optimization_level']     = $level;
-			$data['url']                    = get_imagify_admin_url( 'manual-reoptimize', $url_args );
+	if ( $media_level < 1 ) {
+		$url_args['optimization_level'] = 2;
+		$data['optimization_level']     = 2;
+		$data['url']                    = get_imagify_admin_url( 'reoptimize-file', $url_args );
 
-			$output .= $views->get_template( 'button/re-optimize', $data );
-			$output .= '<br/>';
-		}
+		$output .= $views->get_template( 'button/re-optimize', $data );
+	} elseif ( $media_level > 0 ) {
+		$url_args['optimization_level'] = 0;
+		$data['optimization_level']     = 0;
+		$data['url']                    = get_imagify_admin_url( 'reoptimize-file', $url_args );
+
+		$output .= $views->get_template( 'button/re-optimize', $data );
 	}
 
 	return $output;

--- a/inc/functions/admin-ui.php
+++ b/inc/functions/admin-ui.php
@@ -235,13 +235,13 @@ function get_imagify_attachment_reoptimize_link( $process ) {
 	if ( $media_level < 1 ) {
 		$url_args['optimization_level'] = 2;
 		$data['optimization_level']     = 2;
-		$data['url']                    = get_imagify_admin_url( 'reoptimize-file', $url_args );
+		$data['url']                    = get_imagify_admin_url( 'manual-reoptimize', $url_args );
 
 		$output .= $views->get_template( 'button/re-optimize', $data );
 	} elseif ( $media_level > 0 ) {
 		$url_args['optimization_level'] = 0;
 		$data['optimization_level']     = 0;
-		$data['url']                    = get_imagify_admin_url( 'reoptimize-file', $url_args );
+		$data['url']                    = get_imagify_admin_url( 'manual-reoptimize', $url_args );
 
 		$output .= $views->get_template( 'button/re-optimize', $data );
 	}

--- a/inc/functions/common.php
+++ b/inc/functions/common.php
@@ -365,10 +365,8 @@ function imagify_get_optimization_level_label( $level, $format = '%s' ) {
 
 		switch ( $level ) {
 			case 2:
-				$icon .= '<polygon points="11.6054688 11.6054688 8.7890625 11.6054688 8.7890625 0.39453125 11.6054688 0.39453125"/><polygon points="7.39453125 11.6054688 4.60546875 11.6054688 4.60546875 3.89453125 7.39453125 3.89453125"/><polygon points="3.2109375 11.6054688 0.39453125 11.6054688 0.39453125 6 3.2109375 6"/>';
-				break;
 			case 1:
-				$icon .= '<polygon fill="#CCD1D6" points="11.6054688 11.6054688 8.7890625 11.6054688 8.7890625 0.39453125 11.6054688 0.39453125"/><polygon points="7.39453125 11.6054688 4.60546875 11.6054688 4.60546875 3.89453125 7.39453125 3.89453125"/><polygon points="3.2109375 11.6054688 0.39453125 11.6054688 0.39453125 6 3.2109375 6"/>';
+				$icon .= '<polygon points="11.6054688 11.6054688 8.7890625 11.6054688 8.7890625 0.39453125 11.6054688 0.39453125"/><polygon points="7.39453125 11.6054688 4.60546875 11.6054688 4.60546875 3.89453125 7.39453125 3.89453125"/><polygon points="3.2109375 11.6054688 0.39453125 11.6054688 0.39453125 6 3.2109375 6"/>';
 				break;
 			case 0:
 				$icon .= '<polygon fill="#CCD1D6" points="11.6054688 11.6054688 8.7890625 11.6054688 8.7890625 0.39453125 11.6054688 0.39453125"/><polygon fill="#CCD1D6" points="7.39453125 11.6054688 4.60546875 11.6054688 4.60546875 3.89453125 7.39453125 3.89453125"/><polygon points="3.2109375 11.6054688 0.39453125 11.6054688 0.39453125 6 3.2109375 6"/>';
@@ -381,11 +379,10 @@ function imagify_get_optimization_level_label( $level, $format = '%s' ) {
 
 	switch ( $level ) {
 		case 2:
-			return sprintf( $format, __( 'Ultra', 'imagify' ) );
 		case 1:
-			return sprintf( $format, __( 'Aggressive', 'imagify' ) );
+			return sprintf( $format, __( 'Smart', 'imagify' ) );
 		case 0:
-			return sprintf( $format, __( 'Normal', 'imagify' ) );
+			return sprintf( $format, __( 'Lossless', 'imagify' ) );
 	}
 
 	return '';

--- a/inc/functions/common.php
+++ b/inc/functions/common.php
@@ -246,11 +246,6 @@ function imagify_get_external_url( $target, $query_args = array() ) {
 			$url = 'https://www.facebook.com/sharer/sharer.php?u=' . $url;
 			break;
 
-		case 'exif':
-			/* translators: URL to a Wikipedia page explaining what EXIF means. */
-			$url = __( 'https://en.wikipedia.org/wiki/Exchangeable_image_file_format', 'imagify' );
-			break;
-
 		case 'contact':
 			$lang  = imagify_get_current_lang_in( 'fr' );
 			$paths = array(

--- a/readme.txt
+++ b/readme.txt
@@ -198,7 +198,7 @@ Do not waste your time resizing and optimizing your images in Photoshop. Imagify
 
 =Is the EXIF data of images removed?=
 
-By default EXIF data is removed. It is possible to keep it with the WordPress plugin by enabling the option in the Imagify Settings page.
+EXIF data is not removed.
 
 =I used Kraken, Optimus, EWWW or WP Smush, will Imagify further optimize my images?=
 

--- a/views/button/re-optimize.php
+++ b/views/button/re-optimize.php
@@ -18,9 +18,9 @@ if ( ! isset( $data['atts']['data-processing-label'] ) ) {
 }
 
 $level_labels = [
-	__( 'Normal', 'imagify' ),
-	__( 'Aggressive', 'imagify' ),
-	__( 'Ultra', 'imagify' ),
+	0 => __( 'Lossless', 'imagify' ),
+	1 => __( 'Smart', 'imagify' ),
+	2 => __( 'Smart', 'imagify' ),
 ];
 $level_label = $level_labels[ $data['optimization_level'] ];
 
@@ -33,7 +33,7 @@ $html_atts = $this->build_attributes( $data['atts'] );
 		<?php
 		printf(
 			/* translators: %s is an optimization level. */
-			esc_html__( 'Re-Optimize to %s', 'imagify' ),
+			esc_html__( 'Re-Optimize with %s compression', 'imagify' ),
 			'</span>' . esc_html( $level_label ) . '<span class="imagify-hide-if-small">'
 		);
 		?>

--- a/views/page-settings.php
+++ b/views/page-settings.php
@@ -40,45 +40,6 @@ $wrapper_class = isset( $notices[ $notice ] ) || defined( 'WP_ROCKET_VERSION' ) 
 
 							<h2 class="imagify-options-title"><?php _e( 'General Settings', 'imagify' ); ?></h2>
 
-							<p class="imagify-options-subtitle" id="imagify-optimization-level-label">
-								<?php _e( 'Optimization Level', 'imagify' ); ?>
-
-								<span class="imagify-info">
-									<span class="dashicons dashicons-info"></span>
-									<a href="#imagify-more-info" class="imagify-modal-trigger"><?php _e( 'More info?', 'imagify' ); ?></a>
-								</span>
-							</p>
-
-							<div class="imagify-setting-optim-level">
-								<p class="imagify-inline-options">
-									<input type="radio" id="imagify-optimization_level_normal" name="<?php echo $option_name; ?>[optimization_level]" value="0" <?php checked( $options->get( 'optimization_level' ), 0 ); ?> aria-describedby="imagify-optimization-level-label">
-									<label for="imagify-optimization_level_normal">
-										<?php _e( 'Normal', 'imagify' ); ?>
-									</label>
-
-									<input type="radio" id="imagify-optimization_level_aggro" name="<?php echo $option_name; ?>[optimization_level]" value="1" <?php checked( $options->get( 'optimization_level' ), 1 ); ?>  aria-describedby="imagify-optimization-level-label">
-									<label for="imagify-optimization_level_aggro">
-										<?php _e( 'Aggressive', 'imagify' ); ?>
-									</label>
-
-									<input type="radio" id="imagify-optimization_level_ultra" name="<?php echo $option_name; ?>[optimization_level]" value="2" <?php checked( $options->get( 'optimization_level' ), 2 ); ?> aria-describedby="imagify-optimization-level-label">
-									<label for="imagify-optimization_level_ultra">
-										<?php _e( 'Ultra', 'imagify' ); ?>
-									</label>
-								</p>
-
-								<p class="imagify-visual-comparison-text">
-									<?php
-									printf(
-										/* translators: 1 is a button tag start, 2 is the button tag end. */
-										__( 'Need help to choose? %1$sTry the Visual Comparison%2$s', 'imagify' ),
-										'<button type="button" class="button button-primary button-mini-flat imagify-visual-comparison-btn imagify-modal-trigger" data-target="#imagify-visual-comparison">',
-										'</button>'
-									);
-									?>
-								</p>
-							</div>
-
 							<p class="imagify-setting-line">
 							<?php
 							$settings->field_checkbox( array(

--- a/views/page-settings.php
+++ b/views/page-settings.php
@@ -107,20 +107,6 @@ $wrapper_class = isset( $notices[ $notice ] ) || defined( 'WP_ROCKET_VERSION' ) 
 									?>
 								</strong>
 							</p>
-
-							<p class="imagify-setting-line">
-								<?php
-								$info  = __( 'EXIF data is information stored in your pictures like shutter speed, exposure compensation, ISO, etc...', 'imagify' );
-								$info .= ' <a href="' . esc_url( imagify_get_external_url( 'exif' ) ) . '" target="_blank">' . __( 'Learn more', 'imagify' ) . '</a><br/><br/>';
-								$info .= __( 'If you are a photographer, you may be interested in this option if you are displaying info like the model of your camera on your pages. Also, keeping EXIF data can fix some colorimetric problems.', 'imagify' );
-
-								$settings->field_checkbox( array(
-									'option_name' => 'exif',
-									'label'       => __( 'Keep all EXIF data from your images', 'imagify' ),
-									'info'        => $info,
-								) );
-								?>
-							</p>
 						</div>
 					</div>
 

--- a/views/part-bulk-optimization-table-row-folder-type.php
+++ b/views/part-bulk-optimization-table-row-folder-type.php
@@ -1,7 +1,5 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
-
-$default_level = Imagify_Options::get_instance()->get( 'optimization_level' );
 ?>
 <tr class="imagify-row-folder-type" data-group-id="<?php echo $data['group_id']; ?>" data-context="<?php echo $data['context']; ?>">
 	<td class="imagify-cell-checkbox">
@@ -32,10 +30,9 @@ $default_level = Imagify_Options::get_instance()->get( 'optimization_level' );
 		$this->print_template( 'input/selector', [
 			'current_label' => __( 'Current level:', 'imagify' ),
 			'name'          => 'level[' . $data['group_id'] . ']',
-			'value'         => $default_level,
+			'value'         => 2,
 			'values'        => [
 				0 => imagify_get_optimization_level_label( 0, '%ICON% %s' ),
-				1 => imagify_get_optimization_level_label( 1, '%ICON% %s' ),
 				2 => imagify_get_optimization_level_label( 2, '%ICON% %s' ),
 			],
 		] );

--- a/views/part-bulk-optimization-table-row-folder-type.php
+++ b/views/part-bulk-optimization-table-row-folder-type.php
@@ -25,19 +25,6 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 	<td class="imagify-cell-original-size-size">
 		<?php echo $data['original-size']; ?>
 	</td>
-	<td class="imagify-cell-level">
-		<?php
-		$this->print_template( 'input/selector', [
-			'current_label' => __( 'Current level:', 'imagify' ),
-			'name'          => 'level[' . $data['group_id'] . ']',
-			'value'         => 2,
-			'values'        => [
-				0 => imagify_get_optimization_level_label( 0, '%ICON% %s' ),
-				2 => imagify_get_optimization_level_label( 2, '%ICON% %s' ),
-			],
-		] );
-		?>
-	</td>
 </tr>
 
 <tr>

--- a/views/part-bulk-optimization-table.php
+++ b/views/part-bulk-optimization-table.php
@@ -45,7 +45,6 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 						<th class="imagify-cell-count-errors"><?php esc_html_e( 'Errors', 'imagify' ); ?></th>
 						<th class="imagify-cell-optimized-size-size"><?php esc_html_e( 'Optimized Size', 'imagify' ); ?></th>
 						<th class="imagify-cell-original-size-size"><?php esc_html_e( 'Original Size', 'imagify' ); ?></th>
-						<th class="imagify-cell-level"><?php esc_html_e( 'Level Selection', 'imagify' ); ?></th>
 					</tr>
 				</thead>
 				<tbody>


### PR DESCRIPTION
Update the plugin to use the new smart compression system.

Closes #663
Closes #659
Closes #614

When updating to v2.0:
- Optimization is switched to the smart compression
- Images previously optimized with aggressive or ultra are now showing as smart compression
- Images previously optimized with normal are now showing as lossless compression
- Images optimized with lossless can be re-optimized with smart compression
- Images optimized with smart can be re-optimized with lossless compression
- The optimization level and exif options are removed from the settings
- exif data is always preserved on all images