### PR TITLE
Add PHPStan custom rule for `get_subcribed_events()` callbacks validation

### DIFF
--- a/Tests/phpstan/Rules/SubscriberCallbackRule.php
+++ b/Tests/phpstan/Rules/SubscriberCallbackRule.php
@@ -184,25 +184,28 @@ class SubscriberCallbackRule implements Rule
 	}
 
 	/**
-	 * Get hook type (@filter or @action) from array item PHPDoc comment
+	 * Get hook type (@filter or @action) from array item comment
 	 */
 	private function getHookType( ArrayItem $item ): ?string
 	{
-		$docComment = $item->getDocComment();
+		$comments = $item->getAttribute( 'comments' );
 
-		if ( $docComment === null ) {
+		if ( empty( $comments ) ) {
 			return null;
 		}
 
-		$text = $docComment->getText();
+		// Check all comments attached to this node
+		foreach ( $comments as $comment ) {
+			$text = $comment->getText();
 
-		// Match @filter or @action
-		if ( preg_match( '/@filter\b/i', $text ) ) {
-			return 'filter';
-		}
+			// Match // @filter or // @action
+			if ( preg_match( '/\/\/\s*@filter\b/i', $text ) ) {
+				return 'filter';
+			}
 
-		if ( preg_match( '/@action\b/i', $text ) ) {
-			return 'action';
+			if ( preg_match( '/\/\/\s*@action\b/i', $text ) ) {
+				return 'action';
+			}
 		}
 
 		return null;

--- a/Tests/phpstan/Rules/SubscriberCallbackRule.php
+++ b/Tests/phpstan/Rules/SubscriberCallbackRule.php
@@ -1,0 +1,468 @@
+<?php
+
+namespace Imagify\Tests\phpstan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\Int_;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * PHPStan rule to validate get_subscribed_events() callbacks for SubscriberInterface implementations.
+ *
+ * Ensures that:
+ * - All array elements have @filter or @action PHPDoc annotations
+ * - Filter callbacks return non-void values
+ * - Action callbacks return void
+ * - Parameter counts match accepted_args when specified
+ *
+ * @implements Rule<ClassMethod>
+ */
+class SubscriberCallbackRule implements Rule
+{
+	public function getNodeType(): string
+	{
+		return ClassMethod::class;
+	}
+
+	public function processNode( Node $node, Scope $scope ): array
+	{
+		// Only process get_subscribed_events() methods
+		if ( $node->name->toString() !== 'get_subscribed_events' ) {
+			return [];
+		}
+
+		// Check if class implements SubscriberInterface
+		if ( ! $this->implementsSubscriberInterface( $scope ) ) {
+			return [];
+		}
+
+		// Find the array to analyze
+		$arrayNode = $this->findArrayNode( $node, $scope );
+
+		if ( $arrayNode === null ) {
+			// Skip validation for delegated implementations or complex patterns
+			return [];
+		}
+
+		// Collect all errors for this method
+		$errors = [];
+
+		// Process each array element
+		foreach ( $arrayNode->items as $item ) {
+			// Skip null items (trailing commas)
+			if ( $item === null ) {
+				continue;
+			}
+
+			// Parse PHPDoc annotation for hook type
+			$hookType = $this->getHookType( $item );
+
+			if ( $hookType === null ) {
+				// Missing annotation error
+				$errors[] = RuleErrorBuilder::message( 'Hook element missing required @filter or @action annotation' )
+					->line( $item->getStartLine() )
+					->identifier( 'wpmedia.subscriber.missingAnnotation' )
+					->addTip( 'Add /** @filter */ or /** @action */ annotation before this array element' )
+					->build();
+				continue;
+			}
+
+			// Extract callback information
+			$callbacks = $this->extractCallbacks( $item->value );
+
+			// Validate each callback
+			foreach ( $callbacks as $callbackInfo ) {
+				$methodName = $callbackInfo['method'];
+				$acceptedArgs = $callbackInfo['accepted_args'] ?? null;
+
+				// Validate callback return type
+				$returnTypeErrors = $this->validateCallbackReturnType(
+					$scope,
+					$methodName,
+					$hookType,
+					$item->getStartLine()
+				);
+				$errors = array_merge( $errors, $returnTypeErrors );
+
+				// Validate parameter count if accepted_args is specified
+				if ( $acceptedArgs !== null ) {
+					$paramErrors = $this->validateParameterCount(
+						$scope,
+						$methodName,
+						$acceptedArgs,
+						$item->getStartLine()
+					);
+					$errors = array_merge( $errors, $paramErrors );
+				}
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Check if the current class implements SubscriberInterface
+	 */
+	private function implementsSubscriberInterface( Scope $scope ): bool
+	{
+		$classReflection = $scope->getClassReflection();
+
+		if ( $classReflection === null ) {
+			return false;
+		}
+
+		return $classReflection->implementsInterface( 'Imagify\EventManagement\SubscriberInterface' );
+	}
+
+	/**
+	 * Find the array node to analyze from the method body
+	 * Handles inline arrays and simple variable assignments
+	 */
+	private function findArrayNode( ClassMethod $method, Scope $scope ): ?Array_
+	{
+		$stmts = $method->getStmts();
+
+		if ( $stmts === null ) {
+			return null;
+		}
+
+		$variableArrays = [];
+
+		// Look through statements
+		foreach ( $stmts as $stmt ) {
+			// Direct return of array
+			if ( $stmt instanceof Return_ && $stmt->expr instanceof Array_ ) {
+				$array = $stmt->expr;
+				// Skip empty arrays
+				if ( empty( $array->items ) ) {
+					return null;
+				}
+				return $array;
+			}
+
+			// Variable assignment to array
+			if ( $stmt instanceof Node\Stmt\Expression
+				&& $stmt->expr instanceof Assign
+				&& $stmt->expr->var instanceof Variable
+				&& $stmt->expr->expr instanceof Array_
+			) {
+				$varName = $stmt->expr->var->name;
+				if ( is_string( $varName ) ) {
+					$variableArrays[ $varName ] = $stmt->expr->expr;
+				}
+			}
+
+			// Return of variable
+			if ( $stmt instanceof Return_ && $stmt->expr instanceof Variable ) {
+				$varName = $stmt->expr->name;
+				if ( is_string( $varName ) && isset( $variableArrays[ $varName ] ) ) {
+					$array = $variableArrays[ $varName ];
+					// Skip empty arrays
+					if ( empty( $array->items ) ) {
+						return null;
+					}
+					return $array;
+				}
+			}
+		}
+
+		// Delegated or complex implementation - skip validation
+		return null;
+	}
+
+	/**
+	 * Get hook type (@filter or @action) from array item PHPDoc comment
+	 */
+	private function getHookType( ArrayItem $item ): ?string
+	{
+		$docComment = $item->getDocComment();
+
+		if ( $docComment === null ) {
+			return null;
+		}
+
+		$text = $docComment->getText();
+
+		// Match @filter or @action
+		if ( preg_match( '/@filter\b/i', $text ) ) {
+			return 'filter';
+		}
+
+		if ( preg_match( '/@action\b/i', $text ) ) {
+			return 'action';
+		}
+
+		return null;
+	}
+
+	/**
+	 * Extract callback information from array value
+	 * Handles: 'method', ['method'], ['method', priority], ['method', priority, accepted_args]
+	 * and nested arrays for multiple callbacks per hook
+	 *
+	 * @return array[] Array of callback info: [['method' => string, 'accepted_args' => ?int], ...]
+	 */
+	private function extractCallbacks( Node\Expr $value ): array
+	{
+		$callbacks = [];
+
+		// Simple string method name
+		if ( $value instanceof String_ ) {
+			$callbacks[] = [
+				'method' => $value->value,
+				'accepted_args' => null,
+			];
+			return $callbacks;
+		}
+
+		// Array format
+		if ( $value instanceof Array_ ) {
+			// Check if nested array (multiple callbacks for same hook)
+			$isNested = false;
+			if ( ! empty( $value->items ) ) {
+				$firstItem = $value->items[0];
+				if ( $firstItem !== null && $firstItem->value instanceof Array_ ) {
+					$isNested = true;
+				}
+			}
+
+			if ( $isNested ) {
+				// Process each nested array
+				foreach ( $value->items as $nestedItem ) {
+					if ( $nestedItem === null || ! ( $nestedItem->value instanceof Array_ ) ) {
+						continue;
+					}
+					$callbacks = array_merge( $callbacks, $this->extractCallbackFromArray( $nestedItem->value ) );
+				}
+			} else {
+				// Single callback array
+				$callbacks = $this->extractCallbackFromArray( $value );
+			}
+		}
+
+		return $callbacks;
+	}
+
+	/**
+	 * Extract callback info from array node
+	 * Format: ['method'], ['method', priority], or ['method', priority, accepted_args]
+	 */
+	private function extractCallbackFromArray( Array_ $array ): array
+	{
+		if ( empty( $array->items ) ) {
+			return [];
+		}
+
+		$items = array_values( array_filter( $array->items ) );
+
+		// First element should be method name
+		$firstItem = $items[0] ?? null;
+		if ( $firstItem === null || ! ( $firstItem->value instanceof String_ ) ) {
+			return [];
+		}
+
+		$methodName = $firstItem->value->value;
+		$acceptedArgs = null;
+
+		// Third element (index 2) is accepted_args
+		if ( isset( $items[2] ) && $items[2]->value instanceof Int_ ) {
+			$acceptedArgs = $items[2]->value->value;
+		}
+
+		return [
+			[
+				'method' => $methodName,
+				'accepted_args' => $acceptedArgs,
+			]
+		];
+	}
+
+	/**
+	 * Validate callback return type based on hook type
+	 */
+	private function validateCallbackReturnType( Scope $scope, string $methodName, string $hookType, int $lineNumber ): array
+	{
+		$errors = [];
+		$classReflection = $scope->getClassReflection();
+
+		if ( $classReflection === null ) {
+			return $errors;
+		}
+
+		// Check if method exists
+		if ( ! $classReflection->hasNativeMethod( $methodName ) ) {
+			// Let PHPStan's native undefined method detection handle this
+			return $errors;
+		}
+
+		$methodReflection = $classReflection->getNativeMethod( $methodName );
+		$variants = $methodReflection->getVariants();
+
+		if ( empty( $variants ) ) {
+			return $errors;
+		}
+
+		$returnType = $variants[0]->getReturnType();
+
+		if ( $hookType === 'filter' ) {
+			$errors = array_merge( $errors, $this->validateFilterReturnType( $returnType, $lineNumber ) );
+		} else {
+			$errors = array_merge( $errors, $this->validateActionReturnType( $returnType, $lineNumber ) );
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Validate filter callback return type (must return non-void)
+	 */
+	private function validateFilterReturnType( Type $returnType, int $lineNumber ): array
+	{
+		// Skip non-explicit mixed types (will be handled by PHPStan)
+		if ( $returnType instanceof MixedType ) {
+			return [];
+		}
+
+		// Filter must NOT return void/never
+		if ( ( $returnType->isVoid()->no() ) && ! $this->isExplicitNever( $returnType ) ) {
+			return [];
+		}
+
+		return [
+			RuleErrorBuilder::message( 'Filter callback return statement is missing.' )
+				->line( $lineNumber )
+				->identifier( 'wpmedia.subscriber.filter.missingReturn' )
+				->build()
+		];
+	}
+
+	/**
+	 * Validate action callback return type (must return void)
+	 */
+	private function validateActionReturnType( Type $returnType, int $lineNumber ): array
+	{
+		// Skip non-explicit mixed types (will be handled by PHPStan)
+		if ( $returnType instanceof MixedType && ! $returnType->isExplicitMixed() ) {
+			return [];
+		}
+
+		// Action must return void or explicit never
+		if ( $returnType->isVoid()->yes() || $this->isExplicitNever( $returnType ) ) {
+			return [];
+		}
+
+		return [
+			RuleErrorBuilder::message(
+				sprintf(
+					'Action callback returns %s but should not return anything.',
+					$returnType->describe( VerbosityLevel::getRecommendedLevelByType( $returnType ) )
+				)
+			)
+				->line( $lineNumber )
+				->identifier( 'wpmedia.subscriber.action.unexpectedReturn' )
+				->build()
+		];
+	}
+
+	/**
+	 * Check if type is explicit never
+	 */
+	private function isExplicitNever( Type $type ): bool
+	{
+		return $type instanceof NeverType && $type->isExplicit();
+	}
+
+	/**
+	 * Validate parameter count against accepted_args
+	 */
+	private function validateParameterCount( Scope $scope, string $methodName, int $acceptedArgs, int $lineNumber ): array
+	{
+		$errors = [];
+		$classReflection = $scope->getClassReflection();
+
+		if ( $classReflection === null ) {
+			return $errors;
+		}
+
+		// Check if method exists
+		if ( ! $classReflection->hasNativeMethod( $methodName ) ) {
+			return $errors;
+		}
+
+		$methodReflection = $classReflection->getNativeMethod( $methodName );
+		$variants = $methodReflection->getVariants();
+
+		if ( empty( $variants ) ) {
+			return $errors;
+		}
+
+		$variant = $variants[0];
+		$allParameters = $variant->getParameters();
+		$requiredParameters = array_filter(
+			$allParameters,
+			static function ( $parameter ): bool {
+				return ! $parameter->isOptional();
+			}
+		);
+
+		$maxArgs = count( $allParameters );
+		$minArgs = count( $requiredParameters );
+
+		// Valid: accepted_args within min-max range
+		if ( ( $acceptedArgs >= $minArgs ) && ( $acceptedArgs <= $maxArgs ) ) {
+			return $errors;
+		}
+
+		// Valid: accepted_args >= minArgs and callback is variadic
+		if ( ( $acceptedArgs >= $minArgs ) && $variant->isVariadic() ) {
+			return $errors;
+		}
+
+		// Special case: no required params but accepted_args is 1 (common pattern)
+		if ( $minArgs === 0 && $acceptedArgs === 1 ) {
+			return $errors;
+		}
+
+		// Build error message
+		$expectedParametersMessage = (string) $minArgs;
+		if ( $maxArgs !== $minArgs ) {
+			$expectedParametersMessage = sprintf( '%d-%d', $minArgs, $maxArgs );
+		}
+
+		$message = ( $expectedParametersMessage === '1' )
+			? 'Callback expects %s parameter, $accepted_args is set to %d.'
+			: 'Callback expects %s parameters, $accepted_args is set to %d.';
+
+		if ( $variant->isVariadic() ) {
+			$message = ( $minArgs === 1 )
+				? 'Callback expects at least %s parameter, $accepted_args is set to %d.'
+				: 'Callback expects at least %s parameters, $accepted_args is set to %d.';
+		}
+
+		$errors[] = RuleErrorBuilder::message(
+			sprintf(
+				$message,
+				$expectedParametersMessage,
+				$acceptedArgs
+			)
+		)
+			->line( $lineNumber )
+			->identifier( 'wpmedia.subscriber.arguments.count' )
+			->build();
+
+		return $errors;
+	}
+}

--- a/classes/Admin/AdminBar.php
+++ b/classes/Admin/AdminBar.php
@@ -35,7 +35,9 @@ class AdminBar implements SubscriberInterface {
 	 */
 	public static function get_subscribed_events(): array {
 		return [
+			/** @action */
 			'wp_ajax_imagify_get_admin_bar_profile' => 'get_admin_bar_profile_callback',
+			/** @action */
 			'admin_bar_menu'                        => [ 'add_imagify_admin_bar_menu', IMAGIFY_INT_MAX ],
 		];
 	}

--- a/classes/Admin/AdminBar.php
+++ b/classes/Admin/AdminBar.php
@@ -35,9 +35,9 @@ class AdminBar implements SubscriberInterface {
 	 */
 	public static function get_subscribed_events(): array {
 		return [
-			/** @action */
+			// @action
 			'wp_ajax_imagify_get_admin_bar_profile' => 'get_admin_bar_profile_callback',
-			/** @action */
+			// @action
 			'admin_bar_menu'                        => [ 'add_imagify_admin_bar_menu', IMAGIFY_INT_MAX ],
 		];
 	}

--- a/classes/Admin/AdminSubscriber.php
+++ b/classes/Admin/AdminSubscriber.php
@@ -36,7 +36,9 @@ class AdminSubscriber implements SubscriberInterface {
 		$basename = plugin_basename( IMAGIFY_FILE );
 
 		return [
+			/** @filter */
 			'plugin_action_links_' . $basename => 'plugin_action_links',
+			/** @filter */
 			'network_admin_plugin_action_links_' . $basename => 'plugin_action_links',
 		];
 	}

--- a/classes/Admin/AdminSubscriber.php
+++ b/classes/Admin/AdminSubscriber.php
@@ -36,9 +36,9 @@ class AdminSubscriber implements SubscriberInterface {
 		$basename = plugin_basename( IMAGIFY_FILE );
 
 		return [
-			/** @filter */
+			// @filter
 			'plugin_action_links_' . $basename => 'plugin_action_links',
-			/** @filter */
+			// @filter
 			'network_admin_plugin_action_links_' . $basename => 'plugin_action_links',
 		];
 	}

--- a/classes/CDN/CDN.php
+++ b/classes/CDN/CDN.php
@@ -16,7 +16,7 @@ class CDN implements SubscriberInterface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			/** @filter */
+			// @filter
 			'imagify_cdn_source_url' => 'get_cdn_source',
 		];
 	}

--- a/classes/CDN/CDN.php
+++ b/classes/CDN/CDN.php
@@ -16,6 +16,7 @@ class CDN implements SubscriberInterface {
 	 */
 	public static function get_subscribed_events() {
 		return [
+			/** @filter */
 			'imagify_cdn_source_url' => 'get_cdn_source',
 		];
 	}

--- a/classes/Media/Subscriber.php
+++ b/classes/Media/Subscriber.php
@@ -33,7 +33,7 @@ class Subscriber implements SubscriberInterface {
 	 */
 	public static function get_subscribed_events(): array {
 		return [
-			/** @action */
+			// @action
 			'restrict_manage_posts' => 'imagify_attachments_filter_dropdown',
 		];
 	}

--- a/classes/Media/Subscriber.php
+++ b/classes/Media/Subscriber.php
@@ -33,6 +33,7 @@ class Subscriber implements SubscriberInterface {
 	 */
 	public static function get_subscribed_events(): array {
 		return [
+			/** @action */
 			'restrict_manage_posts' => 'imagify_attachments_filter_dropdown',
 		];
 	}

--- a/classes/Stats/OptimizedMediaWithoutNextGen.php
+++ b/classes/Stats/OptimizedMediaWithoutNextGen.php
@@ -29,13 +29,13 @@ final class OptimizedMediaWithoutNextGen implements StatInterface, SubscriberInt
 	 */
 	public static function get_subscribed_events() {
 		return [
-			/** @action */
+			// @action
 			'imagify_after_optimize'         => [ 'maybe_clear_cache_after_optimization', 10, 2 ],
-			/** @action */
+			// @action
 			'imagify_after_restore_media'    => [ 'maybe_clear_cache_after_restoration', 10, 4 ],
-			/** @action */
+			// @action
 			'imagify_delete_media'           => 'maybe_clear_cache_on_deletion',
-			/** @action */
+			// @action
 			'update_option_imagify_settings' => [ 'maybe_clear_stat_cache', 9, 2 ],
 		];
 	}

--- a/classes/Stats/OptimizedMediaWithoutNextGen.php
+++ b/classes/Stats/OptimizedMediaWithoutNextGen.php
@@ -29,9 +29,13 @@ final class OptimizedMediaWithoutNextGen implements StatInterface, SubscriberInt
 	 */
 	public static function get_subscribed_events() {
 		return [
+			/** @action */
 			'imagify_after_optimize'         => [ 'maybe_clear_cache_after_optimization', 10, 2 ],
+			/** @action */
 			'imagify_after_restore_media'    => [ 'maybe_clear_cache_after_restoration', 10, 4 ],
+			/** @action */
 			'imagify_delete_media'           => 'maybe_clear_cache_on_deletion',
+			/** @action */
 			'update_option_imagify_settings' => [ 'maybe_clear_stat_cache', 9, 2 ],
 		];
 	}

--- a/classes/ThirdParty/Hostings/Extendify.php
+++ b/classes/ThirdParty/Hostings/Extendify.php
@@ -16,7 +16,7 @@ class Extendify implements SubscriberInterface {
 	 */
 	public static function get_subscribed_events(): array {
 		return [
-			/** @filter */
+			// @filter
 			'imagify_hide_plugin_family' => 'hide_plugin_family',
 		];
 	}

--- a/classes/ThirdParty/Hostings/Extendify.php
+++ b/classes/ThirdParty/Hostings/Extendify.php
@@ -16,6 +16,7 @@ class Extendify implements SubscriberInterface {
 	 */
 	public static function get_subscribed_events(): array {
 		return [
+			/** @filter */
 			'imagify_hide_plugin_family' => 'hide_plugin_family',
 		];
 	}

--- a/classes/ThirdParty/Plugins/GravityForms.php
+++ b/classes/ThirdParty/Plugins/GravityForms.php
@@ -21,9 +21,9 @@ class GravityForms implements SubscriberInterface {
 		}
 
 		return [
-			/** @filter */
+			// @filter
 			'gform_noconflict_styles'  => 'imagify_gf_noconflict_styles',
-			/** @filter */
+			// @filter
 			'gform_noconflict_scripts' => 'imagify_gf_noconflict_scripts',
 		];
 	}

--- a/classes/ThirdParty/Plugins/GravityForms.php
+++ b/classes/ThirdParty/Plugins/GravityForms.php
@@ -21,7 +21,9 @@ class GravityForms implements SubscriberInterface {
 		}
 
 		return [
+			/** @filter */
 			'gform_noconflict_styles'  => 'imagify_gf_noconflict_styles',
+			/** @filter */
 			'gform_noconflict_scripts' => 'imagify_gf_noconflict_scripts',
 		];
 	}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,6 +12,7 @@ parameters:
 	scanDirectories:
 		- inc/Dependencies/ActionScheduler
 		- Tests/Fixtures/
+		- Tests/phpstan/Rules
 	scanFiles:
 		- imagify.php
 		- inc/common/attachments.php
@@ -53,3 +54,4 @@ parameters:
 		 - classes/Dependencies/
 rules:
 	- Imagify\Tests\phpstan\Rules\DiscourageApplyFilters
+	- Imagify\Tests\phpstan\Rules\SubscriberCallbackRule


### PR DESCRIPTION
# Description

Port the existing validations for callbacks of `add_filter()` and `add_action()` to the subscriber system and `get_subscribed_events()` array returnedé

## Type of change

- [x] Chore

## SubscriberCallbackRule

This rule validates `get_subscribed_events()` method implementations in classes that implement `SubscriberInterface`.

### Purpose

Ensures that:
- All array elements have `@filter` or `@action` annotations
- Filter callbacks return non-void values
- Action callbacks return void
- Parameter counts match `accepted_args` when specified

### Usage

Add single-line comment annotations to each array element in `get_subscribed_events()`:

```php
public static function get_subscribed_events(): array {
    return [
        // @action
        'wp_ajax_imagify_get_admin_bar_profile' => 'get_admin_bar_profile_callback',
        
        // @action
        'admin_bar_menu' => [ 'add_imagify_admin_bar_menu', IMAGIFY_INT_MAX ],
        
        // @filter
        'imagify_cdn_source_url' => 'get_cdn_source',
        
        // @filter
        'imagify_settings' => [ 'modify_settings', 10, 2 ],
    ];
}
```

### Supported Array Formats

1. **Simple string method name:**
   ```php
   // @action
   'hook_name' => 'method_name'
   ```

2. **Array with method and priority:**
   ```php
   // @filter
   'hook_name' => [ 'method_name', 20 ]
   ```

3. **Array with method, priority, and accepted_args:**
   ```php
   // @action
   'hook_name' => [ 'method_name', 10, 3 ]
   ```

4. **Nested arrays (multiple callbacks for same hook):**
   ```php
   // @action
   'hook_name' => [
       [ 'method_name_1', 10, 2 ],
       [ 'method_name_2', 20, 1 ]
   ]
   ```
   Note: Annotation on parent element applies to all nested callbacks.

5. **Variable assignment:**
   ```php
   public static function get_subscribed_events(): array {
       $events = [
           // @action
           'hook_name' => 'method_name',
       ];
       return $events;
   }
   ```

### Filter vs Action Guidelines

#### Filters (`// @filter`)
- **Must return a value** (cannot return void)
- Used when modifying data that flows through the hook
- Example:
  ```php
  // @filter
  'the_content' => 'modify_content',
  
  public function modify_content( string $content ): string {
      return $content . ' Modified!';
  }
  ```

#### Actions (`// @action`)
- **Must return void** (or explicit never)
- Used when performing side effects without returning data
- Example:
  ```php
  // @action
  'admin_init' => 'register_settings',
  
  public function register_settings(): void {
      register_setting( 'group', 'option' );
  }
  ```

### Error Identifiers

- `wpmedia.subscriber.missingAnnotation` - Missing @filter or @action annotation
- `wpmedia.subscriber.filter.missingReturn` - Filter callback doesn't return a value
- `wpmedia.subscriber.action.unexpectedReturn` - Action callback returns a value
- `wpmedia.subscriber.arguments.count` - Parameter count mismatch with accepted_args

### Skipped Validations

The rule automatically skips validation for:
- Empty array returns
- Delegated implementations (e.g., `return ParentClass::get_subscribed_events()`)
- Complex multi-statement array building
- Conditional array modifications

### Examples

#### Valid Implementation

```php
class MySubscriber implements SubscriberInterface {
    public static function get_subscribed_events(): array {
        return [
            // @action
            'init' => 'initialize',
            
            // @filter
            'the_content' => [ 'filter_content', 10, 2 ],
        ];
    }
    
    public function initialize(): void {
        // Action - returns void
        register_post_type( 'my_type', [] );
    }
    
    public function filter_content( string $content, int $post_id ): string {
        // Filter - returns value
        return $content . ' Filtered';
    }
}
```

#### Invalid Implementation (Will Show Errors)

```php
class MySubscriber implements SubscriberInterface {
    public static function get_subscribed_events(): array {
        return [
            // Error: Missing annotation
            'init' => 'initialize',
            
            // @filter
            'the_content' => 'filter_content',
        ];
    }
    
    // Error: Action returns string instead of void
    public function initialize(): string {
        return 'initialized';
    }
    
    // Error: Filter returns void instead of value
    public function filter_content( string $content ): void {
        echo $content;
    }
}
```

```