### PR TITLE
Closes #822: The filter to enable webP along with AVIF is not working

### DIFF
--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -1537,23 +1537,29 @@ abstract class AbstractProcess implements ProcessInterface {
 		$matches = [];
 
 		foreach ( $formats as $format ) {
-			switch ( $format ) {
-				case 'avif':
-					$suffix = preg_quote( static::AVIF_SUFFIX, '/' );
-					if ( preg_match( '/^(?<size>.+)' . $suffix . '$/', $size_name, $matches ) ) {
-						return $matches['size'];
-					}
-					break;
-				case 'webp':
-					$suffix = preg_quote( static::WEBP_SUFFIX, '/' );
-					if ( preg_match( '/^(?<size>.+)' . $suffix . '$/', $size_name, $matches ) ) {
-						return $matches['size'];
-					}
-					break;
+			$suffix = preg_quote( $this->get_suffix_from_format( $format ), '/' );
+
+			if ( preg_match( '/^(?<size>.+)' . $suffix . '$/', $size_name, $matches ) ) {
+				return $matches['size'];
 			}
 		}
 
 		return false;
+	}
+
+	/**
+	 * Get suffix from format.
+	 *
+	 * @param string $format Format extension of next-gen image.
+	 * @return string
+	 */
+	private function get_suffix_from_format( string $format ): string {
+		$suffixes = [
+			'avif' => static::AVIF_SUFFIX,
+			'webp' => static::WEBP_SUFFIX,
+		];
+
+		return $suffixes[ $format ];
 	}
 
 	/**

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -1534,7 +1534,6 @@ abstract class AbstractProcess implements ProcessInterface {
 	 */
 	public function is_size_next_gen( $size_name ) {
 		$formats = imagify_nextgen_images_formats();
-		$matches = [];
 
 		foreach ( $formats as $format ) {
 			$suffix = preg_quote( $this->get_suffix_from_format( $format ), '/' );

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -1533,7 +1533,7 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * @return string|bool The unsuffixed name of the size if next-gen. False if not next-gen.
 	 */
 	public function is_size_next_gen( $size_name ) {
-        $formats = imagify_nextgen_images_formats();
+		$formats = imagify_nextgen_images_formats();
 		$matches = [];
 
 		foreach ( $formats as $format ) {
@@ -1543,16 +1543,18 @@ abstract class AbstractProcess implements ProcessInterface {
 					if ( preg_match( '/^(?<size>.+)' . $suffix . '$/', $size_name, $matches ) ) {
 						return $matches['size'];
 					}
+					break;
 				case 'webp':
 					$suffix = preg_quote( static::WEBP_SUFFIX, '/' );
 					if ( preg_match( '/^(?<size>.+)' . $suffix . '$/', $size_name, $matches ) ) {
 						return $matches['size'];
 					}
+					break;
 			}
-        }
-        
-        return false;
-    }
+		}
+
+		return false;
+	}
 
 	/**
 	 * Tell if the media has a next gen format.

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -1533,23 +1533,26 @@ abstract class AbstractProcess implements ProcessInterface {
 	 * @return string|bool The unsuffixed name of the size if next-gen. False if not next-gen.
 	 */
 	public function is_size_next_gen( $size_name ) {
-		$formats = imagify_nextgen_images_formats();
-		$suffix  = [];
+        $formats = imagify_nextgen_images_formats();
+		$matches = [];
 
 		foreach ( $formats as $format ) {
-			if ( 'avif' === $format ) {
-				$suffix[] = preg_quote( static::AVIF_SUFFIX, '/' );
-			} elseif ( 'webp' === $format ) {
-				$suffix[] = preg_quote( static::WEBP_SUFFIX, '/' );
+			switch ( $format ) {
+				case 'avif':
+					$suffix = preg_quote( static::AVIF_SUFFIX, '/' );
+					if ( preg_match( '/^(?<size>.+)' . $suffix . '$/', $size_name, $matches ) ) {
+						return $matches['size'];
+					}
+				case 'webp':
+					$suffix = preg_quote( static::WEBP_SUFFIX, '/' );
+					if ( preg_match( '/^(?<size>.+)' . $suffix . '$/', $size_name, $matches ) ) {
+						return $matches['size'];
+					}
 			}
-		}
-
-		if ( preg_match( '/^(?<size>.+)' . implode( '|', $suffix ) . '$/', $size_name, $matches ) ) {
-			return $matches['size'];
-		}
-
-		return false;
-	}
+        }
+        
+        return false;
+    }
 
 	/**
 	 * Tell if the media has a next gen format.


### PR DESCRIPTION
# Description
Fixes the PHP Warning thrown when Webp is enabled via filter.
Fixes #822 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

# Checklists

## Feature validation

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.


## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I named variables and functions explicitely.
- [x] I did not introduce unecessary complexity.

