### PR TITLE
Update WP version tested in legacy PHPUnit action

### DIFF
--- a/.github/workflows/test_legacy.yml
+++ b/.github/workflows/test_legacy.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest]
         php-versions: ['7.3', '7.4']
-        wp-versions: ['5.3']
+        wp-versions: ['5.8']
 
     name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
 

--- a/.github/workflows/test_legacy.yml
+++ b/.github/workflows/test_legacy.yml
@@ -72,9 +72,6 @@ jobs:
     - name: Setup problem matchers for PHPUnit
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-    - name: Require PHPUnit 7.5 for WP compatibility
-      run: composer require --dev --no-scripts phpunit/phpunit "^7.5" -W
-
     - name: Install dependencies
       run: composer install --prefer-dist --no-interaction --no-scripts
 

--- a/.github/workflows/test_legacy.yml
+++ b/.github/workflows/test_legacy.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest]
         php-versions: ['7.3', '7.4']
-        wp-versions: ['5.8']
+        wp-versions: ['5.9']
 
     name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
 

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
 		"phpstan/extension-installer": "^1.3",
 		"phpstan/phpstan-mockery": "^1.1",
 		"phpstan/phpstan-phpunit": "^1.4",
-		"phpunit/phpunit": "^7.5 || ^8 || ^9",
+		"phpunit/phpunit": "^8 || ^9",
 		"roave/security-advisories": "dev-master",
 		"szepeviktor/phpstan-wordpress": "^1.3",
 		"woocommerce/action-scheduler": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
 		"phpstan/extension-installer": "^1.3",
 		"phpstan/phpstan-mockery": "^1.1",
 		"phpstan/phpstan-phpunit": "^1.4",
-		"phpunit/phpunit": "^8 || ^9",
+		"phpunit/phpunit": "^8.5.52 || ^9.6.33",
 		"roave/security-advisories": "dev-master",
 		"szepeviktor/phpstan-wordpress": "^1.3",
 		"woocommerce/action-scheduler": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -33,14 +33,14 @@
 		"source": "https://github.com/wp-media/imagify-plugin"
 	},
 	"require": {
-		"php": ">=7.0",
+		"php": ">=7.3",
 		"composer/installers": "^1.0 || ^2.0",
 		"dangoodman/composer-for-wordpress": "^2.0",
 		"wp-media/apply-filters-typed": "^1.0",
 		"wp-media/plugin-family": "^1.0"
 	},
 	"require-dev": {
-		"php": "^7 || ^8",
+		"php": ">=7.3",
 		"brain/monkey": "^2.0",
 		"coenjacobs/mozart": "^0.7",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -24,9 +24,9 @@
 	<arg name="parallel" value="50"/><!-- Enables parallel processing when available for faster results. -->
 	<arg name="extensions" value="php"/><!-- Limit to PHP files -->
 
-	<!-- Check for cross-version support for PHP 7.3 and higher + WP 5.3 and higher. -->
+	<!-- Check for cross-version support for PHP 7.3 and higher + WP 5.9 and higher. -->
 	<config name="testVersion" value="7.3-"/>
-	<config name="minimum_supported_wp_version" value="5.3"/>
+	<config name="minimum_supported_wp_version" value="5.9"/>
 
 	<!-- Run against the PHPCompatibility ruleset dedicated to WP. -->
 	<rule ref="PHPCompatibilityWP">


### PR DESCRIPTION
# Description

Following a security issue in PHPUnit, not fixed in version under `8.5.52`, update our PHPUnit legacy testing to use the first WP version (`5.9`) compatible with newer PHPUnit version.

## Type of change

- [x] Chore

## Technical description

### Documentation

Updates legacy CI/testing configuration to use WordPress 5.9+ so the pipeline can run with newer (security-fixed) PHPUnit versions.

**Changes:**
- Bump legacy workflow WP matrix from 5.3 → 5.9 and remove the explicit PHPUnit 7.5 install step.
- Update PHPCS minimum supported WP version from 5.3 → 5.9.
- Adjust Composer constraints for PHP and PHPUnit to drop PHPUnit 7.x and require PHP 7.3+.