### PR TITLE
Fixes #1003 Remove esc_html() when outputting data with HTML

### DIFF
--- a/views/input/selector.php
+++ b/views/input/selector.php
@@ -24,11 +24,11 @@ $list_id = 'imagify-' . $list_id . '-selector-list';
 <div class="imagify-selector">
 	<span class="hide-if-js">
 		<?php echo esc_html( $data['current_label'] ); ?>
-		<span class="imagify-selector-current-value-info"><?php echo esc_html( $data['values'][ $data['value'] ] ); ?></span>
+		<span class="imagify-selector-current-value-info"><?php echo $data['values'][ $data['value'] ]; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
 	</span>
 
 	<button aria-controls="<?php echo esc_attr( $list_id ); ?>" type="button" class="button imagify-button-clean hide-if-no-js imagify-selector-button">
-		<span class="imagify-selector-current-value-info"><?php echo esc_html( $data['values'][ $data['value'] ] ); ?></span>
+		<span class="imagify-selector-current-value-info"><?php echo $data['values'][ $data['value'] ]; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
 	</button>
 
 	<ul id="<?php echo esc_attr( $list_id ); ?>" role="listbox" aria-orientation="vertical" aria-hidden="true" class="imagify-selector-list hide-if-no-js">
@@ -38,7 +38,7 @@ $list_id = 'imagify-' . $list_id . '-selector-list';
 			?>
 			<li class="imagify-selector-choice<?php echo $val === $data['value'] ? ' imagify-selector-current-value" aria-current="true' : ''; ?>" role="option">
 				<input type="radio" name="<?php echo esc_attr( $data['name'] ); ?>" value="<?php echo esc_attr( $val ); ?>" id="<?php echo esc_attr( $input_id ); ?>" <?php checked( $val, $data['value'] ); ?> class="screen-reader-text">
-				<label for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_html( $label ); ?></label>
+				<label for="<?php echo esc_attr( $input_id ); ?>"><?php echo  $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></label>
 			</li>
 			<?php
 		}

--- a/views/input/selector.php
+++ b/views/input/selector.php
@@ -38,7 +38,7 @@ $list_id = 'imagify-' . $list_id . '-selector-list';
 			?>
 			<li class="imagify-selector-choice<?php echo $val === $data['value'] ? ' imagify-selector-current-value" aria-current="true' : ''; ?>" role="option">
 				<input type="radio" name="<?php echo esc_attr( $data['name'] ); ?>" value="<?php echo esc_attr( $val ); ?>" id="<?php echo esc_attr( $input_id ); ?>" <?php checked( $val, $data['value'] ); ?> class="screen-reader-text">
-				<label for="<?php echo esc_attr( $input_id ); ?>"><?php echo  $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></label>
+				<label for="<?php echo esc_attr( $input_id ); ?>"><?php echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></label>
 			</li>
 			<?php
 		}

--- a/views/part-bulk-optimization-table-row-folder-type.php
+++ b/views/part-bulk-optimization-table-row-folder-type.php
@@ -17,16 +17,16 @@ defined( 'ABSPATH' ) || exit;
 		<label for="cb-select-<?php echo esc_attr( $data['group_id'] ); ?>"><?php echo esc_html( $data['title'] ); ?></label>
 	</td>
 	<td class="imagify-cell-count-optimized">
-		<?php echo esc_html( $data['count-optimized'] ); ?>
+		<?php echo $data['count-optimized']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</td>
 	<td class="imagify-cell-count-errors">
-		<?php echo esc_html( $data['count-errors'] ); ?>
+		<?php echo $data['count-errors']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</td>
 	<td class="imagify-cell-optimized-size-size">
-		<?php echo esc_html( $data['optimized-size'] ); ?>
+		<?php echo $data['optimized-size']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</td>
 	<td class="imagify-cell-original-size-size">
-		<?php echo esc_html( $data['original-size'] ); ?>
+		<?php echo $data['original-size']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</td>
 	<td class="imagify-cell-level">
 		<?php


### PR DESCRIPTION
# Description

Fixes #1003

The UI was displayed incorrectly on bulk optimization page showing raw HTML

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Tested the output on the bulk optimization page, content is displayed as expected

### How to test

- Go to bulk optimization page
- Optimize some images to show the different sections
- Validate everything is displayed correctly

### Affected Features & Quality Assurance Scope

- Bulk optimization UI page

## Technical description

### Documentation

TBD

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I did not introduce unnecessary complexity.

## Unticked items justification

No tests applicable for this change