### PR TITLE
Cache user API call for 5 minutes

### DIFF
--- a/Tests/Unit/inc/classes/ImagifyUser/getError.php
+++ b/Tests/Unit/inc/classes/ImagifyUser/getError.php
@@ -31,7 +31,7 @@ class Test_GetError extends TestCase {
 			'is_monthly'                   => true,
 		];
 
-		Functions\when( 'imagify_get_cached_user' )->justReturn( false );
+		Functions\when( 'get_transient' )->justReturn( false );
 		Functions\when( 'get_imagify_user' )->justReturn( $userData );
 
 		$this->assertFalse( ( new User() )->get_error() );

--- a/Tests/Unit/inc/classes/ImagifyUser/getError.php
+++ b/Tests/Unit/inc/classes/ImagifyUser/getError.php
@@ -33,6 +33,7 @@ class Test_GetError extends TestCase {
 
 		Functions\when( 'get_transient' )->justReturn( false );
 		Functions\when( 'get_imagify_user' )->justReturn( $userData );
+		Functions\when( 'set_transient')->justReturn();
 
 		$this->assertFalse( ( new User() )->get_error() );
 	}
@@ -57,6 +58,7 @@ class Test_GetError extends TestCase {
 
 		Functions\when( 'imagify_get_cached_user' )->justReturn( $userData );
 		Functions\expect( 'get_imagify_user' )->never();
+		Functions\when( 'set_transient')->justReturn();
 
 		$this->assertSame( 'imagify@example.com', ( new User() )->email );
 	}
@@ -69,6 +71,7 @@ class Test_GetError extends TestCase {
 
 		Functions\when( 'imagify_get_cached_user' )->justReturn( false );
 		Functions\when( 'get_imagify_user' )->justReturn( $wp_error );
+		Functions\when( 'set_transient')->justReturn();
 
 		$this->assertSame( $wp_error, ( new User() )->get_error() );
 	}

--- a/Tests/Unit/inc/classes/ImagifyUser/getError.php
+++ b/Tests/Unit/inc/classes/ImagifyUser/getError.php
@@ -56,7 +56,7 @@ class Test_GetError extends TestCase {
 			'is_monthly'                   => true,
 		];
 
-		Functions\when( 'imagify_get_cached_user' )->justReturn( $userData );
+		Functions\when( 'get_transient' )->justReturn( $userData );
 		Functions\expect( 'get_imagify_user' )->never();
 		Functions\when( 'set_transient')->justReturn();
 
