### PR TITLE
fix(settings): add one-click internal state reset tool

### DIFF
--- a/inc/classes/class-imagify-admin-ajax-post.php
+++ b/inc/classes/class-imagify-admin-ajax-post.php
@@ -68,6 +68,8 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 	protected $post_only_actions = [
 		// Custom folders optimization.
 		'imagify_scan_custom_folders',
+		// Settings page.
+		'imagify_reset_internal_state',
 		// Various.
 		'imagify_dismiss_ad',
 	];
@@ -1133,6 +1135,31 @@ class Imagify_Admin_Ajax_Post extends Imagify_Admin_Ajax_Post_Deprecated {
 
 		imagify_maybe_redirect();
 		wp_send_json_success();
+	}
+
+	/**
+	 * Reset Imagify internal optimization state from the settings page.
+	 *
+	 * @since 2.2.8
+	 *
+	 * @return void
+	 */
+	public function imagify_reset_internal_state_callback() {
+		if ( ! imagify_get_context( 'wp' )->current_user_can( 'manage' ) ) {
+			imagify_die();
+			return;
+		}
+
+		imagify_check_nonce( 'imagify-reset-internal-state' );
+
+		$result = imagify_reset_internal_state();
+
+		if ( is_wp_error( $result ) ) {
+			imagify_maybe_redirect( $result );
+			return;
+		}
+
+		imagify_maybe_redirect( __( 'Imagify internal state has been reset.', 'imagify' ) );
 	}
 
 

