### PR TITLE
Fixes #984 Make settings page checkboxes clickable again

### DIFF
--- a/inc/classes/class-imagify-settings.php
+++ b/inc/classes/class-imagify-settings.php
@@ -491,7 +491,7 @@ class Imagify_Settings {
 		$attributes         = array_merge( $attributes, $args['attributes'] );
 		$args['attributes'] = self::build_attributes( $attributes );
 		?>
-		<input type="checkbox" value="1" 
+		<input type="checkbox" value="1"
 		<?php
 		checked( $current_value, 1 );
 		?>
@@ -500,29 +500,17 @@ class Imagify_Settings {
 		?>
 />
 		<!-- Empty onclick attribute to make clickable labels on iTruc & Mac -->
-		<label for="
-		<?php
-		echo $attributes['id'];
-		?>
-		" onclick="">
-		<?php
-			echo $args['label'];
-		?>
+		<label for="<?php echo $attributes['id']; ?>" onclick="">
+		<?php echo $args['label']; ?>
 </label>
 		<?php
 		if ( ! $args['info'] ) {
 			return;
 		}
 		?>
-		<span id="
-		<?php
-		echo $attributes['aria-describedby'];
-		?>
-		" class="imagify-info">
+		<span id="<?php echo $attributes['aria-describedby']; ?>" class="imagify-info">
 			<span class="dashicons dashicons-info"></span>
-			<?php
-			echo $args['info'];
-			?>
+			<?php echo $args['info']; ?>
 		</span>
 		<?php
 	}
@@ -587,18 +575,12 @@ class Imagify_Settings {
 		$display_check_all = $nb_of_values > 3;
 		$nb_of_checked     = 0;
 		?>
-		<fieldset class="imagify-check-group
-		<?php
-		echo $nb_of_values > 5 ? ' imagify-is-scrollable' : '';
-		?>
-		">
+		<fieldset class="imagify-check-group <?php echo $nb_of_values > 5 ? ' imagify-is-scrollable' : ''; ?>">
 			<?php
 			if ( $args['legend'] ) {
 				?>
 				<legend class="screen-reader-text">
-				<?php
-					echo $args['legend'];
-				?>
+				<?php echo $args['legend']; ?>
 				</legend>
 				<?php
 			}
@@ -620,34 +602,10 @@ class Imagify_Settings {
 				}
 				?>
 				<p>
-					<input type="checkbox" value="
-					<?php
-					echo esc_attr( $value );
-					?>
-					" id="
-					<?php
-					echo $input_id;
-					?>
-"
-				<?php
-					echo $args['attributes'];
-				?>
-				<?php
-					checked( $checked );
-				?>
-				<?php
-					disabled( $disabled );
-				?>
-/>
-					<label for="
-					<?php
-					echo $input_id;
-					?>
-					" onclick="">
-					<?php
-						echo $label;
-					?>
-</label>
+					<input type="checkbox" value="<?php echo esc_attr( $value ); ?>" id="<?php echo $input_id; ?>" <?php echo $args['attributes']; ?> <?php checked( $checked ); ?> <?php disabled( $disabled ); ?> />
+					<label for="<?php echo $input_id; ?>" onclick="">
+					<?php echo $label; ?>
+					</label>
 				</p>
 				<?php
 			}
@@ -662,27 +620,19 @@ class Imagify_Settings {
 			}
 			?>
 			<p class="hide-if-no-js imagify-select-all-buttons">
-				<button type="button" class="imagify-link-like imagify-select-all
-				<?php
-				echo $all_checked ? ' imagify-is-inactive" aria-disabled="true' : '';
-				?>
-				" data-action="select">
+				<button type="button" class="imagify-link-like imagify-select-all <?php echo $all_checked ? ' imagify-is-inactive" aria-disabled="true' : ''; ?>" data-action="select">
 				<?php
 					_e( 'Select All', 'imagify' );
 				?>
-</button>
+				</button>
 
 				<span class="imagify-pipe"></span>
 
-				<button type="button" class="imagify-link-like imagify-select-all
-				<?php
-				echo $nb_of_checked ? '' : ' imagify-is-inactive" aria-disabled="true';
-				?>
-				" data-action="unselect">
+				<button type="button" class="imagify-link-like imagify-select-all <?php echo $nb_of_checked ? '' : ' imagify-is-inactive" aria-disabled="true'; ?>	" data-action="unselect">
 				<?php
 					_e( 'Unselect All', 'imagify' );
 				?>
-</button>
+				</button>
 			</p>
 			<?php
 		}
