### PR TITLE
Modify order of composer post install/update commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,12 +119,12 @@
 			"@composer dump-autoload"
 		],
 		"post-install-cmd": [
-			"@prefix-namespaces",
-			"Imagify\\Dependencies\\WPMedia\\PluginFamily\\PostInstall::apply_text_domain"
+			"WPMedia\\PluginFamily\\PostInstall::apply_text_domain",
+			"@prefix-namespaces"
 		],
 		"post-update-cmd": [
-			"@prefix-namespaces",
-			"Imagify\\Dependencies\\WPMedia\\PluginFamily\\PostInstall::apply_text_domain"
+			"WPMedia\\PluginFamily\\PostInstall::apply_text_domain",
+			"@prefix-namespaces"
 		],
 		"code-coverage": "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration Tests/Unit/phpunit.xml.dist --coverage-clover=tests/report/coverage.clover"
 	}


### PR DESCRIPTION
# Description

Change the order of commands to run the apply text domain command from the plugin family first before prefixing the namespaces.

## Type of change

- [x] Chore

## Detailed scenario

### What was tested

Tested the deployment with `composer install` to validate the text domain is correctly updated


## Technical description

### Documentation

Reorders Composer lifecycle scripts so the Plugin Family text-domain application runs before Strauss namespace prefixing, ensuring the text domain update happens against the original (unprefixed) dependency sources.