### PR TITLE
Fixes #983 Optimization not running in AJAX context

### DIFF
--- a/inc/classes/Dependencies/deliciousbrains/wp-background-processing/classes/wp-background-process.php
+++ b/inc/classes/Dependencies/deliciousbrains/wp-background-processing/classes/wp-background-process.php
@@ -931,7 +931,7 @@ abstract class Imagify_WP_Background_Process extends Imagify_WP_Async_Request {
 	 * @return string
 	 */
 	public function get_chain_id() {
-		if ( empty( $this->chain_id ) && wp_doing_ajax() ) {
+		if ( empty( $this->chain_id ) && wp_doing_ajax() && isset( $_REQUEST['action'] ) && $_REQUEST['action'] === $this->identifier ) {
 			check_ajax_referer( $this->identifier, 'nonce' );
 
 			if ( ! empty( $_GET[ $this->get_chain_id_arg_name() ] ) ) {

--- a/inc/classes/Dependencies/deliciousbrains/wp-background-processing/classes/wp-background-process.php
+++ b/inc/classes/Dependencies/deliciousbrains/wp-background-processing/classes/wp-background-process.php
@@ -931,6 +931,7 @@ abstract class Imagify_WP_Background_Process extends Imagify_WP_Async_Request {
 	 * @return string
 	 */
 	public function get_chain_id() {
+		// The line below is a custom fix while waiting for the upstream package to be updated.
 		if ( empty( $this->chain_id ) && wp_doing_ajax() && isset( $_REQUEST['action'] ) && $_REQUEST['action'] === $this->identifier ) {
 			check_ajax_referer( $this->identifier, 'nonce' );
 


### PR DESCRIPTION
# Description

Fixes #983

Optimization was not running when triggering it in AJAX context, like clicking on the optimize button on the media library.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

- Manual optimization from the media library page
- Bulk optimization

### How to test

Same as above

## Technical description

### Documentation

The issue comes from the WP background processing library, it was reported here https://github.com/deliciousbrains/wp-background-processing/issues/129 and fixed here https://github.com/deliciousbrains/wp-background-processing/pull/130

But the fix is not yet in the current release, so I manually added it to our codebase.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No tests for this