### PR TITLE
fix: render line breaks in admin bar upgrade message

### DIFF
--- a/views/admin/admin-bar-status.php
+++ b/views/admin/admin-bar-status.php
@@ -39,7 +39,7 @@ $plan_label = false !== $pos ? substr( $data['plan_label'], 0, $pos ) : $data['p
 		<?php elseif ( 0 === $data['unconsumed_quota'] ) : ?>
 		<p><i class="dashicons dashicons-warning" aria-hidden="true"></i><strong><?php esc_html_e( 'Oops, It\'s Over!', 'imagify' ); ?></strong></p>
 		<?php endif; ?>
-		<p><?php echo esc_html( $data['text'] ); ?></p>
+		<p><?php echo wp_kses( $data['text'], [ 'br' => [] ] ); ?></p>
 		<p class="center txt-center text-center"><a class="imagify-upsell-admin-bar-button" href="<?php echo esc_url( $data['upgrade_link'] ); ?>" target="_blank"><?php echo esc_html( $data['button_text'] ); ?></a></p>
 		<a href="<?php echo esc_url( get_imagify_admin_url( 'dismiss-notice', 'upsell-admin-bar' ) ); ?>" class="imagify-notice-dismiss imagify-upsell-dismiss notice-dismiss" title="<?php esc_attr_e( 'Dismiss this notice', 'imagify' ); ?>"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice', 'imagify' ); ?></span></a>
 	</div>


### PR DESCRIPTION
## Summary

Fixes a visual bug where the `<br>` tag was visible as literal text in the admin bar upgrade message when credits are exhausted. This occurred because the message was being escaped by `esc_html()` in the template.

Fixes #1033

## Changes

### views/admin/admin-bar-status.php

**Before:**
```php
<p><?php echo esc_html( $data['text'] ); ?></p>
```

**After:**
```php
<p><?php echo wp_kses( $data['text'], [ 'br' => [] ] ); ?></p>
```

**Why:** The `$text` value is built in `AdminBar.php` with hardcoded `<br>` tags. Switching to `wp_kses()` with a narrow allowlist for `br` ensures the line break renders correctly while maintaining security.

## Testing

**Test 1: Admin Bar Profile**
1. Activate the plugin and ensure the account is on a free plan or has low credits.
2. Open the Imagify menu in the admin bar.
3. Verify the upgrade message shows a line break instead of a visible `<br>` tag.

Result: Works as expected