### PR TITLE
Release Readme typo fix and WP version tested in legacy PHPUnit action

### DIFF
--- a/.github/workflows/test_legacy.yml
+++ b/.github/workflows/test_legacy.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest]
         php-versions: ['7.3', '7.4']
-        wp-versions: ['5.3']
+        wp-versions: ['5.9']
 
     name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
 
@@ -71,9 +71,6 @@ jobs:
 
     - name: Setup problem matchers for PHPUnit
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-    - name: Require PHPUnit 7.5 for WP compatibility
-      run: composer require --dev --no-scripts phpunit/phpunit "^7.5" -W
 
     - name: Install dependencies
       run: composer install --prefer-dist --no-interaction --no-scripts

--- a/composer.json
+++ b/composer.json
@@ -33,14 +33,14 @@
 		"source": "https://github.com/wp-media/imagify-plugin"
 	},
 	"require": {
-		"php": ">=7.0",
+		"php": ">=7.3",
 		"composer/installers": "^1.0 || ^2.0",
 		"dangoodman/composer-for-wordpress": "^2.0",
 		"wp-media/apply-filters-typed": "^1.0",
 		"wp-media/plugin-family": "^1.0"
 	},
 	"require-dev": {
-		"php": "^7 || ^8",
+		"php": ">=7.3",
 		"brain/monkey": "^2.0",
 		"coenjacobs/mozart": "^0.7",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1",
@@ -52,7 +52,7 @@
 		"phpstan/extension-installer": "^1.3",
 		"phpstan/phpstan-mockery": "^1.1",
 		"phpstan/phpstan-phpunit": "^1.4",
-		"phpunit/phpunit": "^7.5 || ^8 || ^9",
+		"phpunit/phpunit": "^8.5.52 || ^9.6.33",
 		"roave/security-advisories": "dev-master",
 		"szepeviktor/phpstan-wordpress": "^1.3",
 		"woocommerce/action-scheduler": "^3.4",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -24,9 +24,9 @@
 	<arg name="parallel" value="50"/><!-- Enables parallel processing when available for faster results. -->
 	<arg name="extensions" value="php"/><!-- Limit to PHP files -->
 
-	<!-- Check for cross-version support for PHP 7.3 and higher + WP 5.3 and higher. -->
+	<!-- Check for cross-version support for PHP 7.3 and higher + WP 5.9 and higher. -->
 	<config name="testVersion" value="7.3-"/>
-	<config name="minimum_supported_wp_version" value="5.3"/>
+	<config name="minimum_supported_wp_version" value="5.9"/>
 
 	<!-- Run against the PHPCompatibility ruleset dedicated to WP. -->
 	<rule ref="PHPCompatibilityWP">

--- a/readme.txt
+++ b/readme.txt
@@ -271,7 +271,7 @@ You can report any security bugs found in the source code of the site-reviews pl
 == Changelog ==
 = 2.2.7 =
 - Enhancement: improve code to follow correctly various WordPress coding standards rules
-- Ehnacement: Add a new filter `imagify_hide_plugin_family` to hide the Our Plugins section on the settings page 
+- Enhancement: Add a new filter `imagify_hide_plugin_family` to hide the Our Plugins section on the settings page 
 
 = 2.2.6 =
 - Bugfix: Fix warning related to translation files being loaded too early, improving plugin stability during image optimization. 


### PR DESCRIPTION
# Description

Releases:
- #1017
- Typo in readme

## Type of change

- [x] Chore
