### PR TITLE
Fixes #975 Remove function to load translations

### DIFF
--- a/imagify.php
+++ b/imagify.php
@@ -102,16 +102,6 @@ function imagify_pass_requirements() {
 }
 
 /**
- * Load plugin translations.
- *
- * @since 1.9
- */
-function imagify_load_translations() {
-	load_plugin_textdomain( 'imagify', false, dirname( plugin_basename( IMAGIFY_FILE ) ) . '/languages/' );
-}
-add_action( 'init', 'imagify_load_translations' );
-
-/**
  * Set a transient on plugin activation, it will be used later to trigger activation hooks after the plugin is loaded.
  * The transient contains the ID of the user that activated the plugin.
  *


### PR DESCRIPTION
# Description

Fixes #975 

Remove function to load translations, as it's not needed anymore for plugins hosted on the WP repository with translations managed there as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

- Translations are still loaded

### How to test

- Verify the translations are correctly loaded in the admin, in a different language than english

### Affected Features & Quality Assurance Scope

Translations strings in the admin

## Technical description

### Documentation

TBD

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No tests for removed code