### PR TITLE
feat(cli): add WP-CLI restore command

### DIFF
--- a/classes/Bulk/Bulk.php
+++ b/classes/Bulk/Bulk.php
@@ -220,6 +220,61 @@ final class Bulk {
 	}
 
 	/**
+	 * Runs the bulk restore for a given context.
+	 *
+	 * Restores all optimized media to their original state synchronously.
+	 * Does not use the Action Scheduler since restore is a local file
+	 * operation that does not consume API quota.
+	 *
+	 * @since 2.3
+	 *
+	 * @param string $context Current context (WP/Custom folders).
+	 *
+	 * @return array {
+	 *     @type bool   $success  Whether the operation was successful.
+	 *     @type string $message  Status message.
+	 *     @type int    $restored Number of media successfully restored.
+	 *     @type int    $errors   Number of media that failed to restore.
+	 *     @type int    $total    Total number of media processed.
+	 * }
+	 */
+	public function run_restore( string $context ) {
+		$media_ids = $this->get_bulk_instance( $context )->get_optimized_media_ids();
+
+		if ( empty( $media_ids ) ) {
+			return [
+				'success'  => false,
+				'message'  => 'no-images',
+				'restored' => 0,
+				'errors'   => 0,
+				'total'    => 0,
+			];
+		}
+
+		$restored = 0;
+		$errors   = 0;
+
+		foreach ( $media_ids as $media_id ) {
+			$process = imagify_get_optimization_process( $media_id, $context );
+			$result  = $process->restore();
+
+			if ( is_wp_error( $result ) ) {
+				++$errors;
+			} else {
+				++$restored;
+			}
+		}
+
+		return [
+			'success'  => true,
+			'message'  => 'success',
+			'restored' => $restored,
+			'errors'   => $errors,
+			'total'    => count( $media_ids ),
+		];
+	}
+
+	/**
 	 * Runs the next-gen generation
 	 *
 	 * @param array $contexts An array of contexts (WP/Custom folders).

--- a/classes/Bulk/BulkInterface.php
+++ b/classes/Bulk/BulkInterface.php
@@ -18,6 +18,15 @@ interface BulkInterface {
 	public function get_unoptimized_media_ids( $optimization_level );
 
 	/**
+	 * Get all optimized media ids that can be restored.
+	 *
+	 * @since 2.3
+	 *
+	 * @return array A list of optimized media IDs with backup files available.
+	 */
+	public function get_optimized_media_ids();
+
+	/**
 	 * Get ids of all optimized media without Next gen versions.
 	 *
 	 * @since 2.2

--- a/classes/Bulk/CustomFolders.php
+++ b/classes/Bulk/CustomFolders.php
@@ -79,6 +79,60 @@ class CustomFolders extends AbstractBulk {
 	}
 
 	/**
+	 * Get all optimized media ids that can be restored.
+	 *
+	 * @since 2.3
+	 *
+	 * @return array A list of optimized media IDs with backup files available.
+	 */
+	public function get_optimized_media_ids() {
+		global $wpdb;
+
+		$this->set_no_time_limit();
+
+		$files_table   = Imagify_Files_DB::get_instance()->get_table_name();
+		$folders_table = Imagify_Folders_DB::get_instance()->get_table_name();
+
+		$files = $wpdb->get_results( // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"
+			SELECT fi.file_id, fi.path
+			FROM $files_table as fi
+			INNER JOIN $folders_table AS fo
+				ON ( fi.folder_id = fo.folder_id )
+			WHERE
+				fi.status = 'success'
+			ORDER BY fi.file_id DESC"
+		);
+
+		$wpdb->flush();
+
+		if ( ! $files ) {
+			return [];
+		}
+
+		$data = [];
+
+		foreach ( $files as $file ) {
+			$file_id = absint( $file->file_id );
+
+			if ( empty( $file->path ) ) {
+				continue;
+			}
+
+			$file_path   = Imagify_Files_Scan::remove_placeholder( $file->path );
+			$backup_path = Imagify_Custom_Folders::get_file_backup_path( $file_path );
+
+			if ( ! $this->filesystem->exists( $backup_path ) ) {
+				continue;
+			}
+
+			$data[] = $file_id;
+		}
+
+		return $data;
+	}
+
+	/**
 	 * Get ids of all optimized media without Next gen versions.
 	 *
 	 * @since 2.2

--- a/classes/Bulk/Noop.php
+++ b/classes/Bulk/Noop.php
@@ -20,6 +20,17 @@ class Noop extends AbstractBulk {
 	}
 
 	/**
+	 * Get all optimized media ids that can be restored.
+	 *
+	 * @since 2.3
+	 *
+	 * @return array A list of optimized media IDs with backup files available.
+	 */
+	public function get_optimized_media_ids() {
+		return [];
+	}
+
+	/**
 	 *   * Get ids of all optimized media without Next gen versions.
 	 *
 	 * @since 2.2

--- a/classes/Bulk/WP.php
+++ b/classes/Bulk/WP.php
@@ -172,6 +172,83 @@ class WP extends AbstractBulk {
 	}
 
 	/**
+	 * Get all optimized media ids that can be restored.
+	 *
+	 * @since 2.3
+	 *
+	 * @return array A list of optimized media IDs with backup files available.
+	 */
+	public function get_optimized_media_ids() {
+		global $wpdb;
+
+		$this->set_no_time_limit();
+
+		$mime_types   = Imagify_DB::get_mime_types();
+		$statuses     = Imagify_DB::get_post_statuses();
+		$nodata_join  = Imagify_DB::get_required_wp_metadata_join_clause();
+		$nodata_where = Imagify_DB::get_required_wp_metadata_where_clause(
+			[
+				'prepared' => true,
+			]
+		);
+
+		$ids = $wpdb->get_col( // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"
+			SELECT DISTINCT p.ID
+			FROM $wpdb->posts AS p
+				$nodata_join
+			INNER JOIN $wpdb->postmeta AS mt1
+				ON ( p.ID = mt1.post_id AND mt1.meta_key = '_imagify_status' )
+			WHERE
+				p.post_mime_type IN ( $mime_types )
+				AND mt1.meta_value = 'success'
+				AND p.post_type = 'attachment'
+				AND p.post_status IN ( $statuses )
+				$nodata_where
+			ORDER BY p.ID DESC"
+		);
+
+		$wpdb->flush();
+		$ids = array_filter( array_map( 'absint', $ids ) );
+
+		if ( ! $ids ) {
+			return [];
+		}
+
+		$metas = Imagify_DB::get_metas(
+			[
+				// Get attachments filename.
+				'filenames' => '_wp_attached_file',
+			],
+			$ids
+		);
+
+		$data = [];
+
+		foreach ( $ids as $id ) {
+			if ( empty( $metas['filenames'][ $id ] ) ) {
+				continue;
+			}
+
+			$file_path = get_imagify_attached_file( $metas['filenames'][ $id ] );
+
+			if ( ! $file_path ) {
+				continue;
+			}
+
+			$backup_path = get_imagify_attachment_backup_path( $file_path );
+
+			if ( ! $this->filesystem->exists( $backup_path ) ) {
+				continue;
+			}
+
+			$data[] = $id;
+		}
+
+		return $data;
+	}
+
+	/**
 	 * Get ids of all optimized media without Next gen versions.
 	 *
 	 * @since 2.2

--- a/classes/CLI/RestoreCommand.php
+++ b/classes/CLI/RestoreCommand.php
@@ -1,0 +1,151 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\CLI;
+
+use Imagify\Bulk\Bulk;
+
+/**
+ * Command class for the bulk restore.
+ *
+ * Restores all optimized media back to their original state.
+ *
+ * ## EXAMPLES
+ *
+ *     # Restore all optimized images (library + custom folders).
+ *     $ wp imagify restore
+ *
+ *     # Restore only WordPress media library images.
+ *     $ wp imagify restore library
+ *
+ *     # Restore only custom folders images.
+ *     $ wp imagify restore custom-folders
+ *
+ *     # Restore both contexts explicitly.
+ *     $ wp imagify restore library custom-folders
+ *
+ * @since 2.3
+ */
+class RestoreCommand extends AbstractCommand {
+
+	/**
+	 * Map of user-friendly context names to internal context identifiers.
+	 *
+	 * @var array<string, string>
+	 */
+	private const CONTEXT_MAP = [
+		'library'        => 'wp',
+		'custom-folders' => 'custom-folders',
+	];
+
+	/**
+	 * Executes the command.
+	 *
+	 * @param array $arguments Positional argument.
+	 * @param array $options Optional arguments.
+	 */
+	public function __invoke( $arguments, $options ) {
+		// Default to all contexts if none specified.
+		if ( empty( $arguments ) ) {
+			$arguments = array_keys( self::CONTEXT_MAP );
+		}
+
+		// Validate and map contexts.
+		$contexts = [];
+
+		foreach ( $arguments as $arg ) {
+			if ( ! isset( self::CONTEXT_MAP[ $arg ] ) ) {
+				\WP_CLI::error(
+					sprintf(
+						'Invalid context: "%s". Valid values are: %s',
+						$arg,
+						implode( ', ', array_keys( self::CONTEXT_MAP ) )
+					)
+				);
+			}
+
+			$contexts[] = self::CONTEXT_MAP[ $arg ];
+		}
+
+		$total_restored = 0;
+		$total_errors   = 0;
+
+		foreach ( $contexts as $index => $context ) {
+			$label = $arguments[ $index ];
+
+			\WP_CLI::log( sprintf( 'Restoring optimized media for: %s', $label ) );
+
+			$result = Bulk::get_instance()->run_restore( $context );
+
+			if ( ! $result['success'] ) {
+				\WP_CLI::warning( sprintf( 'No optimized media to restore for: %s', $label ) );
+				continue;
+			}
+
+			$total_restored += $result['restored'];
+			$total_errors   += $result['errors'];
+
+			\WP_CLI::log(
+				sprintf(
+					'%s: %d restored, %d errors out of %d total.',
+					ucfirst( $label ),
+					$result['restored'],
+					$result['errors'],
+					$result['total']
+				)
+			);
+		}
+
+		if ( 0 === $total_restored && 0 === $total_errors ) {
+			\WP_CLI::warning( 'No optimized media found to restore.' );
+			return;
+		}
+
+		if ( $total_errors > 0 ) {
+			\WP_CLI::warning(
+				sprintf(
+					'Restore completed with errors: %d restored, %d failed.',
+					$total_restored,
+					$total_errors
+				)
+			);
+			return;
+		}
+
+		\WP_CLI::success(
+			sprintf(
+				'Restore completed: %d media restored successfully.',
+				$total_restored
+			)
+		);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function get_command_name(): string {
+		return 'restore';
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_description(): string {
+		return 'Restore all optimized media to their original state';
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_synopsis(): array {
+		return [
+			[
+				'type'        => 'positional',
+				'name'        => 'contexts',
+				'description' => 'The context(s) to restore. Possible values are library and custom-folders. Defaults to all if omitted.',
+				'optional'    => true,
+				'repeating'   => true,
+			],
+		];
+	}
+}

--- a/classes/Plugin.php
+++ b/classes/Plugin.php
@@ -5,7 +5,7 @@ namespace Imagify;
 
 use Imagify\Admin\AdminBar;
 use Imagify\Bulk\Bulk;
-use Imagify\CLI\{BulkOptimizeCommand, GenerateMissingNextgenCommand};
+use Imagify\CLI\{BulkOptimizeCommand, GenerateMissingNextgenCommand, RestoreCommand};
 use Imagify\Dependencies\League\Container\Container;
 use Imagify\Dependencies\League\Container\ServiceProvider\ServiceProviderInterface;
 use Imagify\EventManagement\{EventManager, SubscriberInterface};
@@ -133,6 +133,7 @@ class Plugin {
 
 		imagify_add_command( new BulkOptimizeCommand() );
 		imagify_add_command( new GenerateMissingNextgenCommand() );
+		imagify_add_command( new RestoreCommand() );
 
 		foreach ( $providers as $service_provider ) {
 			$provider_instance = new $service_provider();


### PR DESCRIPTION
## Summary

Adds a `wp imagify restore` WP-CLI subcommand for bulk restoring optimized media back to their original state. Currently the only way to restore images is through the admin UI one-by-one, which is impractical when changing compression settings across many images.

Fixes #922

## Problem

When users want to restore many optimized images (e.g., after deciding to change compression levels), they must click "Restore" on each image individually through the media library. There's no CLI equivalent, making bulk restoration tedious for sites with hundreds or thousands of images.

## Solution

Added a new `RestoreCommand` following the same architecture as the existing `BulkOptimizeCommand` and `GenerateMissingNextgenCommand`. Restore runs synchronously (no Action Scheduler) since it's a local file operation that doesn't consume API quota.

Uses `library` as the user-facing context name instead of `wp` to avoid the confusing `wp imagify restore wp` syntax.

## Changes

### [NEW] classes/CLI/RestoreCommand.php

New CLI command class extending `AbstractCommand`. Accepts optional positional `contexts` argument (`library` and/or `custom-folders`). Defaults to all contexts when omitted.

Maps user-friendly names to internal context identifiers via `CONTEXT_MAP`:

```php
private const CONTEXT_MAP = [
    'library'        => 'wp',
    'custom-folders' => 'custom-folders',
];
```

### classes/Bulk/BulkInterface.php

Added new interface method:

```php
public function get_optimized_media_ids();
```

Returns an array of media IDs that are currently optimized (status = `success`) and have a backup file available for restore.

### classes/Bulk/WP.php

Implements `get_optimized_media_ids()` — queries `wp_posts` + `wp_postmeta` for attachments where `_imagify_status = 'success'`, then verifies backup file existence for each match. Pattern follows the existing `get_unoptimized_media_ids()` query structure.

### classes/Bulk/CustomFolders.php

Implements `get_optimized_media_ids()` — queries the custom files/folders tables for files with `status = 'success'`, verifies backup existence. Pattern follows the existing `get_optimized_media_ids_without_format()` query structure.

### classes/Bulk/Noop.php

Implements `get_optimized_media_ids()` — returns empty array (fallback).

### classes/Bulk/Bulk.php

Added `run_restore()` method:

```php
public function run_restore( string $context ) {
    $media_ids = $this->get_bulk_instance( $context )->get_optimized_media_ids();

    if ( empty( $media_ids ) ) {
        return [ 'success' => false, 'message' => 'no-images', ... ];
    }

    foreach ( $media_ids as $media_id ) {
        $process = imagify_get_optimization_process( $media_id, $context );
        $result  = $process->restore();
        // track success/error counts
    }

    return [ 'success' => true, 'restored' => $restored, 'errors' => $errors, ... ];
}
```

**Why synchronous:** Unlike `run_optimize()` which queues via Action Scheduler (API calls consume quota), restore is purely local file operations (copy backup over optimized file, delete optimization metadata). No need for async processing.

### classes/Plugin.php

Added import and registration of `RestoreCommand`.

## Testing

### Manual Testing

**Test Case 1: Restore WP media library**
1. Optimize several images via Imagify
2. Run `wp imagify restore library`
3. Result: All images restored, shows success count

**Test Case 2: Restore with no optimized images**
1. Run `wp imagify restore library` again (already restored)
2. Result: Shows "No optimized media to restore" warning

**Test Case 3: Restore all contexts**
1. Run `wp imagify restore` (no arguments)
2. Result: Processes both library and custom-folders contexts

**Test Case 4: Invalid context**
1. Run `wp imagify restore invalid`
2. Result: Shows error with valid options listed

### Usage

```bash
wp imagify restore                        # Restore all contexts
wp imagify restore library                # Restore WP media library only
wp imagify restore custom-folders         # Restore custom folders only
wp imagify restore library custom-folders # Both explicitly
```

## Build Artifact

`imagify-fix-issue-922.zip` — Ready to install via WordPress Admin → Plugins → Add New → Upload Plugin

[imagify-fix-issue-922.zip](https://github.com/user-attachments/files/25617241/imagify-fix-issue-922.zip)


## Screen recording 

https://videos.faisalahammad.com/recordings/X7geVFuh922vtH3ZdCP7