### PR TITLE
Preserve webp setting options with update from versions older than 2.2

### DIFF
--- a/imagify.php
+++ b/imagify.php
@@ -3,7 +3,7 @@
  * Plugin Name: Imagify
  * Plugin URI: https://wordpress.org/plugins/imagify/
  * Description: Dramatically reduce image file sizes without losing quality, make your website load faster, boost your SEO and save money on your bandwidth using Imagify, the new most advanced image optimization tool.
- * Version: 2.2
+ * Version: 2.2.1
  * Requires at least: 5.3
  * Requires PHP: 7.0
  * Author: Imagify – Optimize Images & Convert WebP & Avif
@@ -19,7 +19,7 @@
 defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
 // Imagify defines.
-define( 'IMAGIFY_VERSION',        '2.2' );
+define( 'IMAGIFY_VERSION',        '2.2.1' );
 define( 'IMAGIFY_SLUG',           'imagify' );
 define( 'IMAGIFY_FILE',           __FILE__ );
 define( 'IMAGIFY_PATH',           realpath( plugin_dir_path( IMAGIFY_FILE ) ) . '/' );

--- a/imagify.php
+++ b/imagify.php
@@ -3,7 +3,7 @@
  * Plugin Name: Imagify
  * Plugin URI: https://wordpress.org/plugins/imagify/
  * Description: Dramatically reduce image file sizes without losing quality, make your website load faster, boost your SEO and save money on your bandwidth using Imagify, the new most advanced image optimization tool.
- * Version: 2.2.1
+ * Version: 2.2
  * Requires at least: 5.3
  * Requires PHP: 7.0
  * Author: Imagify – Optimize Images & Convert WebP & Avif
@@ -19,7 +19,7 @@
 defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
 // Imagify defines.
-define( 'IMAGIFY_VERSION',        '2.2.1' );
+define( 'IMAGIFY_VERSION',        '2.2' );
 define( 'IMAGIFY_SLUG',           'imagify' );
 define( 'IMAGIFY_FILE',           __FILE__ );
 define( 'IMAGIFY_PATH',           realpath( plugin_dir_path( IMAGIFY_FILE ) ) . '/' );

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -310,7 +310,7 @@ function _imagify_new_upgrade( $network_version, $site_version ) {
 
 	if ( version_compare( $site_version, '2.2' ) < 0 ) {
 		Imagify_Options::get_instance()->set( 'display_nextgen', Imagify_Options::get_instance()->get( 'display_webp', 0 ) );
-		Imagify_Options::get_instance()->set( 'display_nextgen_method_rewrite', Imagify_Options::get_instance()->get( 'display_webp_method_rewrite', 0 ) );
+		Imagify_Options::get_instance()->set( 'display_nextgen_method_rewrite', Imagify_Options::get_instance()->get( 'display_webp_method_rewrite' ) );
 	}
 }
 add_action( 'imagify_upgrade', '_imagify_new_upgrade', 10, 2 );

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -310,7 +310,7 @@ function _imagify_new_upgrade( $network_version, $site_version ) {
 
 	if ( version_compare( $site_version, '2.2' ) < 0 ) {
 		Imagify_Options::get_instance()->set( 'display_nextgen', Imagify_Options::get_instance()->get( 'display_webp', 0 ) );
-		Imagify_Options::get_instance()->set( 'display_nextgen_method_rewrite', Imagify_Options::get_instance()->get( 'display_webp_method_rewrite' ) );
+		Imagify_Options::get_instance()->set( 'display_nextgen_method', Imagify_Options::get_instance()->get( 'display_webp_method' ) );
 	}
 }
 add_action( 'imagify_upgrade', '_imagify_new_upgrade', 10, 2 );

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -307,6 +307,11 @@ function _imagify_new_upgrade( $network_version, $site_version ) {
 	if ( version_compare( $site_version, '2.0' ) < 0 ) {
 		Imagify_Options::get_instance()->set( 'optimization_level', 2 );
 	}
+
+	if ( version_compare( $site_version, '2.2' ) < 0 ) {
+		Imagify_Options::get_instance()->set( 'display_nextgen', Imagify_Options::get_instance()->get( 'display_webp', 0 ) );
+		Imagify_Options::get_instance()->set( 'display_nextgen_method_rewrite', Imagify_Options::get_instance()->get( 'display_webp_method_rewrite', 0 ) );
+	}
 }
 add_action( 'imagify_upgrade', '_imagify_new_upgrade', 10, 2 );
 

--- a/inc/classes/class-imagify-options.php
+++ b/inc/classes/class-imagify-options.php
@@ -36,11 +36,14 @@ class Imagify_Options extends Imagify_Abstract_Options {
 		'resize_larger_w'        => 0,
 		'display_nextgen'        => 0,
 		'display_nextgen_method' => 'picture',
+		'display_webp'        => 0,
+		'display_webp_method' => 'picture',
 		'cdn_url'                => '',
 		'disallowed-sizes'       => [],
 		'admin_bar_menu'         => 0,
 		'partner_links'          => 0,
 		'convert_to_avif'        => 0,
+		'convert_to_webp'        => 0,
 	];
 
 	/**
@@ -131,6 +134,7 @@ class Imagify_Options extends Imagify_Abstract_Options {
 			case 'resize_larger':
 			case 'convert_to_webp':
 			case 'display_nextgen':
+			case 'display_webp':
 			case 'admin_bar_menu':
 			case 'partner_links':
 			case 'convert_to_avif':
@@ -160,6 +164,7 @@ class Imagify_Options extends Imagify_Abstract_Options {
 				return array_fill_keys( $value, 1 );
 
 			case 'display_nextgen_method':
+			case 'display_webp_method':
 				$values = [
 					'picture' => 1,
 					'rewrite' => 1,


### PR DESCRIPTION
# Description

Fixes #848
Fixes #850

## Documentation

### User documentation

Here we added back the webp option names, so those old options (display_webp, display_webp_method, and convert_to_webp) will be kept on the database but without UI.

Then when the user updates to the latest version we will move those options' values to the corresponding new ones.

### Technical documentation

*Explain how this code works. Diagram & drawings are welcomed.*

## Type of change
*Delete options that are not relevant.*

- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies
*List any new dependencies that are required for this change.*

## Risks
*List possible performance & security issues or risks, and explain how they have been mitigated.*

We only have one risk that I can think of now, having not used settings in the database but it worth having them because also what if any user reverted back to an older version of imagify after updating to the latest version, with this change, he will find everything set properly in older versions too.

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Documentation

- [ ] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [ ] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [ ] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [ ] I wrote comments to explain why it does it.
- [ ] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [ ] I handled errors when needed.
- [ ] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [ ] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [x] I explicitely mentioned performance risks in the PR.
- [ ] I explicitely mentioned security risks in the PR.