@@ -759,31 +709,10 @@ class Imagify_Settings {
 			foreach ( $args['values'] as $value => $label ) {
 				$input_id = sprintf( $id_attribute, sanitize_html_class( $value ) );
 				?>
-				<input type="radio" value="
-				<?php
-				echo esc_attr( $value );
-				?>
-				" id="
-				<?php
-				echo $input_id;
-				?>
-"
-				<?php
-				echo $args['attributes'];
-				?>
-				<?php
-				checked( $current_value, $value );
-				?>
-/>
-				<label for="
-				<?php
-				echo $input_id;
-				?>
-				" onclick="">
-				<?php
-					echo $label;
-				?>
-</label>
+				<input type="radio" value="<?php echo esc_attr( $value ); ?>" id="<?php echo $input_id; ?>" <?php echo $args['attributes']; ?> <?php checked( $current_value, $value ); ?> />
+				<label for="<?php echo $input_id; ?>" onclick="">
+				<?php echo $label; ?>
+				</label>
 				<br/>
 				<?php
 			}
@@ -794,15 +723,9 @@ class Imagify_Settings {
 			return;
 		}
 		?>
-		<span id="
-		<?php
-		echo $attributes['aria-describedby'];
-		?>
-		" class="imagify-info">
+		<span id="<?php echo $attributes['aria-describedby']; ?>" class="imagify-info">
 			<span class="dashicons dashicons-info"></span>
-			<?php
-			echo $args['info'];
-			?>
+			<?php echo $args['info']; ?>
 		</span>
 		<?php
 	}
@@ -866,15 +789,9 @@ class Imagify_Settings {
 			}
 			?>
 			</p>
-			<span id="
-			<?php
-			echo $attributes['aria-describedby'];
-			?>
-			" class="imagify-<?php echo esc_attr( $args['info_class'] ); ?>">
+			<span id="<?php echo $attributes['aria-describedby']; ?>" class="imagify-<?php echo esc_attr( $args['info_class'] ); ?>">
 				<span class="dashicons dashicons-info"></span>
-				<?php
-				echo $args['info'];
-				?>
+				<?php echo $args['info']; ?>
 			</span>
 		</div>
 		<?php
@@ -931,38 +848,18 @@ class Imagify_Settings {
 		$args['attributes'] = self::build_attributes( $attributes );
 		?>
 		<!-- Empty onclick attribute to make clickable labels on iTruc & Mac -->
-		<label for="
-		<?php
-		echo $attributes['id'];
-		?>
-		" onclick="">
-		<?php
-			echo $args['label'];
-		?>
-</label>
-		<input type="text" value="
-		<?php
-		echo esc_attr( $current_value );
-		?>
-		"
-		<?php
-		echo $args['attributes'];
-		?>
-/>
+		<label for="<?php echo $attributes['id']; ?>" onclick="">
+		<?php echo $args['label']; ?>
+		</label>
+		<input type="text" value="<?php echo esc_attr( $current_value ); ?>" <?php echo $args['attributes']; ?> />
 		<?php
 		if ( ! $args['info'] ) {
 			return;
 		}
 		?>
-		<span id="
-		<?php
-		echo $attributes['aria-describedby'];
-		?>
-		" class="imagify-info">
+		<span id="<?php echo $attributes['aria-describedby']; ?>" class="imagify-info">
 			<span class="dashicons dashicons-info"></span>
-			<?php
-			echo $args['info'];
-			?>
+			<?php echo $args['info']; ?>
 		</span>
 		<?php
 	}
@@ -1009,15 +906,7 @@ class Imagify_Settings {
 		$attributes         = array_merge( $attributes, $args['attributes'] );
 		$args['attributes'] = self::build_attributes( $attributes );
 		?>
-		<input type="hidden" value="
-		<?php
-		echo esc_attr( $current_value );
-		?>
-		"
-		<?php
-		echo $args['attributes'];
-		?>
-/>
+		<input type="hidden" value="<?php echo esc_attr( $current_value ); ?>" <?php echo $args['attributes']; ?> />
 		<?php
 	}
 

