### PR TITLE
fix(admin-bar): prevent strpos() null deprecation on invalid API key

### DIFF
--- a/views/admin/admin-bar-status.php
+++ b/views/admin/admin-bar-status.php
@@ -1,8 +1,9 @@
 <?php
 defined( 'ABSPATH' ) || exit;
 
-$pos        = strpos( $data['plan_label'], '_' );
-$plan_label = false !== $pos ? substr( $data['plan_label'], 0, $pos ) : $data['plan_label'];
+$plan_label_value = (string) $data['plan_label'];
+$pos              = strpos( $plan_label_value, '_' );
+$plan_label       = false !== $pos ? substr( $plan_label_value, 0, $pos ) : $plan_label_value;
 ?>
 <div class="imagify-admin-bar-quota">
 	<div class="imagify-abq-row">


### PR DESCRIPTION
## Summary

Fixes PHP 8.1+ `strpos()` deprecation warning when hovering the Imagify admin bar menu with an invalid API key. The fix casts `plan_label` to string before passing it to `strpos()`.

Fixes #961

## Problem

When the API key is invalid, `User::init_user()` gets a `WP_Error` from `get_imagify_user()` and returns early without calling `set_user_properties()`. This leaves `plan_label` as `null`. When the admin bar profile AJAX fires, `null` is passed to `strpos()` in `admin-bar-status.php`, triggering:

```
PHP Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
in views/admin/admin-bar-status.php on line 4
```

## Solution

Cast `$data['plan_label']` to `(string)` at the point of use in the view template. This is the minimal defensive fix — `null` becomes `''`, `strpos('', '_')` returns `false`, and the label displays as empty. No behavioral change for valid API keys.

## Changes

### views/admin/admin-bar-status.php

**Before:**
```php
$pos        = strpos( $data['plan_label'], '_' );
$plan_label = false !== $pos ? substr( $data['plan_label'], 0, $pos ) : $data['plan_label'];
```

**After:**
```php
$plan_label_value = (string) $data['plan_label'];
$pos              = strpos( $plan_label_value, '_' );
$plan_label       = false !== $pos ? substr( $plan_label_value, 0, $pos ) : $plan_label_value;
```

**Why this works:**
`(string)` cast converts `null` to `''`, satisfying PHP 8.1+'s strict type requirement for `strpos()`. When `plan_label` is a valid string (e.g. `"free"`, `"growth_monthly"`), behavior is unchanged.

## Testing

### Manual Testing
**Invalid API key:**
1. Fresh install Imagify, enter an invalid API key, save
2. Hover Imagify in admin bar
3. Check `debug.log` → no `strpos()` deprecation

**Valid API key:**
1. Enter a valid API key, save
2. Hover Imagify admin bar → plan info displays correctly

### Automated Tests
```bash
$ composer test-unit
OK, but incomplete, skipped, or risky tests!
Tests: 24, Assertions: 59, Risky: 5.
```
All 24 tests pass. The 5 risky tests are pre-existing (unrelated `version_compare()` and `ReflectionProperty` deprecations).

## Screen recording

https://videos.faisalahammad.com/recordings/Ti6Hma9pi0Xdgi8xPut3