### PR TITLE
Fixes #612 Add missing url parameter to the filter

### DIFF
--- a/inc/classes/class-imagify.php
+++ b/inc/classes/class-imagify.php
@@ -504,7 +504,7 @@ class Imagify {
 				curl_setopt( $ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS );
 			}
 
-			$user_agent = apply_filters( 'http_headers_useragent', 'WordPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' ) );
+			$user_agent = apply_filters( 'http_headers_useragent', 'WordPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' ), $url );
 
 			curl_setopt( $ch, CURLOPT_URL, $url );
 			curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );


### PR DESCRIPTION
Add the missing `$url` parameter to the filter usage, as this parameter was added in WP 5.1 and it can be used by other plugins.

Fixes #612