--- a/inc/classes/class-imagify-settings.php
+++ b/inc/classes/class-imagify-settings.php
@@ -491,18 +491,11 @@ class Imagify_Settings {
 		$attributes         = array_merge( $attributes, $args['attributes'] );
 		$args['attributes'] = self::build_attributes( $attributes );
 		?>
-		<input type="checkbox" value="1"
-		<?php
-		checked( $current_value, 1 );
-		?>
-		<?php
-		echo $args['attributes'];
-		?>
-/>
+		<input type="checkbox" value="1" <?php checked( $current_value, 1 ); ?> <?php echo $args['attributes']; ?> />
 		<!-- Empty onclick attribute to make clickable labels on iTruc & Mac -->
 		<label for="<?php echo $attributes['id']; ?>" onclick="">
 		<?php echo $args['label']; ?>
-</label>
+		</label>
 		<?php
 		if ( ! $args['info'] ) {
 			return;
@@ -628,7 +621,7 @@ class Imagify_Settings {
 
 				<span class="imagify-pipe"></span>
 
-				<button type="button" class="imagify-link-like imagify-select-all <?php echo $nb_of_checked ? '' : ' imagify-is-inactive" aria-disabled="true'; ?>	" data-action="unselect">
+				<button type="button" class="imagify-link-like imagify-select-all <?php echo $nb_of_checked ? '' : ' imagify-is-inactive" aria-disabled="true'; ?>  " data-action="unselect">
 				<?php
 					_e( 'Unselect All', 'imagify' );
 				?>

--- a/views/modal-settings-visual-comparison.php
+++ b/views/modal-settings-visual-comparison.php
@@ -1,6 +1,17 @@
 <?php
-defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
+defined( 'ABSPATH' ) || exit;
 
+// translators: %s is a formatted file size.
+$original_alt = sprintf( esc_attr__( 'Original photography about %s', 'imagify' ), imagify_size_format( 343040 ) );
+
+// translators: %s is a formatted file size.
+$normal_alt = sprintf( esc_attr__( 'Optimized photography about %s', 'imagify' ), imagify_size_format( 301056 ) );
+
+// translators: %s is a formatted file size.
+$aggressive_alt = sprintf( esc_attr__( 'Optimized photography about %s', 'imagify' ), imagify_size_format( 108544 ) );
+
+// translators: %s is a formatted file size.
+$ultra_alt = sprintf( esc_attr__( 'Optimized photography about %s', 'imagify' ), imagify_size_format( 46080 ) );
 ?>
 
 <div class="imagify-modal" id="imagify-visual-comparison">
@@ -27,42 +38,23 @@ defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 			data-original-label="<?php esc_attr_e( 'Original', 'imagify' ); ?>"
 			data-original-img="<?php echo IMAGIFY_ASSETS_IMG_URL; ?>mushrooms-original.jpg"
 			data-original-dim="1220x350"
-			data-original-alt="
-			<?php
-				/* translators: %s is a formatted file size. */
-				printf( esc_attr__( 'Original photography about %s', 'imagify' ), imagify_size_format( 343040 ) );
-			?>
-			"
+			data-original-alt="<?php echo $original_alt; ?>"
 
 			data-normal-label="<?php esc_attr_e( 'Normal', 'imagify' ); ?>"
 			data-normal-img="<?php echo IMAGIFY_ASSETS_IMG_URL; ?>mushrooms-normal.jpg"
 			data-normal-dim="1220x350"
-			data-normal-alt="
-			<?php
-				/* translators: %s is a formatted file size. */
-				printf( esc_attr__( 'Optimized photography about %s', 'imagify' ), imagify_size_format( 301056 ) );
-			?>
-			"
+			data-normal-alt="<?php echo $normal_alt; ?>"
 
 			data-aggressive-label="<?php esc_attr_e( 'Aggressive', 'imagify' ); ?>"
 			data-aggressive-img="<?php echo IMAGIFY_ASSETS_IMG_URL; ?>mushrooms-aggressive.jpg"
 			data-aggressive-dim="1220x350"
-			data-aggressive-alt="
-			<?php
-				/* translators: %s is a formatted file size. */
-				printf( esc_attr__( 'Optimized photography about %s', 'imagify' ), imagify_size_format( 108544 ) );
-			?>
-			"
+			data-aggressive-alt=" <?php echo $aggressive_alt; ?>"
 
 			data-ultra-label="<?php esc_attr_e( 'Ultra', 'imagify' ); ?>"
 			data-ultra-img="<?php echo IMAGIFY_ASSETS_IMG_URL; ?>mushrooms-ultra.jpg"
 			data-ultra-dim="1220x350"
-			data-ultra-alt="
-			<?php
-				/* translators: %s is a formatted file size. */
-				printf( esc_attr__( 'Optimized photography about %s', 'imagify' ), imagify_size_format( 46080 ) );
-			?>
-			"></div>
+			data-ultra-alt="<?php echo $ultra_alt; ?>">
+		</div>
 
 		<div class="imagify-comparison-levels">
 			<div class="imagify-c-level imagify-level-original go-left">

--- a/views/part-settings-files-tree-row.php
+++ b/views/part-settings-files-tree-row.php
@@ -1,24 +1,26 @@
 <?php
-defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
+defined( 'ABSPATH' ) || exit;
 
 $disabled_attr  = disabled( true, $data['checkbox_selected'], false );
 $disabled_class = $data['checkbox_selected'] ? ' disabled' : '';
 $folder_icon    = '<svg width="20px" height="17px" viewBox="0 0 20 17" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(-608.000000, -318.000000)" stroke-linecap="round" stroke-linejoin="round"><g transform="translate(609.000000, 319.000000)" stroke="#000000" stroke-width="2"><path d="M0,14.1428571 L18,14.1428571 L18,1.92857143 L7.71428571,1.92857143 L5.14285714,0 L0,0 L0,14.1428571 Z M18,5.14285714 L0,5.14285714 L18,5.14285714 Z"></path></g></g></svg>';
+
+if ( $data['checkbox_selected'] ) {
+	// translators: %s is a folder path.
+	$button_title = sprintf( esc_attr__( 'The folder "%s" is already selected.', 'imagify' ), $data['relative_path'] );
+	// translators: %s is a folder path.
+	$folder_title = sprintf( esc_attr__( 'The folder "%s" is already selected.', 'imagify' ), $data['relative_path'] );
+} else {
+	// translators: %s is a folder path.
+	$button_title = sprintf( esc_attr__( 'Open/Close the folder "%s".', 'imagify' ), $data['relative_path'] );
+	// translators: %s is a folder path.
+	$folder_title = sprintf( esc_attr__( 'Select the folder "%s".', 'imagify' ), $data['relative_path'] );
+}
 ?>
 
-<li<?php echo $data['checkbox_selected'] ? ' class="imagify-folder-already-selected"' : ''; ?>>
+<li <?php echo $data['checkbox_selected'] ? ' class="imagify-folder-already-selected"' : ''; ?>>
 	<?php if ( empty( $data['no_button'] ) ) : ?>
-		<button type="button" class="imagify-folder" data-folder="<?php echo $data['relative_path']; ?>"<?php echo $disabled_attr; ?> title="
-		<?php
-		if ( $data['checkbox_selected'] ) {
-			/* translators: %s is a folder path. */
-			printf( esc_attr__( 'The folder "%s" is already selected.', 'imagify' ), $data['relative_path'] );
-		} else {
-			/* translators: %s is a folder path. */
-			printf( esc_attr__( 'Open/Close the folder "%s".', 'imagify' ), $data['relative_path'] );
-		}
-		?>
-		">
+		<button type="button" class="imagify-folder" data-folder="<?php echo $data['relative_path']; ?>"<?php echo $disabled_attr; ?> title="<?php echo $button_title; ?>">
 			<?php if ( ! $data['checkbox_selected'] ) { ?>
 				<span class="imagify-loader"><img alt="<?php esc_attr_e( 'Loading...', 'imagify' ); ?>" src="<?php echo esc_url( IMAGIFY_ASSETS_IMG_URL . 'spinner.gif' ); ?>" width="20" height="20"/></span>
 			<?php } ?>
@@ -32,17 +34,7 @@ $folder_icon    = '<svg width="20px" height="17px" viewBox="0 0 20 17" version="
 
 	<input type="checkbox" name="imagify-custom-files[]" value="<?php echo $data['checkbox_value']; ?>" id="imagify-custom-folder-<?php echo $data['checkbox_id']; ?>" class="screen-reader-text"<?php echo $disabled_attr; ?>/>
 
-	<label for="imagify-custom-folder-<?php echo $data['checkbox_id']; ?>" title="
-	<?php
-	if ( $data['checkbox_selected'] ) {
-		/* translators: %s is a folder path. */
-		printf( esc_attr__( 'The folder "%s" is already selected.', 'imagify' ), $data['relative_path'] );
-	} else {
-		/* translators: %s is a folder path. */
-		printf( esc_attr__( 'Select the folder "%s".', 'imagify' ), $data['relative_path'] );
-	}
-	?>
-	">
+	<label for="imagify-custom-folder-<?php echo $data['checkbox_id']; ?>" title="<?php echo $folder_title; ?>">
 		<?php echo esc_html( $data['label'] ); ?>
 
 		<span class="imagify-add-ed-folder">


### PR DESCRIPTION
# Description

Fixes #984

Fix the issue where the settings page checkboxes are unclickable in the 2.2.6 first test round

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Tested checking/unchecking checkboxes on Imagify settings page

### How to test

Go on Imagify settings page, and try to check/uncheck the checkboxes

## Technical description

### Documentation

The issue happened because of extra spacing in the HTML attributes, following some fixes for PHP CodeSniffer. This caused the label and input to not match anymore.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Can't add tests for this output