### PR TITLE
Prevent Fatal Error on server with old php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,10 @@
 			"dealerdirect/phpcodesniffer-composer-installer": true,
 			"dangoodman/composer-for-wordpress": true,
 			"mnsami/composer-custom-directory-installer": true
-		}
+		},
+        "platform": {
+            "php": "7.2"
+        }
 	},
 	"support": {
 		"issues": "https://github.com/wp-media/imagify-plugin/issues",

--- a/imagify.php
+++ b/imagify.php
@@ -5,7 +5,7 @@
  * Description: Dramatically reduce image file sizes without losing quality, make your website load faster, boost your SEO and save money on your bandwidth using Imagify, the new most advanced image optimization tool.
  * Version: 2.1.1
  * Requires at least: 5.3
- * Requires PHP: 7.0
+ * Requires PHP: 7.2
  * Author: Imagify – Optimize Images & Convert WebP
  * Author URI: https://imagify.io
  * Licence: GPLv2


### PR DESCRIPTION
Actually, when update version 2.0 to 2.1 on a PHP 7.0 server, a fatal error occure. 

The error: `Fatal error: Composer detected issues in your platform: Your Composer dependencies require a PHP version ">= 7.2.0". You are running 7.0.33-0+deb9u12. in wp-content/plugins/imagify/vendor/composer/platform_check.php on line 24`

Wordpress PHP version in the plugin file need to be changed in order to not give the user the right to download the plugin.