### PR TITLE
Closes #734: Deprecated notice Imagify_Files_Iterator::accept()

### DIFF
--- a/inc/classes/class-imagify-files-iterator.php
+++ b/inc/classes/class-imagify-files-iterator.php
@@ -62,7 +62,7 @@ class Imagify_Files_Iterator extends FilterIterator {
 	 *
 	 * @return bool Returns whether the current element of the iterator is acceptable through this filter.
 	 */
-	public function accept() {
+	public function accept(): bool {
 		static $extensions, $has_extension_method;
 
 		$file_path = $this->current()->getPathname();

--- a/inc/classes/class-imagify-files-recursive-iterator.php
+++ b/inc/classes/class-imagify-files-recursive-iterator.php
@@ -52,7 +52,7 @@ class Imagify_Files_Recursive_Iterator extends RecursiveFilterIterator {
 	 *
 	 * @return bool Returns whether the current element of the iterator is acceptable through this filter.
 	 */
-	public function accept() {
+	public function accept(): bool {
 		static $extensions, $has_extension_method;
 
 		$file_path = $this->current()->getPathname();


### PR DESCRIPTION
## Description

*Please include a summary of the change and which issue is fixed/closed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

With PHP 8.0+ a notice was appearing while using custom folders. 
```bash
PHP Deprecated:  Return type of Imagify_Files_Iterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /shared/httpd/wprocketest/htdocs/wp-content/plugins/imagify-plugin/inc/classes/class-imagify-files-iterator.php on line 65
```
& 
```bash
PHP Deprecated:  Return type of Imagify_Files_Recursive_Iterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/new.rocketlabsqa.ovh/htdocs/wp-content/plugins/imagify-plugin/inc/classes/class-imagify-files-recursive-iterator.php on line 55
```

This happened because `FilterIterator::accept()` is declared as it will returns a `bool`. However `Imagify_Files_Recursive_Iterator::accept()` wasn't explicitly saying that it will returns a bool. 

Fixes #734 

## Type of change


- Bug fix (non-breaking change which fixes an issue).

## Is the solution different from the one proposed during the grooming?

There wasn't any solution provided, however, I've only added a return type to 2 functions. 

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [ ] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.

