### PR TITLE
Fixes #872 Prevent fatal error if returned extension value is false

### DIFF
--- a/classes/Optimization/File.php
+++ b/classes/Optimization/File.php
@@ -745,10 +745,9 @@ class File {
 	/**
 	 * Get the file extension.
 	 *
-	 * @since  1.9
-	 * @author Grégory Viguier
+	 * @since 1.9
 	 *
-	 * @return string|null
+	 * @return string|false
 	 */
 	public function get_extension() {
 		return $this->get_file_type()->ext;

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -581,7 +581,12 @@ abstract class AbstractProcess implements ProcessInterface {
 			// This file type is not supported.
 			$extension = $file->get_extension();
 
-			if ( '' === $extension ) {
+			if ( ! $extension ) {
+				$response = new WP_Error(
+					'extension_not_mime',
+					__( 'This file has an extension that does not match a mime type.', 'imagify' )
+				);
+			} elseif ( '' === $extension ) {
 				$response = new WP_Error(
 					'no_extension',
 					__( 'With no extension, this file cannot be optimized.', 'imagify' )


### PR DESCRIPTION
# Description

Prevent a fatal error when the returned extension value is false. Previous version was only handling string values, but `wp_check_filetype()` can return `false`.

Fixes #872

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklists

## Feature validation

- [ ] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
