### PR TITLE
Fixes #713 Remove WebP type when checking for media without WebP versions

### DIFF
--- a/classes/Bulk/CustomFolders.php
+++ b/classes/Bulk/CustomFolders.php
@@ -95,6 +95,7 @@ class CustomFolders extends AbstractBulk {
 		$files_table   = Imagify_Files_DB::get_instance()->get_table_name();
 		$folders_table = Imagify_Folders_DB::get_instance()->get_table_name();
 		$mime_types    = Imagify_DB::get_mime_types( 'image' );
+		$mime_types   = str_replace( ",'image/webp'", '', $mime_types );
 		$webp_suffix   = constant( imagify_get_optimization_process_class_name( 'custom-folders' ) . '::WEBP_SUFFIX' );
 		$files         = $wpdb->get_results( $wpdb->prepare( // WPCS: unprepared SQL ok.
 			"

--- a/classes/Bulk/WP.php
+++ b/classes/Bulk/WP.php
@@ -184,6 +184,7 @@ class WP extends AbstractBulk {
 		$this->set_no_time_limit();
 
 		$mime_types   = Imagify_DB::get_mime_types( 'image' );
+		$mime_types   = str_replace( ",'image/webp'", '', $mime_types );
 		$statuses     = Imagify_DB::get_post_statuses();
 		$nodata_join  = Imagify_DB::get_required_wp_metadata_join_clause();
 		$nodata_where = Imagify_DB::get_required_wp_metadata_where_clause( [


### PR DESCRIPTION
Remove the WebP type from the mime types list when checking for media without a WebP versions for the generate missing WebP images bulk.