### PR TITLE
Closes #838: Fix the infinite loop of `generate missing next-gen images`

### DIFF
--- a/classes/Bulk/Bulk.php
+++ b/classes/Bulk/Bulk.php
@@ -595,11 +595,6 @@ class Bulk {
 			return;
 		}
 
-		if ( empty( $value['convert_to_avif'] ) ) {
-			// new value is disabled, do nothing.
-			return;
-		}
-
 		$contexts = $this->get_contexts();
 		$formats  = imagify_nextgen_images_formats();
 


### PR DESCRIPTION
# Description
Fix an issue where "Generating missing next-gen files" was stuck in a loop. 

Fixes #838 

## Documentation

### User documentation

Webp will be automatically generated on settings save if AVIF is disabled.

### Technical documentation
The bail-out avoiding the WebP auto-generation has been deleted.

## Type of change
*Delete options that are not relevant.*

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [x] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.