--- a/inc/functions/admin.php
+++ b/inc/functions/admin.php
@@ -377,6 +377,144 @@ function imagify_maybe_redirect( $message = false, $args_or_url = [] ) {
 }
 
 /**
+ * Reset transient and queue data related to Imagify internal optimization state.
+ *
+ * This is intended for troubleshooting stuck optimization states without
+ * deleting user settings.
+ *
+ * @since 2.2.8
+ *
+ * @return bool|WP_Error True on success. WP_Error if any cleanup query failed.
+ */
+function imagify_reset_internal_state() {
+	global $wpdb;
+
+	$errors = new WP_Error();
+
+	$site_transients = [
+		'imagify_check_licence_1',
+		'imagify_user',
+		'imagify_themes_plugins_to_sync',
+		'do_imagify_rating_cron',
+		'imagify_seen_rating_notice',
+		'imagify_user_images_count',
+		'imagify_check_api_version',
+		'imagify_optimize_media_process_lock',
+	];
+
+	$transients = [
+		'imagify_bulk_optimization_level',
+		'imagify_bulk_optimization_infos',
+		'imagify_bulk_optimization_result',
+		'imagify_bulk_optimization_complete',
+		'imagify_custom-folders_optimize_running',
+		'imagify_wp_optimize_running',
+		'imagify_missing_next_gen_total',
+		'imagify_large_library',
+		'imagify_max_image_size',
+		'imagify_user',
+		'imagify_stat_without_next_gen',
+		'imagify_attachments_number_modal',
+		'imagify_user_cache',
+	];
+
+	foreach ( $site_transients as $transient ) {
+		delete_site_transient( $transient );
+	}
+
+	foreach ( $transients as $transient ) {
+		delete_transient( $transient );
+	}
+
+	imagify_delete_cached_user();
+
+	$like_patterns = [
+		'_transient_%imagify-auto-optimize-%',
+		'_transient_timeout_%imagify-auto-optimize-%',
+		'_transient_%imagify\_rpc\_%',
+		'_transient_timeout_%imagify\_rpc\_%',
+		'_transient_imagify\_%\_process\_locked',
+		'_transient_timeout_imagify\_%\_process\_locked',
+		'_site_transient_imagify\_%\_process\_lock%',
+		'_site_transient_timeout_imagify\_%\_process\_lock%',
+	];
+
+	$options_sql = 'DELETE FROM ' . $wpdb->options . ' WHERE ' . implode( ' OR ', array_fill( 0, count( $like_patterns ), 'option_name LIKE %s' ) );
+	$deleted     = $wpdb->query( $wpdb->prepare( $options_sql, $like_patterns ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+	if ( false === $deleted ) {
+		$errors->add( 'imagify_reset_options_transients', __( 'An error occurred while clearing transient data.', 'imagify' ) );
+	}
+
+	$batch_prefix = $wpdb->esc_like( 'imagify_optimize_media_batch_' ) . '%';
+
+	if ( is_multisite() ) {
+		$network_id = get_current_network_id();
+
+		$sitemeta_patterns = [
+			$network_id,
+			$batch_prefix,
+			'imagify_optimize_media_status',
+		];
+
+		$sitemeta_sql = 'DELETE FROM ' . $wpdb->sitemeta . ' WHERE site_id = %d AND ( meta_key LIKE %s OR meta_key = %s )';
+		$deleted      = $wpdb->query( $wpdb->prepare( $sitemeta_sql, $sitemeta_patterns ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( false === $deleted ) {
+			$errors->add( 'imagify_reset_batches', __( 'An error occurred while clearing optimization batches.', 'imagify' ) );
+		}
+
+		$sitemeta_like_patterns = array_merge( [ $network_id ], $like_patterns );
+		$sitemeta_sql           = 'DELETE FROM ' . $wpdb->sitemeta . ' WHERE site_id = %d AND (' . implode( ' OR ', array_fill( 0, count( $like_patterns ), 'meta_key LIKE %s' ) ) . ')';
+		$deleted                = $wpdb->query( $wpdb->prepare( $sitemeta_sql, $sitemeta_like_patterns ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( false === $deleted ) {
+			$errors->add( 'imagify_reset_sitemeta_transients', __( 'An error occurred while clearing network transient data.', 'imagify' ) );
+		}
+	} else {
+		$options_patterns = [
+			$batch_prefix,
+			'imagify_optimize_media_status',
+		];
+
+		$options_sql = 'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE %s OR option_name = %s';
+		$deleted     = $wpdb->query( $wpdb->prepare( $options_sql, $options_patterns ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( false === $deleted ) {
+			$errors->add( 'imagify_reset_batches', __( 'An error occurred while clearing optimization batches.', 'imagify' ) );
+		}
+	}
+
+	// Cancel pending async jobs that can keep the UI in a stuck state.
+	if ( function_exists( 'as_unschedule_all_actions' ) ) {
+		$action_scheduler_groups = [
+			'imagify-wp-optimize-media',
+			'imagify-custom-folders-optimize-media',
+			'imagify-wp-convert-nextgen',
+			'imagify-custom-folders-convert-nextgen',
+		];
+
+		foreach ( $action_scheduler_groups as $group ) {
+			as_unschedule_all_actions( 'imagify_optimize_media', [], $group );
+			as_unschedule_all_actions( 'imagify_convert_next_gen', [], $group );
+		}
+
+		as_unschedule_all_actions( 'imagify_optimize_media' );
+		as_unschedule_all_actions( 'imagify_convert_next_gen' );
+	}
+
+	wp_clear_scheduled_hook( 'imagify_rating_event' );
+	wp_clear_scheduled_hook( 'imagify_update_library_size_calculations_event' );
+	wp_clear_scheduled_hook( 'imagify_optimize_media_cron' );
+
+	if ( ! $errors->has_errors() ) {
+		return true;
+	}
+
+	return $errors;
+}
+
+/**
  * Get cached Imagify user data.
  * This is usefull to prevent triggering an HTTP request to our server on every page load, but it can be used only where the data doesn't need to be in real time.
  *

--- a/views/page-settings.php
+++ b/views/page-settings.php
@@ -182,6 +182,7 @@ $wrapper_class = isset( $notices[ $notice ] ) || isset( $plugins_list['wp-rocket
 						</div>
 					</div>
 					<?php endif; ?>
+					<?php $this->print_template( 'part-settings-troubleshooting' ); ?>
 					<?php
 					if ( Imagify_Requirements::is_api_key_valid() ) {
 						$this->print_template( 'part-settings-footer' );
@@ -200,4 +201,3 @@ $wrapper_class = isset( $notices[ $notice ] ) || isset( $plugins_list['wp-rocket
 	?>
 
 </div>
-

--- a/views/part-settings-troubleshooting.php
+++ b/views/part-settings-troubleshooting.php
@@ -1,0 +1,19 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+$reset_url = wp_nonce_url(
+	self_admin_url( 'admin-post.php?action=imagify_reset_internal_state' ),
+	'imagify-reset-internal-state'
+);
+?>
+<div class="imagify-settings-section imagify-clear">
+	<h2 class="imagify-options-title"><?php esc_html_e( 'Troubleshooting', 'imagify' ); ?></h2>
+	<p>
+		<?php esc_html_e( 'If optimization appears stuck, reset Imagify internal state to clear transient and queue data without changing your settings.', 'imagify' ); ?>
+	</p>
+	<p>
+		<a class="button imagify-button-secondary" href="<?php echo esc_url( $reset_url ); ?>">
+			<?php esc_html_e( 'Reset internal state', 'imagify' ); ?>
+		</a>
+	</p>
+</div>


### PR DESCRIPTION
## Summary

Add a one-click troubleshooting action in Imagify settings to reset stale internal optimization state without deleting user settings. This addresses recurring stuck optimization states caused by leftover transients, queue locks, and pending async jobs.

Fixes #1012

## Problem

Users can hit persistent stuck optimization states (endless loading, stalled percentages, false quota-like state) even when server conditions are healthy. Current recovery is often plugin deactivate/reactivate or reinstall, which is disruptive.

## Solution

Introduce a dedicated admin-post reset action and settings UI entry point that clears runtime state only: Imagify transients, stale background-process batches/locks, and pending Imagify Action Scheduler jobs. The reset is capability- and nonce-protected and keeps plugin settings intact.

## Changes

### `inc/classes/class-imagify-admin-ajax-post.php`

**Before:**
```php
protected $post_only_actions = [
	'imagify_scan_custom_folders',
	'imagify_dismiss_ad',
];
```

**After:**
```php
protected $post_only_actions = [
	'imagify_scan_custom_folders',
	'imagify_reset_internal_state',
	'imagify_dismiss_ad',
];

public function imagify_reset_internal_state_callback() {
	if ( ! imagify_get_context( 'wp' )->current_user_can( 'manage' ) ) {
		imagify_die();
		return;
	}

	imagify_check_nonce( 'imagify-reset-internal-state' );
	$result = imagify_reset_internal_state();
	imagify_maybe_redirect( is_wp_error( $result ) ? $result : __( 'Imagify internal state has been reset.', 'imagify' ) );
}
```

**Why this works:**
It provides a secure, explicit endpoint for the reset flow in wp-admin. Capability and nonce checks prevent unauthorized state resets, and existing redirect/notice plumbing provides immediate operator feedback.

### `inc/functions/admin.php`

**Before:**
```php
function imagify_maybe_redirect( $message = false, $args_or_url = [] ) {
	// redirect helper only
}
```

**After:**
```php
function imagify_reset_internal_state() {
	// clear key Imagify transients/site transients
	// delete wildcard transient rows from options/sitemeta
	// delete imagify_optimize_media_batch_* and status rows
	// unschedule imagify_optimize_media / imagify_convert_next_gen actions
	// clear related cron hooks
}
```

**Why this works:**
It centralizes runtime-state cleanup into one deterministic routine while preserving user configuration. It also targets both transient APIs and DB-level leftovers (batch/status keys), covering the failure modes seen in stuck-state support cases.

### Settings UI

**Before:**
```php
// no explicit troubleshooting reset entry point on settings page
```

**After:**
```php
<?php $this->print_template( 'part-settings-troubleshooting' ); ?>
```

`views/part-settings-troubleshooting.php` adds a nonce-protected button:
```php
$reset_url = wp_nonce_url(
	self_admin_url( 'admin-post.php?action=imagify_reset_internal_state' ),
	'imagify-reset-internal-state'
);
```

**Why this works:**
It makes recovery available in a predictable place for admins without requiring reinstall/deactivation workflows.

## Testing

### Manual Testing
**Test Case 1: UI visibility and action trigger**
- Steps:
1. Open Imagify settings.
2. Locate the new Troubleshooting section.
3. Click “Reset internal state”.
- Result: Redirects back with success notice and no fatal errors.

**Test Case 2: Settings preservation**
- Steps:
1. Note current Imagify settings values.
2. Run reset action.
3. Re-open settings and compare values.
- Result: Settings remain unchanged.

**Test Case 3: Post-reset behavior**
- Steps:
1. Trigger optimization/bulk flow after reset.
2. Verify processing starts normally.
- Result: Flow proceeds as expected.

### Automated Tests
```bash
$ vendor/bin/phpcs inc/classes/class-imagify-admin-ajax-post.php inc/functions/admin.php views/page-settings.php views/part-settings-troubleshooting.php
.... 4 / 4 (100%)

$ composer test-unit
OK, but incomplete, skipped, or risky tests!
Tests: 24, Assertions: 59, Risky: 5.
```

## Build Artifact

For manual verification, I built an installable package:
[imagify-fix-issue-1012-reset-internal-state.zip](https://github.com/user-attachments/files/25577473/imagify-fix-issue-1012-reset-internal-state.zip)


Installation: `WordPress Admin > Plugins > Add New > Upload Plugin`

## Screenshot 
<img width="1913" height="873" alt="image" src="https://github.com/user-attachments/assets/bec30dc3-de9b-48ee-a285-8afae5dcfef8" />
