### PR TITLE
Closes #837: htaccess always modified when saving settings

### DIFF
--- a/classes/Avif/Display.php
+++ b/classes/Avif/Display.php
@@ -47,13 +47,15 @@ class Display implements SubscriberInterface {
 		}
 
 		$enabled = isset( $values['display_nextgen'] ) ? true : false;
+		$was_enabled = (bool) get_imagify_option( 'display_nextgen' );
+
 		$result  = false;
 
-		if ( $enabled ) {
-			// Add the AVIF file type.
+		if ( $enabled && ! $was_enabled ) {
+			// Add the WebP file type.
 			$result = $this->get_server_conf()->add();
-		} elseif ( ! $enabled ) {
-			// Remove the AVIF file type.
+		} elseif ( ! $enabled && $was_enabled ) {
+			// Remove the WebP file type.
 			$result = $this->get_server_conf()->remove();
 		}
 

--- a/classes/Webp/Display.php
+++ b/classes/Webp/Display.php
@@ -53,12 +53,14 @@ class Display implements SubscriberInterface {
 		}
 
 		$enabled = isset( $values['display_nextgen'] ) ? true : false;
+		$was_enabled = (bool) get_imagify_option( 'display_nextgen' );
+
 		$result  = false;
 
-		if ( $enabled ) {
+		if ( $enabled && ! $was_enabled ) {
 			// Add the WebP file type.
 			$result = $this->get_server_conf()->add();
-		} elseif ( ! $enabled ) {
+		} elseif ( ! $enabled && $was_enabled ) {
 			// Remove the WebP file type.
 			$result = $this->get_server_conf()->remove();
 		}


### PR DESCRIPTION
# Description

Fixes #837 

## Documentation

### User documentation

The `.htaccess` was always being modified while saving Imagify settings. 
This PR fix this behavior to modify the `.htaccess` only when there is a change in the settings.

### Technical documentation

We just check if the previous value is the same as the current one before changing the `.htaccess`.

## Type of change
*Delete options that are not relevant.*

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [x] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.
