### PR TITLE
fix(cleanup): delete Imagify transients on deactivation and uninstall

### DIFF
--- a/imagify.php
+++ b/imagify.php
@@ -143,6 +143,10 @@ function imagify_deactivation() {
 		return;
 	}
 
+	// Clean up site transients.
+	delete_site_transient( 'imagify_check_api_version' );
+	delete_site_transient( 'imagify_check_licence_1' );
+
 	/**
 	 * Imagify deactivation.
 	 *

--- a/uninstall.php
+++ b/uninstall.php
@@ -15,6 +15,7 @@ delete_option( $wpdb->prefix . 'ngg_imagify_data_db_version' );
 // Delete all transients.
 delete_site_transient( 'imagify_activation' );
 delete_site_transient( 'imagify_check_licence_1' );
+delete_site_transient( 'imagify_check_api_version' );
 delete_site_transient( 'imagify_user' );
 delete_site_transient( 'imagify_themes_plugins_to_sync' );
 delete_site_transient( 'do_imagify_rating_cron' );
@@ -27,6 +28,7 @@ delete_transient( 'imagify_large_library' );
 delete_transient( 'imagify_max_image_size' );
 delete_transient( 'imagify_user' );
 delete_transient( 'imagify_stat_without_next_gen' );
+delete_transient( 'imagify_bulk_optimization_result' );
 delete_transient( 'imagify_attachments_number_modal' );
 delete_transient( 'imagify_user_cache' );
 


### PR DESCRIPTION
## Summary

Deletes `imagify_check_api_version` and other missing transients on plugin deactivation and uninstall, so no Imagify data is left behind in the database.

Fixes #942

## Problem

The `imagify_check_api_version` site transient (set by `Imagify_Requirements::is_api_up()`) persists in the database after deactivating or deleting Imagify. A few other transients (`imagify_check_licence_1`, `imagify_bulk_optimization_result`) were also missing from cleanup hooks.

## Solution

Added the missing `delete_site_transient()` / `delete_transient()` calls to both the deactivation hook and `uninstall.php`. This follows the existing pattern used by `Bulk::delete_transients_data()`.

## Changes

### imagify.php

**Before:**
```php
function imagify_deactivation() {
    if ( ! imagify_pass_requirements() ) {
        return;
    }

    /** Imagify deactivation. */
    do_action( 'imagify_deactivation' );
}
```

**After:**
```php
function imagify_deactivation() {
    if ( ! imagify_pass_requirements() ) {
        return;
    }

    // Clean up site transients.
    delete_site_transient( 'imagify_check_api_version' );
    delete_site_transient( 'imagify_check_licence_1' );

    /** Imagify deactivation. */
    do_action( 'imagify_deactivation' );
}
```

**Why:** These site transients are set by `Imagify_Requirements::is_api_up()` and `is_api_key_valid()` but were never cleared on deactivation. Placing the cleanup before `do_action( 'imagify_deactivation' )` ensures they're removed regardless of what other hooks do.

### uninstall.php

Added two missing lines to the existing transient cleanup block:

```diff
 delete_site_transient( 'imagify_check_licence_1' );
+delete_site_transient( 'imagify_check_api_version' );
 delete_site_transient( 'imagify_user' );
```

```diff
 delete_transient( 'imagify_stat_without_next_gen' );
+delete_transient( 'imagify_bulk_optimization_result' );
 delete_transient( 'imagify_attachments_number_modal' );
```

## Testing

### Manual Testing

**Test 1: Deactivation cleanup**
1. Activated Imagify, visited settings to trigger `imagify_check_api_version` transient
2. Verified transient exists via Transients Manager
3. Deactivated Imagify
4. Result: `imagify_check_api_version` and `imagify_check_licence_1` are deleted ✅

**Test 2: Uninstall cleanup**
1. Re-activated, triggered transients again
2. Deleted Imagify entirely
3. Result: All Imagify transients removed from the database ✅

## Screen recording 

Screen recording: https://videos.faisalahammad.com/recordings/J88o1IstjuKlmsUkRyld

## Plugin build
[imagify-fix-issue-942.zip](https://github.com/user-attachments/files/25602668/imagify-fix-issue-942.zip)