@@ -69,7 +69,7 @@ class Test_GetError extends TestCase {
 	public function testShouldReturnErrorWhenCouldNotFetchUserData() {
 		$wp_error = new WP_Error( 'error_id', 'Error Message' );
 
-		Functions\when( 'imagify_get_cached_user' )->justReturn( false );
+		Functions\when( 'get_transient' )->justReturn( false );
 		Functions\when( 'get_imagify_user' )->justReturn( $wp_error );
 		Functions\when( 'set_transient')->justReturn();
 

--- a/Tests/Unit/inc/classes/ImagifyUser/getPercentConsumedQuota.php
+++ b/Tests/Unit/inc/classes/ImagifyUser/getPercentConsumedQuota.php
@@ -23,7 +23,7 @@ class Test_GetPercentConsumedQuota extends TestCase {
 	public function testShouldReturnZeroWhenCouldNotFetchUserData() {
 		$wp_error = new WP_Error( 'error_id', 'Error Message' );
 
-		Functions\when( 'imagify_get_cached_user' )->justReturn( false );
+		Functions\when( 'get_transient' )->justReturn( false );
 		Functions\when( 'get_imagify_user' )->justReturn( $wp_error );
 		Functions\expect( 'imagify_round_half_five' )->never();
 
@@ -48,7 +48,7 @@ class Test_GetPercentConsumedQuota extends TestCase {
 			'is_monthly'                   => true,
 		];
 
-		Functions\when( 'imagify_get_cached_user' )->justReturn( false );
+		Functions\when( 'get_transient' )->justReturn( false );
 		Functions\when( 'get_imagify_user' )->justReturn( $userData );
 		Functions\expect( 'imagify_round_half_five' )
 			->twice()

--- a/Tests/Unit/inc/classes/ImagifyUser/getPercentConsumedQuota.php
+++ b/Tests/Unit/inc/classes/ImagifyUser/getPercentConsumedQuota.php
@@ -25,6 +25,7 @@ class Test_GetPercentConsumedQuota extends TestCase {
 
 		Functions\when( 'get_transient' )->justReturn( false );
 		Functions\when( 'get_imagify_user' )->justReturn( $wp_error );
+		Functions\when( 'set_transient')->justReturn();
 		Functions\expect( 'imagify_round_half_five' )->never();
 
 		$this->assertSame( ( new User() )->get_percent_consumed_quota(), 0 );
@@ -50,6 +51,7 @@ class Test_GetPercentConsumedQuota extends TestCase {
 
 		Functions\when( 'get_transient' )->justReturn( false );
 		Functions\when( 'get_imagify_user' )->justReturn( $userData );
+		Functions\when( 'set_transient')->justReturn();
 		Functions\expect( 'imagify_round_half_five' )
 			->twice()
 			->with( 0 ) // extra_quota_consumed.

--- a/Tests/Unit/inc/classes/ImagifyUser/isOverQuota.php
+++ b/Tests/Unit/inc/classes/ImagifyUser/isOverQuota.php
@@ -24,6 +24,7 @@ class Test_IsOverQuota extends TestCase {
 
 		Functions\when( 'get_transient' )->justReturn( false );
 		Functions\when( 'get_imagify_user' )->justReturn( $wp_error );
+		Functions\when( 'set_transient')->justReturn();
 
 		$this->assertFalse( ( new User() )->is_over_quota() );
 	}
@@ -48,6 +49,7 @@ class Test_IsOverQuota extends TestCase {
 
 		Functions\when( 'get_transient' )->justReturn( false );
 		Functions\when( 'get_imagify_user' )->justReturn( $userData );
+		Functions\when( 'set_transient')->justReturn();
 
 		$this->assertFalse( ( new User() )->is_over_quota() );
 	}
@@ -101,6 +103,7 @@ class Test_IsOverQuota extends TestCase {
 	private function createMocks( $userData, $dataPreviousQuotaPercent ) {
 		Functions\when( 'get_transient' )->justReturn( false );
 		Functions\when( 'get_imagify_user' )->justReturn( $userData );
+		Functions\when( 'set_transient')->justReturn();
 		Functions\expect( 'imagify_round_half_five' )
 			->once()
 			->with( 0 ) // extra_quota_consumed.

--- a/Tests/Unit/inc/classes/ImagifyUser/isOverQuota.php
+++ b/Tests/Unit/inc/classes/ImagifyUser/isOverQuota.php
@@ -22,7 +22,7 @@ class Test_IsOverQuota extends TestCase {
 	public function testShouldReturnFalseWhenCouldNotFetchUserData() {
 		$wp_error = new WP_Error( 'error_id', 'Error Message' );
 
-		Functions\when( 'imagify_get_cached_user' )->justReturn( false );
+		Functions\when( 'get_transient' )->justReturn( false );
 		Functions\when( 'get_imagify_user' )->justReturn( $wp_error );
 
 		$this->assertFalse( ( new User() )->is_over_quota() );
@@ -46,7 +46,7 @@ class Test_IsOverQuota extends TestCase {
 			'is_monthly'                   => true,
 		];
 
-		Functions\when( 'imagify_get_cached_user' )->justReturn( false );
+		Functions\when( 'get_transient' )->justReturn( false );
 		Functions\when( 'get_imagify_user' )->justReturn( $userData );
 
 		$this->assertFalse( ( new User() )->is_over_quota() );
@@ -99,7 +99,7 @@ class Test_IsOverQuota extends TestCase {
 	}
 
 	private function createMocks( $userData, $dataPreviousQuotaPercent ) {
-		Functions\when( 'imagify_get_cached_user' )->justReturn( false );
+		Functions\when( 'get_transient' )->justReturn( false );
 		Functions\when( 'get_imagify_user' )->justReturn( $userData );
 		Functions\expect( 'imagify_round_half_five' )
 			->once()

--- a/Tests/bootstrap-functions.php
+++ b/Tests/bootstrap-functions.php
@@ -44,5 +44,6 @@ function init_constants( $test_suite_folder ) {
 
 	if ( 'Unit' === $test_suite_folder && ! defined( 'ABSPATH' ) ) {
 		define( 'ABSPATH', IMAGIFY_PLUGIN_ROOT );
+		define( 'MINUTE_IN_SECONDS', 60 );
 	}
 }

--- a/classes/User/User.php
+++ b/classes/User/User.php
@@ -129,12 +129,13 @@ class User {
 
 		if ( ! $user ) {
 			$user = get_imagify_user();
-			set_transient( 'imagify_user_cache', $user, 5 * MINUTE_IN_SECONDS );
-		}
 
-		if ( is_wp_error( $user ) ) {
-			$this->error = $user;
-			return;
+			if ( is_wp_error( $user ) ) {
+				$this->error = $user;
+				return;
+			}
+
+			set_transient( 'imagify_user_cache', $user, 5 * MINUTE_IN_SECONDS );
 		}
 
 		$this->id                           = $user->id;

--- a/classes/User/User.php
+++ b/classes/User/User.php
@@ -125,7 +125,12 @@ class User {
 	 * @return void
 	 */
 	public function __construct() {
-		$user = imagify_get_cached_user() ?: get_imagify_user();
+		$user = get_transient( 'imagify_user_cache' );
+
+		if ( ! $user ) {
+			$user = get_imagify_user();
+			set_transient( 'imagify_user_cache', $user, 5 * MINUTE_IN_SECONDS );
+		}
 
 		if ( is_wp_error( $user ) ) {
 			$this->error = $user;


### PR DESCRIPTION
# Description

Cache the user API call for 5 minutes to avoid the request on each page load.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

- With current `develop`, using query monitor, you can see there is a request to `https://app.imagify.io/api/users/me/` on every page load
- Using this PR branch, the request happens once, and should not happen again for 5 minutes

## Technical description

### Documentation

Following changes made in #899, #900, #902, the `User` class is used on more pages than before, and this class makes an API call to get the user information, with a timeout of 10 seconds.

Caching the result of the API call allows to prevent the request on every page.

It was not possible to use the existing `imagify_get_cached_user()` function, because this function returns a cache that doesn't match the result from the API call, but a result from the cache of the `User` class itself.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.