### PR TITLE
Closes #69 Only display plan selection block if on free plan

### DIFF
--- a/views/part-settings-account.php
+++ b/views/part-settings-account.php
@@ -30,7 +30,13 @@ if ( Imagify_Requirements::is_api_key_valid() ) {
 <div class="imagify-settings-section">
 
 	<?php
-	if ( Imagify_Requirements::is_api_key_valid() ) {
+	$imagify_user = new Imagify_User();
+
+	if (
+		$imagify_user->is_free()
+		&&
+		Imagify_Requirements::is_api_key_valid()
+	) {
 		?>
 		<div class="imagify-col-content imagify-block-secondary imagify-mt2">
 			<?php


### PR DESCRIPTION
Remove the "what plan do I need?" block on settings page if the user has a subscription