### PR TITLE
Adjust priority for template_redirect 

### DIFF
--- a/classes/Picture/Display.php
+++ b/classes/Picture/Display.php
@@ -42,7 +42,7 @@ class Display implements SubscriberInterface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'template_redirect'            => [ 'start_content_process', -1000 ],
+			'template_redirect'            => 'start_content_process',
 			'imagify_process_webp_content' => 'process_content',
 		];
 	}


### PR DESCRIPTION
# Description

Fixes #891

## Documentation

### User documentation

As mentioned in the issue itself, here we fixed the priority of `template_redirect` hook's callback to be `10` instead of `-1000` to fix the buffer closing conflict with WP Rocket.

### Technical documentation

Just changed the priority.

## Type of change
*Delete options that are not relevant.*

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).

## New dependencies
*List any new dependencies that are required for this change.*

## Risks

As I mentioned here:
https://github.com/wp-media/imagify-plugin/issues/891#issuecomment-2283827408

We added this `-1000` priority in the mentioned PR to support rocket CDN so I tested this and it works so we may need to check another CDN plugin to see how it works with this branch.

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [ ] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [ ] I wrote comments to explain why it does it.
- [ ] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [ ] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [ ] I handled errors when needed.
- [ ] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [ ] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [x] I explicitely mentioned performance risks in the PR.
- [ ] I explicitely mentioned security risks in the PR.
