### PR TITLE
Fixes #729 Escape error message before printing

### DIFF
--- a/views/notice-temporary.php
+++ b/views/notice-temporary.php
@@ -15,7 +15,7 @@ foreach ( $notices as $type => $type_notices ) {
 	?>
 	<div class="<?php echo $type; ?> settings-error notice is-dismissible">
 		<?php foreach ( $type_notices as $details ) { ?>
-			<p><strong><?php echo $details['message']; ?></strong></p>
+			<p><strong><?php echo esc_html( $details['message'] ); ?></strong></p>
 		<?php } ?>
 	</div>
 	<?php

--- a/views/notice-temporary.php
+++ b/views/notice-temporary.php
@@ -15,7 +15,7 @@ foreach ( $notices as $type => $type_notices ) {
 	?>
 	<div class="<?php echo $type; ?> settings-error notice is-dismissible">
 		<?php foreach ( $type_notices as $details ) { ?>
-			<p><strong><?php echo wp_kses( $details['message'], [ 'code' ] ); ?></strong></p>
+			<p><strong><?php echo wp_kses( $details['message'], [ 'code' => [] ] ); ?></strong></p>
 		<?php } ?>
 	</div>
 	<?php

--- a/views/notice-temporary.php
+++ b/views/notice-temporary.php
@@ -15,7 +15,7 @@ foreach ( $notices as $type => $type_notices ) {
 	?>
 	<div class="<?php echo $type; ?> settings-error notice is-dismissible">
 		<?php foreach ( $type_notices as $details ) { ?>
-			<p><strong><?php echo esc_html( $details['message'] ); ?></strong></p>
+			<p><strong><?php echo wp_kses( $details['message'], [ 'code' ] ); ?></strong></p>
 		<?php } ?>
 	</div>
 	<?php


### PR DESCRIPTION
Following the audit, use `esc_html()` to escape the notice message before printing it.

Fixes #729 