### PR TITLE
Fix the fatal error Class "WP_List_Table" not found

### DIFF
--- a/inc/classes/class-imagify-files-list-table.php
+++ b/inc/classes/class-imagify-files-list-table.php
@@ -1,6 +1,10 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
+if ( ! class_exists( 'WP_List_Table' ) ) {
+	require_once( ABSPATH . 'wp-admin/includes/class-wp-list-table.php' );
+}
+
 /**
  * Class that display the "custom folders" files.
  *

--- a/inc/classes/class-imagify-files-list-table.php
+++ b/inc/classes/class-imagify-files-list-table.php
@@ -2,7 +2,7 @@
 defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
 if ( ! class_exists( 'WP_List_Table' ) ) {
-	require_once( ABSPATH . 'wp-admin/includes/class-wp-list-table.php' );
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }
 
 /**


### PR DESCRIPTION
# Description

Fixes #869 

## Documentation

### User documentation

Nothing changed, we just guarded against not having this class.

### Technical documentation

We just loaded the file `ABSPATH . 'wp-admin/includes/class-wp-list-table.php'` when this class is not there.

## Type of change
*Delete options that are not relevant.*

- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies

No

## Risks
No risks.

# Checklists

## Feature validation

- [ ] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [ ] I wrote comments to explain why it does it.
- [ ] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [ ] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [ ] I handled errors when needed.
- [ ] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [ ] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [x] I explicitely mentioned performance risks in the PR.
- [x] I explicitely mentioned security risks in the PR.
