### PR TITLE
Initialize Bulk instance and update methods signatures

### DIFF
--- a/classes/Bulk/Bulk.php
+++ b/classes/Bulk/Bulk.php
@@ -12,8 +12,8 @@ class Bulk {
 	 * @since 2.1
 	 */
 	public function init() {
-		add_action( 'imagify_optimize_media', [ $this, 'optimize_media' ] );
-		add_action( 'imagify_convert_webp', [ $this, 'generate_webp_versions' ] );
+		add_action( 'imagify_optimize_media', [ $this, 'optimize_media' ], 10, 2 );
+		add_action( 'imagify_convert_webp', [ $this, 'generate_webp_versions' ], 10, 2 );
 		add_action( 'wp_ajax_imagify_bulk_optimize', 'bulk_optimize_callback' );
 		add_action( 'wp_ajax_imagify_get_folder_type_data', 'get_folder_type_data_callback' );
 		add_action( 'wp_ajax_imagify_bulk_info_seen', 'bulk_info_seen_callback' );
@@ -25,16 +25,16 @@ class Bulk {
 	 *
 	 * @since 2.1
 	 */
-	public function optimize_media( array $args ) {
-		if ( ! $args['id'] || ! $args['context'] ) {
+	public function optimize_media( string $media_id, string $context ) {
+		if ( ! $media_id || ! $context ) {
 			return;
 		}
 
-		if ( ! imagify_get_context( $args['context'] )->current_user_can( 'bulk-optimize', $args['id'] ) ) {
+		if ( ! imagify_get_context( $context )->current_user_can( 'bulk-optimize', $media_id ) ) {
 			return;
 		}
 
-		$this->force_optimize( $args['id'], $args['context'], 2 );
+		$this->force_optimize( $media_id, $context, 2 );
 	}
 
 	/**
@@ -163,7 +163,7 @@ class Bulk {
 	 * @param  int    $level    The optimization level.
 	 * @return bool|WP_Error    True if successfully launched. A \WP_Error instance on failure.
 	 */
-	private function force_optimize( $media_id, $context, $level ) {
+	private function force_optimize( int $media_id, string $context, int $level ) {
 		$process = imagify_get_optimization_process( $media_id, $context );
 		$data    = $process->get_data();
 
@@ -187,8 +187,8 @@ class Bulk {
 	 *
 	 * @return bool|WP_Error    True if successfully launched. A \WP_Error instance on failure.
 	 */
-	public function generate_webp_versions( $args ) {
-		return imagify_get_optimization_process( $args['id'], $args['context'] )->generate_webp_versions();
+	public function generate_webp_versions( string $media_id, string $context ) {
+		return imagify_get_optimization_process( $media_id, $context )->generate_webp_versions();
 	}
 
 	/**

--- a/classes/Bulk/Bulk.php
+++ b/classes/Bulk/Bulk.php
@@ -25,7 +25,7 @@ class Bulk {
 	 *
 	 * @since 2.1
 	 */
-	public function optimize_media( string $media_id, string $context ) {
+	public function optimize_media( int $media_id, string $context ) {
 		if ( ! $media_id || ! $context ) {
 			return;
 		}
@@ -187,7 +187,7 @@ class Bulk {
 	 *
 	 * @return bool|WP_Error    True if successfully launched. A \WP_Error instance on failure.
 	 */
-	public function generate_webp_versions( string $media_id, string $context ) {
+	public function generate_webp_versions( int $media_id, string $context ) {
 		return imagify_get_optimization_process( $media_id, $context )->generate_webp_versions();
 	}
 

--- a/classes/Bulk/CustomFolders.php
+++ b/classes/Bulk/CustomFolders.php
@@ -28,7 +28,8 @@ class CustomFolders extends AbstractBulk {
 	 * @since 1.9
 	 *
 	 * @param  int $optimization_level The optimization level.
-	 * @return array                   A list of unoptimized media. Array keys are media IDs prefixed with an underscore character, array values are the main file’s URL.
+	 *
+	 * @return array A list of unoptimized media IDs.
 	 */
 	public function get_unoptimized_media_ids( $optimization_level ) {
 		@set_time_limit( 0 );

--- a/classes/Bulk/CustomFolders.php
+++ b/classes/Bulk/CustomFolders.php
@@ -67,7 +67,7 @@ class CustomFolders extends AbstractBulk {
 
 		// We need to output file URLs.
 		foreach ( $files as $k => $file ) {
-			$files[ $k ] = esc_url( Imagify_Files_Scan::remove_placeholder( $file['path'], 'url' ) );
+			$files[ $k ] = $file['file_id'];
 		}
 
 		return $files;

--- a/classes/Bulk/CustomFolders.php
+++ b/classes/Bulk/CustomFolders.php
@@ -66,7 +66,6 @@ class CustomFolders extends AbstractBulk {
 			return [];
 		}
 
-		// We need to output file URLs.
 		foreach ( $files as $k => $file ) {
 			$files[ $k ] = $file['file_id'];
 		}

--- a/classes/Bulk/WP.php
+++ b/classes/Bulk/WP.php
@@ -22,8 +22,9 @@ class WP extends AbstractBulk {
 	 *
 	 * @since 1.9
 	 *
-	 * @param  int $optimization_level The optimization level.
-	 * @return array                   A list of unoptimized media. Array keys are media IDs prefixed with an underscore character, array values are the main file’s URL.
+	 * @param int $optimization_level The optimization level.
+	 *
+	 * @return array A list of unoptimized media IDs.
 	 */
 	public function get_unoptimized_media_ids( $optimization_level ) {
 		global $wpdb;

--- a/classes/Bulk/WP.php
+++ b/classes/Bulk/WP.php
@@ -157,7 +157,7 @@ class WP extends AbstractBulk {
 				continue;
 			}
 
-			$data[ '_' . $id ] = esc_url( get_imagify_attachment_url( $metas['filenames'][ $id ] ) );
+			$data[] = $id;
 		} // End foreach().
 
 		return $data;

--- a/classes/Plugin.php
+++ b/classes/Plugin.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Imagify;
 
+use Imagify\Bulk\Bulk;
 use Imagify\Notices\Notices;
 
 /**
@@ -52,6 +53,7 @@ class Plugin {
 		\Imagify\Auth\Basic::get_instance()->init();
 		\Imagify\Job\MediaOptimization::get_instance()->init();
 		\Imagify\Stats\OptimizedMediaWithoutWebp::get_instance()->init();
+		Bulk::get_instance()->init();
 
 		if ( is_admin() ) {
 			Notices::get_instance()->init();

--- a/inc/3rd-party/nextgen-gallery/classes/Bulk/NGG.php
+++ b/inc/3rd-party/nextgen-gallery/classes/Bulk/NGG.php
@@ -25,7 +25,7 @@ class NGG extends AbstractBulk {
 	 * @since 1.9
 	 *
 	 * @param  int $optimization_level The optimization level.
-	 * @return array                   A list of unoptimized media. Array keys are media IDs prefixed with an underscore character, array values are the main file’s URL.
+	 * @return array                   A list of unoptimized media IDs.
 	 */
 	public function get_unoptimized_media_ids( $optimization_level ) {
 		global $wpdb;
@@ -93,7 +93,7 @@ class NGG extends AbstractBulk {
 				continue;
 			}
 
-			$data[ '_' . $id ] = esc_url( $storage->get_image_url( $id ) );
+			$data[] = $id;
 		} // End foreach().
 
 		return $data;


### PR DESCRIPTION
Initialize the bulk instance to register the hooks.

Update methods signature to receive individual parameters instead of an array.