### PR TITLE
Prevent PHP warning when displaying pricing modal with packs removed from API

### DIFF
--- a/inc/classes/class-imagify-admin-ajax-post.php
+++ b/inc/classes/class-imagify-admin-ajax-post.php
@@ -1,5 +1,6 @@
 <?php
-defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
+
+use Imagify\Traits\InstanceGetterTrait;
 
 /**
  * Class that handles admin ajax/post callbacks.
@@ -8,7 +9,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
  * @author Grégory Viguier
  */
 class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
-	use \Imagify\Traits\InstanceGetterTrait;
+	use InstanceGetterTrait;
 
 	/**
 	 * Class version.
@@ -24,7 +25,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 *
 	 * @var    array
 	 * @since  1.6.11
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $ajax_post_actions = [
@@ -47,7 +47,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 *
 	 * @var    array
 	 * @since  1.6.11
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $ajax_only_actions = [
@@ -80,7 +79,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 *
 	 * @var    array
 	 * @since  1.6.11
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $post_only_actions = [
@@ -95,7 +93,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 *
 	 * @var    object Imagify_Filesystem
 	 * @since  1.7.1
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $filesystem;
@@ -110,7 +107,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 *
 	 * @since  1.6.11
 	 * @since  1.9 Visibility set to public.
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function __construct() {
@@ -121,7 +117,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Launch the hooks.
 	 *
 	 * @since  1.6.11
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function init() {
@@ -151,7 +146,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Optimize one media.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  int    $media_id The media ID.
@@ -166,7 +160,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Re-optimize a media to a different optimization level.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  int    $media_id The media ID.
@@ -183,7 +176,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * This is used by the bulk optimization page.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  int    $media_id The media ID.
@@ -212,7 +204,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Optimize one or some thumbnails that are not optimized yet.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  int    $media_id The media ID.
@@ -227,7 +218,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Generate WebP images if they are missing.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  int    $media_id The media ID.
@@ -242,7 +232,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Delete WebP images for media that are "already_optimize".
 	 *
 	 * @since  1.9.6
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  int    $media_id The media ID.
@@ -280,7 +269,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Restore a media.
 	 *
 	 * @since  1.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param  int    $media_id The media ID.
@@ -300,7 +288,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Get media ids for the requested imagify bulk action.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_get_media_ids_callback() {
@@ -355,7 +342,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Process a media with the requested imagify bulk action.
 	 *
 	 * @since  1.6.11
-	 * @access public
 	 * @author Jonathan Buttigieg
 	 */
 	public function imagify_bulk_optimize_callback() {
@@ -397,7 +383,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Get stats data for a specific folder type.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_get_folder_type_data_callback() {
@@ -422,7 +407,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Set the "bulk info" popup state as "seen".
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_bulk_info_seen_callback() {
@@ -447,7 +431,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Get generic stats to display in the bulk page.
 	 *
 	 * @since  1.7.1
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_bulk_get_stats_callback() {
@@ -480,7 +463,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Optimize all thumbnails of a specific image with the manual method.
 	 *
 	 * @since  1.6.11
-	 * @access public
 	 * @author Jonathan Buttigieg
 	 */
 	public function imagify_manual_optimize_callback() {
@@ -515,7 +497,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Optimize all thumbnails of a specific image with a different optimization level.
 	 *
 	 * @since  1.6.11
-	 * @access public
 	 * @author Jonathan Buttigieg
 	 */
 	public function imagify_manual_reoptimize_callback() {
@@ -550,7 +531,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Optimize one or some thumbnails that are not optimized yet.
 	 *
 	 * @since  1.6.11
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_optimize_missing_sizes_callback() {
@@ -585,7 +565,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Generate WebP images if they are missing.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_generate_webp_versions_callback() {
@@ -620,7 +599,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Generate WebP images if they are missing.
 	 *
 	 * @since  1.9.6
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_delete_webp_versions_callback() {
@@ -655,7 +633,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Process a restoration to the original attachment.
 	 *
 	 * @since  1.6.11
-	 * @access public
 	 * @author Jonathan Buttigieg
 	 */
 	public function imagify_restore_callback() {
@@ -703,7 +680,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Optimize a file.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_optimize_file_callback() {
@@ -735,7 +711,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Re-optimize a file.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_reoptimize_file_callback() {
@@ -769,7 +744,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Restore a file.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_restore_file_callback() {
@@ -802,7 +776,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Check if a file has been modified, and update the database accordingly.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_refresh_file_modified_callback() {
@@ -842,7 +815,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Look for new files in custom folders.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_scan_custom_folders_callback() {
@@ -897,7 +869,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * This is used to display an error message in the plugin's settings page.
 	 *
 	 * @since  1.6.11
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_check_backup_dir_is_writable_callback() {
@@ -916,7 +887,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Get files and folders that are direct children of a given folder.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_get_files_tree_callback() {
@@ -1010,7 +980,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Create a new Imagify account.
 	 *
 	 * @since  1.6.11
-	 * @access public
 	 * @author Jonathan Buttigieg
 	 */
 	public function imagify_signup_callback() {
@@ -1049,7 +1018,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Check the API key validity.
 	 *
 	 * @since  1.6.11
-	 * @access public
 	 * @author Jonathan Buttigieg
 	 */
 	public function imagify_check_api_key_validity_callback() {
@@ -1079,7 +1047,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Get admin bar profile output.
 	 *
 	 * @since  1.6.11
-	 * @access public
 	 * @author Jonathan Buttigieg
 	 */
 	public function imagify_get_admin_bar_profile_callback() {
@@ -1158,7 +1125,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Get pricings from API for Onetime and Plans at the same time.
 	 *
 	 * @since  1.6.11
-	 * @access public
 	 * @author Geoffrey Crofte
 	 */
 	public function imagify_get_prices_callback() {
@@ -1179,7 +1145,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 		}
 
 		wp_send_json_success( array(
-			'onetimes'  => $prices_all->Packs,
 			'monthlies' => $prices_all->Plans,
 		) );
 	}
@@ -1188,7 +1153,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Check Coupon code on modal popin.
 	 *
 	 * @since  1.6.11
-	 * @access public
 	 * @author Geoffrey Crofte
 	 */
 	public function imagify_check_coupon_callback() {
@@ -1235,7 +1199,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Get estimated sizes from the WordPress library.
 	 *
 	 * @since  1.6.11
-	 * @access public
 	 * @author Geoffrey Crofte
 	 */
 	public function imagify_get_images_counts_callback() {
@@ -1269,7 +1232,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Estimate sizes and update the options values for them.
 	 *
 	 * @since  1.6.11
-	 * @access public
 	 * @author Remy Perona
 	 */
 	public function imagify_update_estimate_sizes_callback() {
@@ -1294,7 +1256,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Get the Imagify User data.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_get_user_data_callback() {
@@ -1328,7 +1289,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Delete the Imagify User data cache.
 	 *
 	 * @since  1.9.5
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_delete_user_data_cache_callback() {
@@ -1353,7 +1313,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * When XML-RPC is used, a current user is set, but no cookies are set, so they cannot be sent with the request. Instead we stored the user ID in a transient.
 	 *
 	 * @since  1.6.11
-	 * @access public
 	 * @author Grégory Viguier
 	 * @see    imagify_do_async_job()
 	 */
@@ -1404,7 +1363,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Store the "closed" status of the ads.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function imagify_dismiss_ad_callback() {
@@ -1451,7 +1409,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 *
 	 * @since  1.7
 	 * @since  1.9 Added $method and $parameter parameters.
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $method The method used: 'GET' (default), or 'POST'.
@@ -1473,7 +1430,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Get the submitted context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $method The method used: 'GET' (default), or 'POST'.
@@ -1491,7 +1447,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Get the submitted media ID.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $method    The method used: 'GET' (default), or 'POST'.
@@ -1513,7 +1468,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Get the submitted folder_type.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $method    The method used: 'GET' (default), or 'POST'.
@@ -1530,7 +1484,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Get the submitted imagify action.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $method    The method used: 'GET' (default), or 'POST'.
@@ -1548,7 +1501,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Get the Bulk class name depending on a context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $context The context name. Default values are 'wp' and 'custom-folders'.
@@ -1586,7 +1538,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Get the Bulk instance depending on a context.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  string $context The context name. Default values are 'wp' and 'custom-folders'.
@@ -1601,7 +1552,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Check if the user has a valid account and has quota. Die on failure.
 	 *
 	 * @since  1.7
-	 * @access public
 	 * @author Grégory Viguier
 	 */
 	public function check_can_optimize() {
@@ -1626,7 +1576,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * Get a media columns for the "Other Media" page.
 	 *
 	 * @since  1.9
-	 * @access public
 	 * @author Grégory Viguier
 	 *
 	 * @param  object $process    A \Imagify\Optimization\Process\CustomFolders object.
@@ -1652,7 +1601,6 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	 * @since  1.7
 	 * @since  1.9 Removed parameter $result.
 	 * @since  1.9 Added $folder in the returned JSON.
-	 * @access protected
 	 * @author Grégory Viguier
 	 *
 	 * @param object $process A \Imagify\Optimization\Process\CustomFolders object.

--- a/inc/classes/class-imagify.php
+++ b/inc/classes/class-imagify.php
@@ -1,11 +1,11 @@
 <?php
-defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
+use Imagify\Traits\InstanceGetterTrait;
 
 /**
  * Imagify.io API for WordPress.
  */
 class Imagify {
-	use \Imagify\Traits\InstanceGetterTrait;
+	use InstanceGetterTrait;
 
 	/**
 	 * The Imagify API endpoint.
@@ -47,7 +47,6 @@ class Imagify {
 	 *
 	 * @var    object Imagify_Filesystem
 	 * @since  1.7.1
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected $filesystem;
@@ -57,7 +56,6 @@ class Imagify {
 	 *
 	 * @var    \stdClass|\WP_Error
 	 * @since  1.9.9
-	 * @access protected
 	 * @author Grégory Viguier
 	 */
 	protected static $user;
@@ -83,7 +81,6 @@ class Imagify {
 	/**
 	 * Get your Imagify account infos.
 	 *
-	 * @access public
 	 * @since  1.6.5
 	 *
 	 * @return object
@@ -128,7 +125,6 @@ class Imagify {
 	/**
 	 * Create a user on your Imagify account.
 	 *
-	 * @access public
 	 * @since  1.6.5
 	 *
 	 * @param  array $data All user data.
@@ -166,7 +162,6 @@ class Imagify {
 	/**
 	 * Update an existing user on your Imagify account.
 	 *
-	 * @access public
 	 * @since  1.6.5
 	 *
 	 * @param  string $data All user data.
@@ -188,7 +183,6 @@ class Imagify {
 	/**
 	 * Check your Imagify API key status.
 	 *
-	 * @access public
 	 * @since  1.6.5
 	 *
 	 * @param  string $data The license key.
@@ -220,7 +214,6 @@ class Imagify {
 	/**
 	 * Get the Imagify API version.
 	 *
-	 * @access public
 	 * @since  1.6.5
 	 *
 	 * @return object
@@ -242,7 +235,6 @@ class Imagify {
 	/**
 	 * Get Public Info.
 	 *
-	 * @access public
 	 * @since  1.6.5
 	 *
 	 * @return object
@@ -256,7 +248,6 @@ class Imagify {
 	/**
 	 * Optimize an image from its binary content.
 	 *
-	 * @access public
 	 * @since 1.6.5
 	 * @since 1.6.7 $data['image'] can contain the file path (prefered) or the result of `curl_file_create()`.
 	 *
@@ -280,7 +271,6 @@ class Imagify {
 	/**
 	 * Optimize an image from its URL.
 	 *
-	 * @access public
 	 * @since  1.6.5
 	 *
 	 * @param  string $data All options. Details here: --.
@@ -301,7 +291,6 @@ class Imagify {
 	/**
 	 * Get prices for plans.
 	 *
-	 * @access public
 	 * @since  1.6.5
 	 *
 	 * @return object
@@ -313,23 +302,8 @@ class Imagify {
 	}
 
 	/**
-	 * Get prices for packs (One Time).
+	 * Get all prices (Plans included).
 	 *
-	 * @access public
-	 * @since  1.6.5
-	 *
-	 * @return object
-	 */
-	public function get_packs_prices() {
-		$this->headers = $this->all_headers;
-
-		return $this->http_call( 'pricing/pack/' );
-	}
-
-	/**
-	 * Get all prices (packs & plans included).
-	 *
-	 * @access public
 	 * @since  1.6.5
 	 *
 	 * @return object
@@ -341,9 +315,8 @@ class Imagify {
 	}
 
 	/**
-	 * Get all prices (packs & plans included).
+	 * Get coupon code data.
 	 *
-	 * @access public
 	 * @since  1.6.5
 	 *
 	 * @param  string $coupon A coupon code.
@@ -358,7 +331,6 @@ class Imagify {
 	/**
 	 * Get information about current discount.
 	 *
-	 * @access public
 	 * @since  1.6.5
 	 *
 	 * @return object
@@ -372,7 +344,6 @@ class Imagify {
 	/**
 	 * Make an HTTP call using curl.
 	 *
-	 * @access private
 	 * @since  1.6.5
 	 * @since  1.6.7 Use `wp_remote_request()` when possible (when we don't need to send an image).
 	 *
@@ -451,7 +422,6 @@ class Imagify {
 	/**
 	 * Make an HTTP call using curl.
 	 *
-	 * @access private
 	 * @since  1.6.7
 	 * @throws Exception When curl_init() fails.
 	 * @author Grégory Viguier
@@ -580,7 +550,6 @@ class Imagify {
 	/**
 	 * Handle the request response and maybe trigger an error.
 	 *
-	 * @access private
 	 * @since  1.6.7
 	 * @author Grégory Viguier
 	 *
@@ -629,7 +598,6 @@ class Imagify {
 	 * Generate a random key.
 	 * Similar to wp_generate_password() but without filter.
 	 *
-	 * @access private
 	 * @since  1.8.4
 	 * @see    wp_generate_password()
 	 * @author Grégory Viguier
@@ -651,7 +619,6 @@ class Imagify {
 	/**
 	 * Filter the arguments used in an HTTP request, to make sure our API key has not been overwritten by some other plugin.
 	 *
-	 * @access public
 	 * @since  1.8.4
 	 * @author Grégory Viguier
 	 *

--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -96,19 +96,7 @@ function get_imagify_plans_prices() {
 }
 
 /**
- * Get Imagify Plans Prices.
- *
- * @since  1.5
- * @author Geoffrey Crofte
- *
- * @return object
- */
-function get_imagify_packs_prices() {
-	return imagify()->get_packs_prices();
-}
-
-/**
- * Get Imagify All Prices (plan & packs).
+ * Get Imagify All Prices (plans).
  *
  * @since  1.5.4
  * @author Geoffrey Crofte


### PR DESCRIPTION
The following error was showing in the log when displaying the pricing modal on the settings page:
`PHP Warning:  Undefined property: stdClass::$Packs in /imagify-plugin/inc/classes/class-imagify-admin-ajax-post.php on line 1182`

It was happening because the Packs were removed from the API data returned by the `pricing/all` endpoint. This PR prevents the error by removing the usage of the packs data in the plugin.