### PR TITLE
Add API function to check if API Key is valid

### DIFF
--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -303,3 +303,12 @@ function imagify_add_command( CommandInterface $command ) {
 		'synopsis' => $command->get_synopsis(),
 	] );
 }
+
+/**
+ * Checks if the API key is valid
+ *
+ * @return bool
+ */
+function imagify_is_api_key_valid() {
+	return Imagify_Requirements::is_api_key_valid();
+}


### PR DESCRIPTION
Add a function to check if the API key is valid, to be used by 3rd parties to know if the plugin is active and the user has a valid Imagify key in use.

It's going to be used notably by One.com