### PR TITLE
Closes 2554: Prevent having a webp bigger than the original

### DIFF
--- a/classes/Optimization/Data/AbstractData.php
+++ b/classes/Optimization/Data/AbstractData.php
@@ -25,6 +25,7 @@ abstract class AbstractData implements DataInterface {
 	 */
 	protected $default_optimization_data = [
 		'status' => '',
+		'message' => '',
 		'level'  => false,
 		'sizes'  => [],
 		'stats'  => [

--- a/classes/Optimization/Data/CustomFolders.php
+++ b/classes/Optimization/Data/CustomFolders.php
@@ -159,6 +159,10 @@ class CustomFolders extends AbstractData {
 				$old_data['hash'] = md5_file( $file_path );
 			}
 
+			if ( key_exists( 'message', $data ) ) {
+				$old_data['message'] = $data['message'];
+			}
+
 			if ( ! $data['success'] ) {
 				/**
 				 * Error.

--- a/classes/Optimization/Data/WP.php
+++ b/classes/Optimization/Data/WP.php
@@ -93,7 +93,12 @@ class WP extends AbstractData {
 			'original_size'  => 0,
 			'optimized_size' => 0,
 			'percent'        => 0,
+			'message'        => '',
 		], $old_data['stats'] );
+
+		if ( key_exists( 'message', $data ) ) {
+			$old_data['message'] = $data['message'];
+		}
 
 		if ( ! $data['success'] ) {
 			/**

--- a/classes/Optimization/File.php
+++ b/classes/Optimization/File.php
@@ -530,6 +530,10 @@ class File {
 			return new \WP_Error( 'temp_file_not_found', $temp_file->get_error_message() );
 		}
 
+		if(property_exists($response, 'message' )) {
+			$args['convert'] = '';
+		}
+
 		if ( 'webp' === $args['convert'] ) {
 			$destination_path = $this->get_path_to_webp();
 			$this->path       = $destination_path;

--- a/classes/Optimization/File.php
+++ b/classes/Optimization/File.php
@@ -530,7 +530,7 @@ class File {
 			return new \WP_Error( 'temp_file_not_found', $temp_file->get_error_message() );
 		}
 
-		if(property_exists($response, 'message' )) {
+		if ( property_exists( $response, 'message' ) ) {
 			$args['convert'] = '';
 		}
 

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -659,8 +659,8 @@ abstract class AbstractProcess implements ProcessInterface {
 
 					if ( property_exists( $response, 'message' ) ) {
 						$path_is_temp = false;
-						if($path !== $sizes[ $thumb_size ]['path']) {
-							$this->filesystem->delete($path);
+						if ( $path !== $sizes[ $thumb_size ]['path'] ) {
+							$this->filesystem->delete( $path );
 						}
 						$path = $sizes[ $thumb_size ]['path'];
 					}

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -656,6 +656,11 @@ abstract class AbstractProcess implements ProcessInterface {
 						'non_webp_file_path'  => $sizes[ $thumb_size ]['path'], // Don't use $path nor $file->get_path(), it may return the path to a temporary file.
 						'optimization_level'  => $optimization_level,
 					] );
+
+					if(property_exists( $response, 'message' )) {
+						$path_is_temp = false;
+					}
+
 				}
 			}
 		}
@@ -731,7 +736,7 @@ abstract class AbstractProcess implements ProcessInterface {
 		}
 
 		// Optimization succeeded.
-		if ( $args['is_webp'] ) {
+		if (! property_exists( $args['response'], 'message' ) && $args['is_webp'] ) {
 			/**
 			 * We just created a WebP version:
 			 * Check if it is lighter than the (maybe optimized) non-WebP file.
@@ -776,7 +781,7 @@ abstract class AbstractProcess implements ProcessInterface {
 		$webp_size      = $args['non_webp_thumb_size'] . static::WEBP_SUFFIX;
 		$webp_file_size = $this->get_data()->get_size_data( $webp_size, 'optimized_size' );
 
-		if ( ! $webp_file_size || $webp_file_size < $args['response']->new_size ) {
+		if ( property_exists( $args['response'], 'message' ) || ! $webp_file_size || $webp_file_size < $args['response']->new_size ) {
 			// The WebP file is lighter than this one.
 			return $args['response'];
 		}
@@ -966,7 +971,7 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Then we use the backup file to create temporary files.
 	 */
 
-	/**
+	/**w
 	 * Create a temporary copy of a size file.
 	 *
 	 * @since 1.9
@@ -1787,6 +1792,8 @@ abstract class AbstractProcess implements ProcessInterface {
 		 * @param object $media_data The DataInterface instance of the media.
 		 */
 		$data = (array) apply_filters( "imagify{$_unauthorized}_file_optimization_data", $data, $response, $size, $level, $this->get_data() );
+
+		$size = str_replace('@imagify-webp', '', $size);
 
 		// Store.
 		$this->get_data()->update_size_optimization_data( $size, $data );

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -657,10 +657,9 @@ abstract class AbstractProcess implements ProcessInterface {
 						'optimization_level'  => $optimization_level,
 					] );
 
-					if(property_exists( $response, 'message' )) {
+					if ( property_exists( $response, 'message' ) ) {
 						$path_is_temp = false;
 					}
-
 				}
 			}
 		}
@@ -736,7 +735,7 @@ abstract class AbstractProcess implements ProcessInterface {
 		}
 
 		// Optimization succeeded.
-		if (! property_exists( $args['response'], 'message' ) && $args['is_webp'] ) {
+		if ( ! property_exists( $args['response'], 'message' ) && $args['is_webp'] ) {
 			/**
 			 * We just created a WebP version:
 			 * Check if it is lighter than the (maybe optimized) non-WebP file.
@@ -1793,7 +1792,7 @@ abstract class AbstractProcess implements ProcessInterface {
 		 */
 		$data = (array) apply_filters( "imagify{$_unauthorized}_file_optimization_data", $data, $response, $size, $level, $this->get_data() );
 
-		$size = str_replace('@imagify-webp', '', $size);
+		$size = str_replace( '@imagify-webp', '', $size );
 
 		// Store.
 		$this->get_data()->update_size_optimization_data( $size, $data );

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -659,6 +659,10 @@ abstract class AbstractProcess implements ProcessInterface {
 
 					if ( property_exists( $response, 'message' ) ) {
 						$path_is_temp = false;
+						if($path !== $sizes[ $thumb_size ]['path']) {
+							$this->filesystem->delete($path);
+						}
+						$path = $sizes[ $thumb_size ]['path'];
 					}
 				}
 			}

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -970,7 +970,7 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * Then we use the backup file to create temporary files.
 	 */
 
-	/**w
+	/**
 	 * Create a temporary copy of a size file.
 	 *
 	 * @since 1.9
@@ -1792,8 +1792,9 @@ abstract class AbstractProcess implements ProcessInterface {
 		 */
 		$data = (array) apply_filters( "imagify{$_unauthorized}_file_optimization_data", $data, $response, $size, $level, $this->get_data() );
 
-		$size = str_replace( '@imagify-webp', '', $size );
-
+		if ( property_exists( $response, 'message' ) ) {
+			$size = str_replace( '@imagify-webp', '', $size );
+		}
 		// Store.
 		$this->get_data()->update_size_optimization_data( $size, $data );
 

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -1757,8 +1757,8 @@ abstract class AbstractProcess implements ProcessInterface {
 
 			// Size data.
 			$data['success']        = true;
-			if(property_exists($response, 'message')) {
-				$data['message']  = imagify_translate_api_message($response->message);
+			if ( property_exists( $response, 'message' ) ) {
+				$data['message']  = imagify_translate_api_message( $response->message );
 			}
 			$data['original_size']  = $response->original_size;
 			$data['optimized_size'] = $response->new_size;

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -1757,6 +1757,9 @@ abstract class AbstractProcess implements ProcessInterface {
 
 			// Size data.
 			$data['success']        = true;
+			if(property_exists($response, 'message')) {
+				$data['message']  = imagify_translate_api_message($response->message);
+			}
 			$data['original_size']  = $response->original_size;
 			$data['optimized_size'] = $response->new_size;
 		}

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -1561,13 +1561,13 @@ abstract class AbstractProcess implements ProcessInterface {
 			return false;
 		}
 
-		$keys = array_keys($sizes);
-		$non_webp_keys = array_values(array_filter($keys, function ($key) {
-			return strpos($key, static::WEBP_SUFFIX) === false;
+		$keys = array_keys( $sizes );
+		$non_webp_keys = array_values(array_filter($keys, function ( $key ) {
+			return strpos( $key, static::WEBP_SUFFIX ) === false;
 		}));
 
-		return array_reduce($non_webp_keys, function ($is_fully, $key) use ($sizes) {
-			return key_exists($key. self::WEBP_SUFFIX, $sizes) && $is_fully;
+		return array_reduce($non_webp_keys, function ( $is_fully, $key ) use ( $sizes ) {
+			return key_exists( $key . self::WEBP_SUFFIX, $sizes ) && $is_fully;
 		}, true);
 	}
 

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -1540,6 +1540,38 @@ abstract class AbstractProcess implements ProcessInterface {
 	}
 
 	/**
+	 * Tell if the media has all WebP versions.
+	 *
+	 * @return bool
+	 */
+	public function is_full_webp() {
+		if ( ! $this->is_valid() ) {
+			return false;
+		}
+
+		if ( ! $this->get_media()->is_image() ) {
+			return false;
+		}
+
+		$data = $this->get_data()->get_optimization_data();
+
+		$sizes = $data['sizes'];
+
+		if ( empty( $sizes ) ) {
+			return false;
+		}
+
+		$keys = array_keys($sizes);
+		$non_webp_keys = array_values(array_filter($keys, function ($key) {
+			return strpos($key, static::WEBP_SUFFIX) === false;
+		}));
+
+		return array_reduce($non_webp_keys, function ($is_fully, $key) use ($sizes) {
+			return key_exists($key. self::WEBP_SUFFIX, $sizes) && $is_fully;
+		}, true);
+	}
+
+	/**
 	 * Tell if a WebP version can be created for the given file.
 	 * Make sure the file is an image before using this method.
 	 *

--- a/classes/Optimization/Process/ProcessInterface.php
+++ b/classes/Optimization/Process/ProcessInterface.php
@@ -275,6 +275,13 @@ interface ProcessInterface {
 	public function is_size_webp( $size_name );
 
 	/**
+	 * Tell if the media has all WebP versions.
+	 *
+	 * @return bool
+	 */
+	public function is_full_webp();
+
+	/**
 	 * Tell if the media has WebP versions.
 	 *
 	 * @since  1.9

--- a/inc/classes/class-imagify-files-list-table.php
+++ b/inc/classes/class-imagify-files-list-table.php
@@ -612,6 +612,10 @@ class Imagify_Files_List_Table extends WP_List_Table {
 						<span class="data"><?php esc_html_e( 'WebP generated:', 'imagify' ); ?></span>
 						<strong class="data-value"><?php echo esc_html( $has_webp ); ?></strong>
 					</li>
+					<li class="imagify-data-item">
+						<span class="data"><?php esc_html_e( 'WebP generated:', 'imagify' ); ?></span>
+						<strong class="data-value"><?php echo esc_html( $has_webp ); ?></strong>
+					</li>
 					<?php
 				}
 			}

--- a/inc/classes/class-imagify.php
+++ b/inc/classes/class-imagify.php
@@ -443,7 +443,7 @@ class Imagify {
 		 * @param string $url URL from the call.
 		 * @param array $args Arguments from the call.
 		 */
-		$response = apply_filters('pre_imagify_request', null, $url, $args);
+		$response = apply_filters( 'pre_imagify_request', null, $url, $args );
 
 		if ( $response ) {
 			return $response;

--- a/inc/classes/class-imagify.php
+++ b/inc/classes/class-imagify.php
@@ -436,6 +436,19 @@ class Imagify {
 			return new WP_Error( 'curl', 'cURL isn\'t installed on the server.' );
 		}
 
+		/**
+		 * Allows to mock Imagify calls to the API.
+		 *
+		 * @param stdClass|null $response Response from the call.
+		 * @param string $url URL from the call.
+		 * @param array $args Arguments from the call.
+		 */
+		$response = apply_filters('pre_imagify_request', null, $url, $args);
+
+		if ( $response ) {
+			return $response;
+		}
+
 		try {
 			$url = self::API_ENDPOINT . $url;
 			$ch  = curl_init();

--- a/inc/functions/admin-ui.php
+++ b/inc/functions/admin-ui.php
@@ -96,7 +96,7 @@ function get_imagify_attachment_optimization_text( $process ) {
 	if ( $media->is_image() ) {
 		$has_webp = $process->has_webp() ? __( 'Yes', 'imagify' ) : __( 'No', 'imagify' );
 
-		if( $process->has_webp() ) {
+		if ( $process->has_webp() ) {
 			$has_webp = $process->is_full_webp() ? __( 'Yes', 'imagify' ) : __( 'Partially', 'imagify' );
 		}
 		$output  .= $output_before . '<span class="data">' . __( 'WebP generated:', 'imagify' ) . '</span> <strong class="big">' . esc_html( $has_webp ) . '</strong>' . $output_after;

--- a/inc/functions/admin-ui.php
+++ b/inc/functions/admin-ui.php
@@ -95,6 +95,10 @@ function get_imagify_attachment_optimization_text( $process ) {
 
 	if ( $media->is_image() ) {
 		$has_webp = $process->has_webp() ? __( 'Yes', 'imagify' ) : __( 'No', 'imagify' );
+
+		if( $process->has_webp() ) {
+			$has_webp = $process->is_full_webp() ? __( 'Yes', 'imagify' ) : __( 'Partially', 'imagify' );
+		}
 		$output  .= $output_before . '<span class="data">' . __( 'WebP generated:', 'imagify' ) . '</span> <strong class="big">' . esc_html( $has_webp ) . '</strong>' . $output_after;
 
 		$total_optimized_thumbnails = $data->get_optimized_sizes_count();

--- a/inc/functions/admin-ui.php
+++ b/inc/functions/admin-ui.php
@@ -42,6 +42,7 @@ function get_imagify_attachment_optimization_text( $process ) {
 	}
 
 	$data               = $process->get_data();
+	$optimized_data     = $data->get_optimization_data();
 	$attachment_id      = $media->get_id();
 	$optimization_level = imagify_get_optimization_level_label( $data->get_optimization_level() );
 
@@ -49,8 +50,8 @@ function get_imagify_attachment_optimization_text( $process ) {
 		$output .= $output_before . '<span class="data">' . __( 'New Filesize:', 'imagify' ) . '</span> <strong class="big">' . $data->get_optimized_size() . '</strong>' . $output_after;
 	}
 
-	if ( key_exists('message', $data) ) {
-		$output .= $output_before . '<span class="data">' . $data['message'] . '</span>' . $output_after;
+	if ( key_exists( 'message', $optimized_data ) ) {
+		$output .= $output_before . '<span class="data">' . __( 'Convert:', 'imagify' ) . '</span> <strong class="big">' . $optimized_data['message'] . '</strong>' . $output_after;
 	}
 
 	$chart = '';

--- a/inc/functions/admin-ui.php
+++ b/inc/functions/admin-ui.php
@@ -49,6 +49,10 @@ function get_imagify_attachment_optimization_text( $process ) {
 		$output .= $output_before . '<span class="data">' . __( 'New Filesize:', 'imagify' ) . '</span> <strong class="big">' . $data->get_optimized_size() . '</strong>' . $output_after;
 	}
 
+	if ( key_exists('message', $data) ) {
+		$output .= $output_before . '<span class="data">' . $data['message'] . '</span>' . $output_after;
+	}
+
 	$chart = '';
 
 	if ( ! $is_media_page ) {

--- a/inc/functions/admin-ui.php
+++ b/inc/functions/admin-ui.php
@@ -94,7 +94,7 @@ function get_imagify_attachment_optimization_text( $process ) {
 	$output .= $output_before . '<span class="data">' . __( 'Level:', 'imagify' ) . '</span> <strong>' . $optimization_level . '</strong>' . $output_after;
 
 	if ( $media->is_image() ) {
-		$has_webp = $process->has_webp() && ! key_exists( 'message', $optimized_data ) ? __( 'Yes', 'imagify' ) : __( 'No', 'imagify' );
+		$has_webp = $process->has_webp() ? __( 'Yes', 'imagify' ) : __( 'No', 'imagify' );
 		$output  .= $output_before . '<span class="data">' . __( 'WebP generated:', 'imagify' ) . '</span> <strong class="big">' . esc_html( $has_webp ) . '</strong>' . $output_after;
 
 		$total_optimized_thumbnails = $data->get_optimized_sizes_count();

--- a/inc/functions/admin-ui.php
+++ b/inc/functions/admin-ui.php
@@ -50,7 +50,7 @@ function get_imagify_attachment_optimization_text( $process ) {
 		$output .= $output_before . '<span class="data">' . __( 'New Filesize:', 'imagify' ) . '</span> <strong class="big">' . $data->get_optimized_size() . '</strong>' . $output_after;
 	}
 
-	if ( key_exists( 'message', $optimized_data ) ) {
+	if ( key_exists( 'message', $optimized_data ) && $optimized_data['message'] ) {
 		$output .= $output_before . '<span class="data">' . __( 'Convert:', 'imagify' ) . '</span> <strong class="big">' . $optimized_data['message'] . '</strong>' . $output_after;
 	}
 

--- a/inc/functions/admin-ui.php
+++ b/inc/functions/admin-ui.php
@@ -94,7 +94,7 @@ function get_imagify_attachment_optimization_text( $process ) {
 	$output .= $output_before . '<span class="data">' . __( 'Level:', 'imagify' ) . '</span> <strong>' . $optimization_level . '</strong>' . $output_after;
 
 	if ( $media->is_image() ) {
-		$has_webp = $process->has_webp() ? __( 'Yes', 'imagify' ) : __( 'No', 'imagify' );
+		$has_webp = $process->has_webp() && ! key_exists( 'message', $optimized_data ) ? __( 'Yes', 'imagify' ) : __( 'No', 'imagify' );
 		$output  .= $output_before . '<span class="data">' . __( 'WebP generated:', 'imagify' ) . '</span> <strong class="big">' . esc_html( $has_webp ) . '</strong>' . $output_after;
 
 		$total_optimized_thumbnails = $data->get_optimized_sizes_count();

--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -164,7 +164,7 @@ function get_imagify_max_image_size() {
  */
 function imagify_translate_api_message( $message ) {
 	if ( ! $message ) {
-		return imagify_translate_api_message( 'Unknown error occurred' );
+		$message = 'Unknown error occurred';
 	}
 
 	if ( is_wp_error( $message ) ) {
@@ -199,6 +199,7 @@ function imagify_translate_api_message( $message ) {
 			'</a>'
 		),
 		'Your image is too big to be uploaded on our server'                                       => __( 'Your file is too big to be uploaded on our server.', 'imagify' ),
+		'Webp is less performant than original'                                                    => __( 'Webp is less performant than original', 'imagify' ),
 		'Our server returned an invalid response'                                                  => __( 'Our server returned an invalid response.', 'imagify' ),
 		'cURL isn\'t installed on the server'                                                      => __( 'cURL is not available on the server.', 'imagify' ),
 		// API messages.

--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -199,7 +199,7 @@ function imagify_translate_api_message( $message ) {
 			'</a>'
 		),
 		'Your image is too big to be uploaded on our server'                                       => __( 'Your file is too big to be uploaded on our server.', 'imagify' ),
-		'Webp is less performant than original'                                                    => __( 'Webp is less performant than original', 'imagify' ),
+		'Webp is less performant than original'                                                    => __( 'WebP file is larger than the original image', 'imagify' ),
 		'Our server returned an invalid response'                                                  => __( 'Our server returned an invalid response.', 'imagify' ),
 		'cURL isn\'t installed on the server'                                                      => __( 'cURL is not available on the server.', 'imagify' ),
 		// API messages.


### PR DESCRIPTION
## Description
Fixes #2554

Display the message when we display a original format instead of the webp one.

## Type of change

*Please delete options that are not relevant.*

- New feature (non-breaking change which adds functionality).

## Is the solution different from the one proposed during the grooming?

No.

# Checklists

## Generic development checklist

- [ ] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [ ] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [ ] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.

*If not, detail what you could not test.*

*Please describe any additional tests you performed.*
