### PR TITLE
Guard against php8.0 ArgumentCountError

### DIFF
--- a/inc/classes/class-imagify-custom-folders.php
+++ b/inc/classes/class-imagify-custom-folders.php
@@ -844,7 +844,7 @@ class Imagify_Custom_Folders {
 			return array();
 		}
 
-		$files_from_db = call_user_func_array( 'array_merge', $files_from_db );
+		$files_from_db = call_user_func_array( 'array_merge', array_values( $files_from_db ) );
 
 		if ( $already_optimized ) {
 			// Put the files already optimized at the end of the list.


### PR DESCRIPTION
Fixes the following error:
```
2022-06-21T00:00:13+00:00 CRITICAL Uncaught ArgumentCountError: array_merge() does not accept unknown named parameters in /home/XXX/public_html/wp-content/plugins/imagify/inc/classes/class-imagify-custom-folders.php:847
```

that's php8.0 new feature which called [Named Parameters](https://php.watch/versions/8.0/named-parameters) which means that we can pass arguments to any function and give them names, something like:
```
//PHP function usage
function str_contains(string $haystack, string $needle): bool {}

//how to use it with the new feature (named parameters)
str_contains(haystack: 'FooBar', needle: 'Foo');
```

back to our code, in the following line:
https://github.com/wp-media/imagify-plugin/blob/5971929e9842066e1351704ce14f25c5f31a7180/inc/classes/class-imagify-custom-folders.php#L847

this variable `$files_from_db` is associative array (array with keys and values) and we are trying to merge all values (which are arrays)
This is because call_user_func_array will interpret the top-level array keys as parameter names to be passed into the array_merge, and these keys will not match the function arguments.
the solution here is just to get the array_values before passing it to call_user_func_array to be like

```
$files_from_db = call_user_func_array( 'array_merge', array_values( $files_from_db ) );
```

I wasn't able to see that in the test environment but this PR should fix this error.