### PR TITLE
Cache attachments number count in payment modal for one day

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ When the plugin is disabled, your existing images remain optimized. Backups of t
 Please report security bugs found in the site-reviews plugin's source code through the [Patchstack Vulnerability Disclosure Program](https://patchstack.com/database/vdp/imagify). The Patchstack team will assist you with verification, CVE assignment and take care of notifying the developers of this plugin.
 
 ## Changelog
+### 2.2.3.2
+- Enhancement: Optimize and cache the modal attachment counter database query.
+
 ### 2.2.3.1
 - Enhancement: Decrease the amount of requests to imagify servers.
 

--- a/imagify.php
+++ b/imagify.php
@@ -3,7 +3,7 @@
  * Plugin Name: Imagify
  * Plugin URI: https://wordpress.org/plugins/imagify/
  * Description: Dramatically reduce image file sizes without losing quality, make your website load faster, boost your SEO and save money on your bandwidth using Imagify, the new most advanced image optimization tool.
- * Version: 2.2.3.1
+ * Version: 2.2.3.2
  * Requires at least: 5.3
  * Requires PHP: 7.3
  * Author: Imagify Image Optimizer – Optimize Images & Convert WebP & Avif
@@ -19,7 +19,7 @@
 defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
 // Imagify defines.
-define( 'IMAGIFY_VERSION',        '2.2.3' );
+define( 'IMAGIFY_VERSION',        '2.2.3.2' );
 define( 'IMAGIFY_SLUG',           'imagify' );
 define( 'IMAGIFY_FILE',           __FILE__ );
 define( 'IMAGIFY_PATH',           realpath( plugin_dir_path( IMAGIFY_FILE ) ) . '/' );

--- a/inc/classes/class-imagify-views.php
+++ b/inc/classes/class-imagify-views.php
@@ -638,7 +638,31 @@ class Imagify_Views {
 	 * Print the payment modal.
 	 */
 	public function print_modal_payment() {
-		$this->print_template( 'modal-payment' );
+		$this->print_template(
+			'modal-payment',
+			[
+				'attachments_number' => $this->get_attachments_number_modal(),
+			]
+		);
+	}
+
+	/**
+	 * Get the number of attachments to display in the payment modal.
+	 *
+	 * @return int
+	 */
+	private function get_attachments_number_modal() {
+		$transient = get_transient( 'imagify_attachments_number_modal' );
+
+		if ( false !== $transient ) {
+			return $transient;
+		}
+
+		$attachments_number = imagify_count_attachments() + Imagify_Files_Stats::count_all_files();
+
+		set_transient( 'imagify_attachments_number_modal', $attachments_number, 1 * DAY_IN_SECONDS );
+
+		return $attachments_number;
 	}
 
 	/** ----------------------------------------------------------------------------------------- */

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Imagify – Optimize Images & Convert WebP & AVIF | Compress Images Easily ===
 Contributors: wp_rocket, imagify
 Tags: optimize images, image optimization, compress images, convert webp, convert AVIF
-Tested up to: 6.6
-Stable tag: 2.2.3.1
+Tested up to: 6.7
+Stable tag: 2.2.3.2
 Requires PHP: 7.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -266,6 +266,9 @@ You can report any security bugs found in the source code of the site-reviews pl
 4. Other Media Page
 
 == Changelog ==
+= 2.2.3.2 =
+- Enhancement: Optimize and cache the modal attachment counter database query.
+
 = 2.2.3.1 =
 - Enhancement: Decrease the amount of requests to imagify servers.
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -27,6 +27,8 @@ delete_transient( 'imagify_large_library' );
 delete_transient( 'imagify_max_image_size' );
 delete_transient( 'imagify_user' );
 delete_transient( 'imagify_stat_without_next_gen' );
+delete_transient( 'imagify_attachments_number_modal' );
+delete_transient( 'imagify_user_cache' );
 
 // Delete transients.
 $transients = implode( '" OR option_name LIKE "', array(

--- a/views/modal-payment.php
+++ b/views/modal-payment.php
@@ -26,12 +26,10 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 							<p>
 								<span class="imagify-border-styled">
 									<?php
-									$attachments_number = imagify_count_attachments() + Imagify_Files_Stats::count_all_files();
-
 									printf(
 										/* translators: %s is a formatted number (don't use %d). */
-										_n( 'You have %s original image', 'You have %s original images', $attachments_number, 'imagify' ),
-										'</span><span class="imagify-big-number">' . number_format_i18n( $attachments_number ) . '</span><span class="imagify-border-styled">'
+										_n( 'You have %s original image', 'You have %s original images', $data['attachments_number'], 'imagify' ),
+										'</span><span class="imagify-big-number">' . number_format_i18n( $data['attachments_number'] ) . '</span><span class="imagify-border-styled">'
 									);
 									?>
 								</span>


### PR DESCRIPTION
# Description

Prevent excessive SQL requests on all pages by caching the attachments number count in the payment modal for a day.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

- Load any admin page
- Look at the number of SQL requests made by Imagify (using Query Monitor)
- Reload any page
- The number of SQL requests should be reduced + transient `imagify_attachments_number_modal` created

## Technical description

### Documentation

Use a transient to cache the value for a day

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
