### PR TITLE
Apply nginx rules for next gen images

### DIFF
--- a/classes/Avif/RewriteRules/Nginx.php
+++ b/classes/Avif/RewriteRules/Nginx.php
@@ -25,24 +25,6 @@ class Nginx extends AbstractNginxDirConfFile {
 	 * @return string
 	 */
 	protected function get_raw_new_contents() {
-		$extensions = $this->get_extensions_pattern();
-		$extensions = str_replace( '|avif', '', $extensions );
-		$home_root  = wp_parse_url( home_url( '/' ) );
-		$home_root  = $home_root['path'];
-
-		return trim( '
-location ~* ^(' . $home_root . '.+)\.(' . $extensions . ')$ {
-	add_header Vary Accept;
-
-	if ($http_accept ~* "avif"){
-		set $imavif A;
-	}
-	if (-f $request_filename.avif) {
-		set $imavif  "${imavif}B";
-	}
-	if ($imavif = AB) {
-		rewrite ^(.*) $1.avif;
-	}
-}' );
+		return '';
 	}
 }

--- a/classes/Webp/RewriteRules/Nginx.php
+++ b/classes/Webp/RewriteRules/Nginx.php
@@ -34,9 +34,9 @@ class Nginx extends AbstractNginxDirConfFile {
 
 		return trim( '
 location ~* ^(' . $home_root . '.+)\.(' . $extensions . ')$ {
-	add_header Vary Accept;
+    add_header Vary Accept;
 
-	set $canavif 1;
+    set $canavif 1;
 
     if ($http_accept !~* "avif"){
         set $canavif 0;

--- a/classes/Webp/RewriteRules/Nginx.php
+++ b/classes/Webp/RewriteRules/Nginx.php
@@ -29,7 +29,6 @@ class Nginx extends AbstractNginxDirConfFile {
 	 */
 	protected function get_raw_new_contents() {
 		$extensions = $this->get_extensions_pattern();
-		$extensions = str_replace( '|webp', '', $extensions );
 		$home_root  = wp_parse_url( home_url( '/' ) );
 		$home_root  = $home_root['path'];
 

--- a/classes/Webp/RewriteRules/Nginx.php
+++ b/classes/Webp/RewriteRules/Nginx.php
@@ -37,15 +37,35 @@ class Nginx extends AbstractNginxDirConfFile {
 location ~* ^(' . $home_root . '.+)\.(' . $extensions . ')$ {
 	add_header Vary Accept;
 
-	if ($http_accept ~* "webp"){
-		set $imwebp A;
-	}
-	if (-f $request_filename.webp) {
-		set $imwebp  "${imwebp}B";
-	}
-	if ($imwebp = AB) {
-		rewrite ^(.*) $1.webp;
-	}
+	set $canavif 1;
+
+    if ($http_accept !~* "avif"){
+        set $canavif 0;
+    }
+
+    if (!-f $request_filename.avif) {
+        set $canavif 0;
+
+    }
+    if ($canavif = 1){
+        rewrite ^(.*) $1.avif;
+        break;
+    }
+
+    set $canwebp 1;
+
+    if ($http_accept !~* "webp"){
+        set $canwebp 0;
+    }
+
+    if (!-f $request_filename.webp) {
+        set $canwebp 0;
+
+    }
+    if ($canwebp = 1){
+        rewrite ^(.*) $1.webp;
+        break;
+    }
 }' );
 	}
 }

--- a/classes/Webp/RewriteRules/Nginx.php
+++ b/classes/Webp/RewriteRules/Nginx.php
@@ -28,7 +28,7 @@ class Nginx extends AbstractNginxDirConfFile {
 	 * @return string
 	 */
 	protected function get_raw_new_contents() {
-		$extensions = $this->get_extensions_pattern();
+		$extensions = $this->get_extensions_pattern() . '|avif';
 		$home_root  = wp_parse_url( home_url( '/' ) );
 		$home_root  = $home_root['path'];
 

--- a/inc/functions/attachments.php
+++ b/inc/functions/attachments.php
@@ -19,6 +19,7 @@ function imagify_get_mime_types( $type = null ) {
 			'png'          => 'image/png',
 			'gif'          => 'image/gif',
 			'webp'         => 'image/webp',
+			'avif'         => 'image/avif',
 		];
 	}
 

--- a/inc/functions/attachments.php
+++ b/inc/functions/attachments.php
@@ -19,7 +19,6 @@ function imagify_get_mime_types( $type = null ) {
 			'png'          => 'image/png',
 			'gif'          => 'image/gif',
 			'webp'         => 'image/webp',
-			'avif'         => 'image/avif',
 		];
 	}
 


### PR DESCRIPTION
# Description

Fixes #821

## Documentation

### User documentation

Here we are playing with rewrite rules so users need to reload their nginx after upload to get those new rules being applied.

### Technical documentation

Here I used the webp class to write the next gen handling rewrite rules so we don't need to run any code with plugin update to remove the old rules and insert the new ones, as I think those webp rules were already there in previous versions.

Also I kept avif rewrite rules empty to unify the code structure and keep it as currently used, but it's not added to the config file at all because it's empty.

If you think this would be confusing having the comment `Imagify: rewrite rules for webp` let me know and I can check how to do this upgrade routine here in imagify.

## Type of change
*Delete options that are not relevant.*

- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies
*List any new dependencies that are required for this change.*

## Risks
*List possible performance & security issues or risks, and explain how they have been mitigated.*

As mentioned above we have two risks:
1. We need to tell users to restart their nginx once our rules are changed, maybe we can use admin notices or add this to our documentation in a clear way.
2. We need to check if the comment in config file is confusing or it;s OK to have `Imagify: rewrite rules for webp` but it's handling webp and avif.

What do u think @piotrbak ?

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Documentation

- [ ] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [ ] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [ ] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [ ] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [ ] I handled errors when needed.
- [ ] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [ ] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [x] I explicitely mentioned performance risks in the PR.
- [ ] I explicitely mentioned security risks in the PR.
