### PR TITLE
Update action scheduler to v3.5.4

### DIFF
--- a/inc/Dependencies/ActionScheduler/action-scheduler.php
+++ b/inc/Dependencies/ActionScheduler/action-scheduler.php
@@ -5,7 +5,7 @@
  * Description: A robust scheduling library for use in WordPress plugins.
  * Author: Automattic
  * Author URI: https://automattic.com/
- * Version: 3.5.3
+ * Version: 3.5.4
  * License: GPLv3
  *
  * Copyright 2019 Automattic, Inc.  (https://automattic.com/contact/)
@@ -26,27 +26,27 @@
  * @package ActionScheduler
  */
 
-if ( ! function_exists( 'action_scheduler_register_3_dot_5_dot_3' ) && function_exists( 'add_action' ) ) { // WRCS: DEFINED_VERSION.
+if ( ! function_exists( 'action_scheduler_register_3_dot_5_dot_4' ) && function_exists( 'add_action' ) ) { // WRCS: DEFINED_VERSION.
 
 	if ( ! class_exists( 'ActionScheduler_Versions', false ) ) {
 		require_once __DIR__ . '/classes/ActionScheduler_Versions.php';
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
-	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_5_dot_3', 0, 0 ); // WRCS: DEFINED_VERSION.
+	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_5_dot_4', 0, 0 ); // WRCS: DEFINED_VERSION.
 
 	/**
 	 * Registers this version of Action Scheduler.
 	 */
-	function action_scheduler_register_3_dot_5_dot_3() { // WRCS: DEFINED_VERSION.
+	function action_scheduler_register_3_dot_5_dot_4() { // WRCS: DEFINED_VERSION.
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( '3.5.3', 'action_scheduler_initialize_3_dot_5_dot_3' ); // WRCS: DEFINED_VERSION.
+		$versions->register( '3.5.4', 'action_scheduler_initialize_3_dot_5_dot_4' ); // WRCS: DEFINED_VERSION.
 	}
 
 	/**
 	 * Initializes this version of Action Scheduler.
 	 */
-	function action_scheduler_initialize_3_dot_5_dot_3() { // WRCS: DEFINED_VERSION.
+	function action_scheduler_initialize_3_dot_5_dot_4() { // WRCS: DEFINED_VERSION.
 		// A final safety check is required even here, because historic versions of Action Scheduler
 		// followed a different pattern (in some unusual cases, we could reach this point and the
 		// ActionScheduler class is already defined—so we need to guard against that).
@@ -58,7 +58,7 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_5_dot_3' ) && function_
 
 	// Support usage in themes - load this version if no plugin has loaded a version yet.
 	if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler', false ) ) {
-		action_scheduler_initialize_3_dot_5_dot_3(); // WRCS: DEFINED_VERSION.
+		action_scheduler_initialize_3_dot_5_dot_4(); // WRCS: DEFINED_VERSION.
 		do_action( 'action_scheduler_pre_theme_init' );
 		ActionScheduler_Versions::initialize_latest_version();
 	}

--- a/inc/Dependencies/ActionScheduler/changelog.txt
+++ b/inc/Dependencies/ActionScheduler/changelog.txt
@@ -1,5 +1,15 @@
 *** Changelog ***
 
+= 3.5.4 - 2023-01-17 =
+* Add pre filters during action registration.
+* Async scheduling.
+* Calculate timeouts based on total actions.
+* Correctly order the parameters for `ActionScheduler_ActionFactory`'s calls to `single_unique`.
+* Fetch action in memory first before releasing claim to avoid deadlock.
+* PHP 8.2: declare property to fix creation of dynamic property warning.
+* PHP 8.2: fix "Using ${var} in strings is deprecated, use {$var} instead".
+* Prevent `undefined variable` warning for `$num_pastdue_actions`.
+
 = 3.5.3 - 2022-11-09 =
 * Query actions with partial match.
 

--- a/inc/Dependencies/ActionScheduler/classes/ActionScheduler_ActionFactory.php
+++ b/inc/Dependencies/ActionScheduler/classes/ActionScheduler_ActionFactory.php
@@ -52,12 +52,9 @@ class ActionScheduler_ActionFactory {
 	/**
 	 * Enqueue an action to run one time, as soon as possible (rather a specific scheduled time).
 	 *
-	 * This method creates a new action with the NULLSchedule. This schedule maps to a MySQL datetime string of
-	 * 0000-00-00 00:00:00. This is done to create a psuedo "async action" type that is fully backward compatible.
-	 * Existing queries to claim actions claim by date, meaning actions scheduled for 0000-00-00 00:00:00 will
-	 * always be claimed prior to actions scheduled for a specific date. This makes sure that any async action is
-	 * given priority in queue processing. This has the added advantage of making sure async actions can be
-	 * claimed by both the existing WP Cron and WP CLI runners, as well as a new async request runner.
+	 * This method creates a new action using the NullSchedule. In practice, this results in an action scheduled to
+	 * execute "now". Therefore, it will generally run as soon as possible but is not prioritized ahead of other actions
+	 * that are already past-due.
 	 *
 	 * @param string $hook The hook to trigger when this action runs.
 	 * @param array  $args Args to pass when the hook is triggered.
@@ -146,7 +143,7 @@ class ActionScheduler_ActionFactory {
 	 */
 	public function recurring_unique( $hook, $args = array(), $first = null, $interval = null, $group = '', $unique = true ) {
 		if ( empty( $interval ) ) {
-			return $this->single_unique( $hook, $unique, $args, $first, $group );
+			return $this->single_unique( $hook, $args, $first, $group, $unique );
 		}
 		$date     = as_get_datetime_object( $first );
 		$schedule = new ActionScheduler_IntervalSchedule( $date, $interval );
@@ -188,7 +185,7 @@ class ActionScheduler_ActionFactory {
 	 **/
 	public function cron_unique( $hook, $args = array(), $base_timestamp = null, $schedule = null, $group = '', $unique = true ) {
 		if ( empty( $schedule ) ) {
-			return $this->single_unique( $hook, $unique, $args, $base_timestamp, $group );
+			return $this->single_unique( $hook, $args, $base_timestamp, $group, $unique );
 		}
 		$date     = as_get_datetime_object( $base_timestamp );
 		$cron     = CronExpression::factory( $schedule );

--- a/inc/Dependencies/ActionScheduler/classes/ActionScheduler_AdminView.php
+++ b/inc/Dependencies/ActionScheduler/classes/ActionScheduler_AdminView.php
@@ -147,8 +147,16 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 		$threshold_seconds = ( int ) apply_filters( 'action_scheduler_pastdue_actions_seconds', DAY_IN_SECONDS );
 		$threshhold_min    = ( int ) apply_filters( 'action_scheduler_pastdue_actions_min', 1 );
 
-		# Allow third-parties to preempt the default check logic.
+		// Set fallback value for past-due actions count.
+		$num_pastdue_actions = 0;
+
+		// Allow third-parties to preempt the default check logic.
 		$check = apply_filters( 'action_scheduler_pastdue_actions_check_pre', null );
+
+		// If no third-party preempted and there are no past-due actions, return early.
+		if ( ! is_null( $check ) ) {
+			return;
+		}
 
 		# Scheduled actions query arguments.
 		$query_args = array(

--- a/inc/Dependencies/ActionScheduler/classes/ActionScheduler_QueueRunner.php
+++ b/inc/Dependencies/ActionScheduler/classes/ActionScheduler_QueueRunner.php
@@ -14,6 +14,9 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	/** @var ActionScheduler_QueueRunner  */
 	private static $runner = null;
 
+	/** @var int  */
+	private $processed_actions_count = 0;
+
 	/**
 	 * @return ActionScheduler_QueueRunner
 	 * @codeCoverageIgnore
@@ -125,17 +128,18 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 		ActionScheduler_Compatibility::raise_time_limit( $this->get_time_limit() );
 		do_action( 'action_scheduler_before_process_queue' );
 		$this->run_cleanup();
-		$processed_actions = 0;
+
+		$this->processed_actions_count = 0;
 		if ( false === $this->has_maximum_concurrent_batches() ) {
 			$batch_size = apply_filters( 'action_scheduler_queue_runner_batch_size', 25 );
 			do {
-				$processed_actions_in_batch = $this->do_batch( $batch_size, $context );
-				$processed_actions         += $processed_actions_in_batch;
-			} while ( $processed_actions_in_batch > 0 && ! $this->batch_limits_exceeded( $processed_actions ) ); // keep going until we run out of actions, time, or memory
+				$processed_actions_in_batch     = $this->do_batch( $batch_size, $context );
+				$this->processed_actions_count += $processed_actions_in_batch;
+			} while ( $processed_actions_in_batch > 0 && ! $this->batch_limits_exceeded( $this->processed_actions_count ) ); // keep going until we run out of actions, time, or memory
 		}
 
 		do_action( 'action_scheduler_after_process_queue' );
-		return $processed_actions;
+		return $this->processed_actions_count;
 	}
 
 	/**
@@ -162,7 +166,7 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 			$this->process_action( $action_id, $context );
 			$processed_actions++;
 
-			if ( $this->batch_limits_exceeded( $processed_actions ) ) {
+			if ( $this->batch_limits_exceeded( $processed_actions + $this->processed_actions_count ) ) {
 				break;
 			}
 		}

--- a/inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -223,9 +223,14 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 	 * @return bool
 	 */
 	protected function time_likely_to_be_exceeded( $processed_actions ) {
+		$execution_time     = $this->get_execution_time();
+		$max_execution_time = $this->get_time_limit();
 
-		$execution_time        = $this->get_execution_time();
-		$max_execution_time    = $this->get_time_limit();
+		// Safety against division by zero errors.
+		if ( 0 === $processed_actions ) {
+			return $execution_time >= $max_execution_time;
+		}
+
 		$time_per_action       = $execution_time / $processed_actions;
 		$estimated_time        = $execution_time + ( $time_per_action * 3 );
 		$likely_to_be_exceeded = $estimated_time > $max_execution_time;

--- a/inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Store.php
+++ b/inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Store.php
@@ -257,7 +257,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	protected function get_scheduled_date_string( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
 		$next = null === $scheduled_date ? $action->get_schedule()->get_date() : $scheduled_date;
 		if ( ! $next ) {
-			return '0000-00-00 00:00:00';
+			$next = date_create();
 		}
 		$next->setTimezone( new DateTimeZone( 'UTC' ) );
 
@@ -274,7 +274,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	protected function get_scheduled_date_string_local( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
 		$next = null === $scheduled_date ? $action->get_schedule()->get_date() : $scheduled_date;
 		if ( ! $next ) {
-			return '0000-00-00 00:00:00';
+			$next = date_create();
 		}
 
 		ActionScheduler_TimezoneHelper::set_local_timezone( $next );

--- a/inc/Dependencies/ActionScheduler/classes/schedules/ActionScheduler_NullSchedule.php
+++ b/inc/Dependencies/ActionScheduler/classes/schedules/ActionScheduler_NullSchedule.php
@@ -5,6 +5,9 @@
  */
 class ActionScheduler_NullSchedule extends ActionScheduler_SimpleSchedule {
 
+	/** @var DateTime|null */
+	protected $scheduled_date;
+
 	/**
 	 * Make the $date param optional and default to null.
 	 *

--- a/inc/Dependencies/ActionScheduler/classes/schema/ActionScheduler_StoreSchema.php
+++ b/inc/Dependencies/ActionScheduler/classes/schema/ActionScheduler_StoreSchema.php
@@ -47,14 +47,14 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        action_id bigint(20) unsigned NOT NULL auto_increment,
 				        hook varchar(191) NOT NULL,
 				        status varchar(20) NOT NULL,
-				        scheduled_date_gmt datetime NULL default '${default_date}',
-				        scheduled_date_local datetime NULL default '${default_date}',
+				        scheduled_date_gmt datetime NULL default '{$default_date}',
+				        scheduled_date_local datetime NULL default '{$default_date}',
 				        args varchar($max_index_length),
 				        schedule longtext,
 				        group_id bigint(20) unsigned NOT NULL default '0',
 				        attempts int(11) NOT NULL default '0',
-				        last_attempt_gmt datetime NULL default '${default_date}',
-				        last_attempt_local datetime NULL default '${default_date}',
+				        last_attempt_gmt datetime NULL default '{$default_date}',
+				        last_attempt_local datetime NULL default '{$default_date}',
 				        claim_id bigint(20) unsigned NOT NULL default '0',
 				        extended_args varchar(8000) DEFAULT NULL,
 				        PRIMARY KEY  (action_id),
@@ -71,7 +71,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 
 				return "CREATE TABLE {$table_name} (
 				        claim_id bigint(20) unsigned NOT NULL auto_increment,
-				        date_created_gmt datetime NULL default '${default_date}',
+				        date_created_gmt datetime NULL default '{$default_date}',
 				        PRIMARY KEY  (claim_id),
 				        KEY date_created_gmt (date_created_gmt)
 				        ) $charset_collate";
@@ -111,16 +111,16 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$table_name   = $wpdb->prefix . 'actionscheduler_actions';
-		$table_list   = $wpdb->get_col( "SHOW TABLES LIKE '${table_name}'" );
+		$table_list   = $wpdb->get_col( "SHOW TABLES LIKE '{$table_name}'" );
 		$default_date = self::DEFAULT_DATE;
 
 		if ( ! empty( $table_list ) ) {
 			$query = "
-				ALTER TABLE ${table_name}
-				MODIFY COLUMN scheduled_date_gmt datetime NULL default '${default_date}',
-				MODIFY COLUMN scheduled_date_local datetime NULL default '${default_date}',
-				MODIFY COLUMN last_attempt_gmt datetime NULL default '${default_date}',
-				MODIFY COLUMN last_attempt_local datetime NULL default '${default_date}'
+				ALTER TABLE {$table_name}
+				MODIFY COLUMN scheduled_date_gmt datetime NULL default '{$default_date}',
+				MODIFY COLUMN scheduled_date_local datetime NULL default '{$default_date}',
+				MODIFY COLUMN last_attempt_gmt datetime NULL default '{$default_date}',
+				MODIFY COLUMN last_attempt_local datetime NULL default '{$default_date}'
 		";
 			$wpdb->query( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		}

--- a/inc/Dependencies/ActionScheduler/functions.php
+++ b/inc/Dependencies/ActionScheduler/functions.php
@@ -19,6 +19,26 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique =
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
+
+	/**
+	 * Provides an opportunity to short-circuit the default process for enqueuing async
+	 * actions.
+	 *
+	 * Returning a value other than null from the filter will short-circuit the normal
+	 * process. The expectation in such a scenario is that callbacks will return an integer
+	 * representing the enqueued action ID (enqueued using some alternative process) or else
+	 * zero.
+	 *
+	 * @param int|null $pre_option The value to return instead of the option value.
+	 * @param string   $hook       Action hook.
+	 * @param array    $args       Action arguments.
+	 * @param string   $group      Action group.
+	 */
+	$pre = apply_filters( 'pre_as_enqueue_async_action', null, $hook, $args, $group );
+	if ( null !== $pre ) {
+		return is_int( $pre ) ? $pre : 0;
+	}
+
 	return ActionScheduler::factory()->async_unique( $hook, $args, $group, $unique );
 }
 
@@ -37,6 +57,27 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
+
+	/**
+	 * Provides an opportunity to short-circuit the default process for enqueuing single
+	 * actions.
+	 *
+	 * Returning a value other than null from the filter will short-circuit the normal
+	 * process. The expectation in such a scenario is that callbacks will return an integer
+	 * representing the scheduled action ID (scheduled using some alternative process) or else
+	 * zero.
+	 *
+	 * @param int|null $pre_option The value to return instead of the option value.
+	 * @param int      $timestamp  When the action will run.
+	 * @param string   $hook       Action hook.
+	 * @param array    $args       Action arguments.
+	 * @param string   $group      Action group.
+	 */
+	$pre = apply_filters( 'pre_as_schedule_single_action', null, $timestamp, $hook, $args, $group );
+	if ( null !== $pre ) {
+		return is_int( $pre ) ? $pre : 0;
+	}
+
 	return ActionScheduler::factory()->single_unique( $hook, $args, $timestamp, $group, $unique );
 }
 
@@ -56,6 +97,28 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
+
+	/**
+	 * Provides an opportunity to short-circuit the default process for enqueuing recurring
+	 * actions.
+	 *
+	 * Returning a value other than null from the filter will short-circuit the normal
+	 * process. The expectation in such a scenario is that callbacks will return an integer
+	 * representing the scheduled action ID (scheduled using some alternative process) or else
+	 * zero.
+	 *
+	 * @param int|null $pre_option          The value to return instead of the option value.
+	 * @param int      $timestamp           When the action will run.
+	 * @param int      $interval_in_seconds How long to wait between runs.
+	 * @param string   $hook                Action hook.
+	 * @param array    $args                Action arguments.
+	 * @param string   $group               Action group.
+	 */
+	$pre = apply_filters( 'pre_as_schedule_recurring_action', null, $timestamp, $interval_in_seconds, $hook, $args, $group );
+	if ( null !== $pre ) {
+		return is_int( $pre ) ? $pre : 0;
+	}
+
 	return ActionScheduler::factory()->recurring_unique( $hook, $args, $timestamp, $interval_in_seconds, $group, $unique );
 }
 
@@ -87,6 +150,28 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
+
+	/**
+	 * Provides an opportunity to short-circuit the default process for enqueuing cron
+	 * actions.
+	 *
+	 * Returning a value other than null from the filter will short-circuit the normal
+	 * process. The expectation in such a scenario is that callbacks will return an integer
+	 * representing the scheduled action ID (scheduled using some alternative process) or else
+	 * zero.
+	 *
+	 * @param int|null $pre_option The value to return instead of the option value.
+	 * @param int      $timestamp  When the action will run.
+	 * @param string   $schedule   Cron-like schedule string.
+	 * @param string   $hook       Action hook.
+	 * @param array    $args       Action arguments.
+	 * @param string   $group      Action group.
+	 */
+	$pre = apply_filters( 'pre_as_schedule_cron_action', null, $timestamp, $schedule, $hook, $args, $group );
+	if ( null !== $pre ) {
+		return is_int( $pre ) ? $pre : 0;
+	}
+
 	return ActionScheduler::factory()->cron_unique( $hook, $args, $timestamp, $schedule, $group, $unique );
 }
 

--- a/inc/Dependencies/ActionScheduler/readme.txt
+++ b/inc/Dependencies/ActionScheduler/readme.txt
@@ -3,7 +3,7 @@ Contributors: Automattic, wpmuguru, claudiosanches, peterfabian1000, vedjain, ja
 Tags: scheduler, cron
 Requires at least: 5.2
 Tested up to: 6.0
-Stable tag: 3.5.3
+Stable tag: 3.5.4
 License: GPLv3
 Requires PHP: 5.6
 
@@ -46,6 +46,16 @@ Action Scheduler is developed and maintained by [Automattic](http://automattic.c
 Collaboration is cool. We'd love to work with you to improve Action Scheduler. [Pull Requests](https://github.com/woocommerce/action-scheduler/pulls) welcome.
 
 == Changelog ==
+
+= 3.5.4 - 2023-01-17 =
+* Add pre filters during action registration.
+* Async scheduling.
+* Calculate timeouts based on total actions.
+* Correctly order the parameters for `ActionScheduler_ActionFactory`'s calls to `single_unique`.
+* Fetch action in memory first before releasing claim to avoid deadlock.
+* PHP 8.2: declare property to fix creation of dynamic property warning.
+* PHP 8.2: fix "Using ${var} in strings is deprecated, use {$var} instead".
+* Prevent `undefined variable` warning for `$num_pastdue_actions`.
 
 = 3.5.3 - 2022-11-09 =
 * Query actions with partial match.


### PR DESCRIPTION
## Description

Update action scheduler to v3.5.4

changelog: https://github.com/woocommerce/action-scheduler/releases/tag/3.5.4

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
