### PR TITLE
Added a way fix filter issue on type from media

### DIFF
--- a/inc/admin/upload.php
+++ b/inc/admin/upload.php
@@ -123,7 +123,9 @@ function _imagify_sort_attachments_by_status( $vars ) {
 		),
 	) );
 
-	$vars['post_mime_type'] = imagify_get_mime_types();
+	if ( ! key_exists( 'post_mime_type', $vars ) ) {
+		$vars['post_mime_type'] = imagify_get_mime_types();
+	}
 
 	return $vars;
 }


### PR DESCRIPTION
Fixes #670 
Prevent override from the `post_mime_type` offset when it is already defined to make filters work correctly.