### PR TITLE
Fixes #975 Update translations loading

### DIFF
--- a/classes/Plugin.php
+++ b/classes/Plugin.php
@@ -131,9 +131,6 @@ class Plugin {
 
 		add_action( 'init', [ $this, 'maybe_activate' ] );
 
-		// Load plugin translations.
-		imagify_load_translations();
-
 		imagify_add_command( new BulkOptimizeCommand() );
 		imagify_add_command( new GenerateMissingNextgenCommand() );
 

--- a/imagify.php
+++ b/imagify.php
@@ -104,20 +104,12 @@ function imagify_pass_requirements() {
 /**
  * Load plugin translations.
  *
- * @since  1.9
- * @author Grégory Viguier
+ * @since 1.9
  */
 function imagify_load_translations() {
-	static $done = false;
-
-	if ( $done ) {
-		return;
-	}
-
-	$done = true;
-
 	load_plugin_textdomain( 'imagify', false, dirname( plugin_basename( IMAGIFY_FILE ) ) . '/languages/' );
 }
+add_action( 'init', 'imagify_load_translations' );
 
 /**
  * Set a transient on plugin activation, it will be used later to trigger activation hooks after the plugin is loaded.

--- a/inc/classes/class-imagify-requirements-check.php
+++ b/inc/classes/class-imagify-requirements-check.php
@@ -230,16 +230,12 @@ class Imagify_Requirements_Check {
 	/**
 	 * Warn if PHP version is less than 5.4 and offers to rollback.
 	 *
-	 * @since  1.9
-	 * @access public
-	 * @author Grégory Viguier
+	 * @since 1.9
 	 */
 	public function print_notice() {
 		if ( ! $this->current_user_can() ) {
 			return;
 		}
-
-		imagify_load_translations();
 
 		$message      = array();
 		$required     = array();
@@ -273,9 +269,7 @@ class Imagify_Requirements_Check {
 	/**
 	 * Do the rollback.
 	 *
-	 * @since  1.9
-	 * @access public
-	 * @author Grégory Viguier
+	 * @since 1.9
 	 */
 	public function rollback() {
 		check_ajax_referer( 'imagify_rollback' );
@@ -283,8 +277,6 @@ class Imagify_Requirements_Check {
 		if ( ! $this->current_user_can() ) {
 			wp_die();
 		}
-
-		imagify_load_translations();
 
 		$plugin_transient = get_site_transient( 'update_plugins' );
 		$plugin_basename  = plugin_basename( $this->plugin_file );


### PR DESCRIPTION
# Description

Fixes #975

Prevent warning displayed since WordPress 6.7 related to translations being loaded too early.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

I'm not sure how the warning is happening in Imagify, I could see it sometimes but not in a way that is systematically reproducible.

## Technical description

### Documentation

Hook translation function on `init` and remove direct calls to it.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.