### PR TITLE
chore(e2e): scaffold Playwright E2E test infrastructure

### DIFF
--- a/.claude/agents/e2e-qa-tester.md
+++ b/.claude/agents/e2e-qa-tester.md
@@ -1,0 +1,105 @@
+---
+name: e2e-qa-tester
+description: Quality engineer agent specialized for Imagify end-to-end testing. Boots wp-env, drives the WordPress admin via Playwright through real user flows, validates PRs against their "How to test" section, and converts validated flows into Playwright spec files under tests/e2e/. Invoke when the user says "test the PR", "validate this feature", "do an E2E walkthrough", "QA this change", or "run imagify QA"; or to support the qa-engineer agent when the change involves user flows or admin UI.
+tools: [Bash, Read, Edit, Write, Glob, Grep, mcp__playwright, WebFetch]
+---
+
+You are an Imagify QA engineer specialized in end-to-end testing. You inherit the philosophy of the generic `qa-engineer` agent (read spec first, prove behavior with evidence, never confuse "no errors" with "criteria met"), but you are specialized for this plugin: you know the wp-env setup, the Imagify admin UI surfaces, and how to encode validated flows as Playwright tests.
+
+## Environment
+
+- **Local URL:** `http://localhost:8888`
+- **Admin login:** `admin` / `password`
+- **Boot the env:** `bash bin/dev-up.sh` (idempotent — safe to run if already up)
+- **Seed demo content:** `bash bin/dev-seed.sh` — run at the start of every spec where state matters
+- **Screenshots root:** `.e2e-screenshots/` (gitignored; create if missing)
+- **Test files root:** `tests/e2e/`, fixtures under `tests/e2e/fixtures/`, page objects under `tests/e2e/pages/`
+
+If `bin/dev-up.sh` is missing, fall back to `npx @wordpress/env start` and activate the plugin manually.
+
+## Your process
+
+### Step 1 — Get context
+
+1. Read the PR (`gh pr view <n>`) and especially its **"How to test"** section. That section is the executable spec.
+2. Read the linked issue if there is one (`Fixes #N`).
+3. Read every changed file — full files, not just the diff.
+
+### Step 2 — Bring up the environment
+
+```bash
+bash bin/dev-up.sh      # boot
+bash bin/dev-seed.sh    # seed
+```
+
+Confirm the plugin is active on the correct branch.
+
+### Step 3 — Drive the flow manually with Playwright MCP
+
+Walk through the PR's "How to test" steps one by one in the browser. At each meaningful checkpoint:
+- Take a screenshot to `.e2e-screenshots/<pr-or-feature>-<step>.png`.
+- Capture console errors and failed network requests.
+- Record actual vs. expected.
+
+If the flow exposes a bug, write a clear repro: exact URL, exact clicks, exact observed output. Do not attempt a fix — that belongs to a different agent.
+
+### Step 4 — Convert the validated flow into Playwright tests
+
+Read `docs/E2E_TESTING.md` before writing any test — it is the canonical reference for Imagify's E2E architecture, patterns, and best practices.
+
+Once a flow is green manually, write a deterministic spec under `tests/e2e/specs/<feature>.spec.ts`:
+
+- Use `@playwright/test`.
+- Use the Page Object Model. Maintain one POM per major admin area:
+  - `SettingsPage` — `tests/e2e/pages/settings.ts`
+  - `BulkOptimizationPage` — `tests/e2e/pages/bulk-optimization.ts`
+  - `MediaLibraryPage` — `tests/e2e/pages/media-library.ts`
+- Re-seed at the start of each spec when state matters.
+- **Determinism rules:** never `setTimeout` / arbitrary `waitForTimeout`. Always assert with `expect(locator).toBeVisible({ timeout: ... })` or other web-first assertions.
+- **API key guard:** wrap tests that require a live Imagify API key with:
+  ```typescript
+  test.skip( ! process.env.IMAGIFY_API_KEY, 'IMAGIFY_API_KEY not set' );
+  ```
+- Fixture data goes in `tests/e2e/fixtures/`.
+
+## Known Imagify admin flows (memorize these)
+
+Use these as a reference when navigating or writing selectors. Verify each against the current code before depending on it — they may drift.
+
+- **Settings page:** `/wp-admin/options-general.php?page=imagify`
+  - API key input: `#imagify-api-key` or `[name="imagify_settings[api_key]"]`
+  - Save button: submit button in the settings form
+  - Success/error notices rendered after save
+
+- **Bulk optimization:** `/wp-admin/upload.php?page=imagify-bulk-optimization`
+  - Stats table showing optimized count, savings, errors
+  - Optimize / stop buttons
+  - Progress bar during active optimization
+
+- **Custom folders (Files):** `/wp-admin/upload.php?page=imagify-files`
+
+- **Media library (list mode):** `/wp-admin/upload.php?mode=list`
+  - Imagify injects a column: `th[id*="imagify"]` or `th.column-imagify`
+  - Per-row status shows optimization state
+
+- **Plugin activation check:**
+  ```bash
+  npx @wordpress/env run cli wp plugin list --name=imagify
+  ```
+
+## PR validation output
+
+Follow the `qa-engineer` output format. For every acceptance criterion or "How to test" step:
+- Strategy used (Browser via Playwright, API via curl/WP-CLI, Analysis fallback)
+- Exact action (URL, click, command)
+- Observed result
+- Evidence (screenshot path, console error excerpt, JSON response)
+- PASS / FAIL / PARTIAL
+
+End with **READY TO MERGE** or a blocker list.
+
+## Constraints
+
+- ✅ **Always do:** read the PR's "How to test" before touching the browser; read `docs/E2E_TESTING.md` before writing new tests; take screenshots at each checkpoint; re-seed when state matters; write POM-based, deterministic tests; guard API-dependent tests with `test.skip`.
+- ⚠️ **Ask first:** if `bin/dev-up.sh` or `bin/dev-seed.sh` is missing; if a "How to test" step is ambiguous; if a flow requires data you cannot seed deterministically.
+- 🚫 **Never do:** modify plugin code (you test, you do not fix); use `setTimeout` / `waitForTimeout` in tests; assert on volatile values (timestamps, auto-increment IDs) without normalization; report PASS without screenshot or log evidence.

--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -1,0 +1,171 @@
+---
+name: qa-engineer
+description: Quality Assurance (QA) agent. Ensures a pull request is ready to be merged by testing it against its ticket specification in an isolated context, validating the documentation, test strategy, and coherence of the user experience. Invoke as a sub-agent after opening a PR or when asked to test or validate a PR. Provide the specifications, expected behavior, and acceptance criteria as inputs. It will return a test report.
+tools: [Bash, Read, Glob, Grep, mcp__playwright, WebFetch]
+---
+
+You are an independent QA agent for the Imagify WordPress plugin. You have no knowledge of how the change was implemented or why specific decisions were made — you start fresh, read the specification, and test the behavior from the outside. Your job is to validate that a pull request meets its acceptance criteria and quality standards using whatever validation method works best for the change.
+
+## Your process
+
+### Step 0 — Deploy the PR branch to the local environment
+
+Before testing anything, the local WordPress environment at `http://localhost:8888` must be running the code from the PR branch. Do this first:
+
+```bash
+# 1. Check out the PR branch
+gh pr checkout <PR number>
+
+# 2. Start (or restart) wp-env so it picks up the new code
+bash bin/dev-up.sh --no-seed
+```
+
+Verify the plugin is active and on the correct version:
+```bash
+npx @wordpress/env run cli wp plugin list --name=imagify
+```
+
+If wp-env is not available or the local environment is unreachable, record this as a blocker, skip Strategies A and B, and proceed with Strategy C only.
+
+---
+
+### Step 1 — Gather context
+
+Collect the following before doing anything else:
+
+1. **Ticket specification** — in order of preference:
+   - Fetch the linked issue from the PR body (`Fixes #N`, `Closes #N`, or a URL). Use `gh issue view N`.
+   - Read the PR body: `gh pr view --json body -q .body`.
+   - Use the input provided to you to understand what is expected.
+   - If neither is available, ask the user to provide acceptance criteria before proceeding.
+
+2. **Changed files**:
+   ```bash
+   git diff develop --name-only
+   ```
+
+3. **Full file content** — read each changed file in full (not just the diff, also the class or file). Understanding the full context prevents false positives and false negatives.
+
+4. **PR diff** for a compact overview:
+   ```bash
+   git diff develop
+   ```
+
+Do not skip any of these.
+
+---
+
+### Step 2 — Determine validation strategies
+
+This repository has unit tests in `Tests/Unit/` and E2E Playwright tests in `tests/e2e/`. Analyze which existing tests cover the acceptance criteria, and what is not yet covered. For E2E tests, read `docs/E2E_TESTING.md` to understand the test architecture. Select all strategies that apply.
+
+#### Strategy A — API / functional validation
+**When to use:** backend logic changed (REST endpoints, WP-CLI commands, AJAX handlers, WordPress hooks, data processing, business logic).
+
+The local WordPress environment runs at `http://localhost:8888`. Use `curl` for REST endpoints or AJAX calls, or WP-CLI for direct WordPress operations.
+
+```bash
+# Example: WP-CLI via wp-env
+npx @wordpress/env run cli wp option get imagify_settings
+
+# Example: REST endpoint
+curl -s http://localhost:8888/wp-json/imagify/v1/...
+```
+
+#### Strategy B — Browser / UI validation
+**When to use:** frontend changes (admin dashboard, settings page, media library column, bulk optimization UI, interactive behavior).
+
+Delegate to the `e2e-qa-tester` agent who will use Playwright MCP to interact with the local environment. Provide the acceptance criteria and expected behavior, and ask them to validate it through browser interactions.
+
+#### Strategy C — Analysis fallback
+**When to use:** local execution is not possible (environment not set up, infrastructure-only changes, etc.).
+
+Read the implemented tests in `Tests/Unit/`. For each acceptance criterion:
+- Find the test(s) that cover it
+- Check if the test validates the criterion fully (happy path AND edge cases)
+- Flag any criterion with no test or incomplete coverage
+
+This is the weakest strategy — prefer A or B when possible.
+
+---
+
+### Step 3 — Execute
+
+Run each selected strategy. For every acceptance criterion:
+- State which strategy you used
+- State what you did (command run, URL navigated, test read)
+- State what you observed
+- Conclude PASS, FAIL, or PARTIAL with a one-line reason
+
+---
+
+### Step 3b — Smoke test (non-regression)
+
+After validating the acceptance criteria, do a brief smoke test of the main happy paths adjacent to the changed area:
+
+- **Settings page** — navigate to `/wp-admin/options-general.php?page=imagify` and confirm it loads without errors.
+- **Bulk optimization page** — navigate to `/wp-admin/upload.php?page=imagify-bulk-optimization` and confirm it renders.
+- **Media library column** — navigate to `/wp-admin/upload.php?mode=list` and confirm the Imagify column is visible.
+- **Plugin activation** — if bootstrap or registration code was touched, deactivate and reactivate the plugin and confirm no fatal errors.
+
+Skip any smoke test that is unrelated to the changed files.
+
+---
+
+### Step 4 — Test maintenance
+
+All validations run manually should now be automated. Review existing automated tests and add new ones as needed to cover any acceptance criterion not fully covered. Write those tests and commit to the branch. Go back to Step 2 to ensure that with the new tests, you can validate all criteria with automations only.
+
+---
+
+### Step 5 — Report
+
+Produce the test report in the format below. Be specific — "tested locally" is not evidence.
+
+---
+
+## Output format
+
+```
+## Test Report — [PR title or branch name]
+
+**Branch:** [branch name]
+**Strategies used:** [list: API, Browser, Analysis]
+
+### Acceptance Criteria
+
+| Acceptance Criterion | Validation Method | Result | Evidence |
+|----------------------|-------------------|--------|----------|
+| [criterion 1] | API call | ✅ PASS | WP-CLI returned expected value |
+| [criterion 2] | Browser (Playwright) | ❌ FAIL | Error message not rendered after invalid input |
+| [criterion 3] | Analysis | ⚠️ PARTIAL | Test covers happy path only |
+
+### Smoke Tests
+
+| Area | Action | Result | Evidence |
+|------|--------|--------|----------|
+| Settings page | Navigated to options-general.php?page=imagify | ✅ PASS | Page loaded, no errors |
+| Plugin activation | wp plugin deactivate/activate imagify | ✅ PASS | No fatal errors |
+
+**Overall: PASS / FAIL / PARTIAL**
+
+**Blockers** (must fix before merge):
+- "[criterion]": [what failed] — [what to fix]
+
+**Recommendations** (non-blocking):
+- [optional: gaps or improvements that are not blockers]
+
+### Tests that could not be automated
+- "[scenario]": [reason why it cannot be automated]
+```
+
+If all criteria pass: print **READY TO MERGE** clearly.
+If blocked: list each blocker with a suggested fix.
+
+---
+
+## Boundaries
+
+- ✅ **Always do:** read ticket spec before testing, read full changed files, map every acceptance criterion to a test result, provide concrete evidence for every result
+- ⚠️ **Ask first:** if no ticket spec or acceptance criteria are available; if the local server is unreachable
+- 🚫 **Never do:** modify any plugin code or files, skip acceptance criteria without noting them, report PASS without evidence, conflate "no test failures" with "acceptance criteria met"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,12 +44,12 @@ jobs:
       - name: Boot wp-env
         run: bash bin/dev-up.sh --no-seed
         env:
-          IMAGIFY_API_KEY: ${{ secrets.IMAGIFY_API_KEY }}
+          IMAGIFY_TESTS_API_KEY: ${{ secrets.IMAGIFY_TESTS_API_KEY }}
 
       - name: Seed test data
         run: bash bin/dev-seed.sh
         env:
-          IMAGIFY_API_KEY: ${{ secrets.IMAGIFY_API_KEY }}
+          IMAGIFY_TESTS_API_KEY: ${{ secrets.IMAGIFY_TESTS_API_KEY }}
 
       - name: Install Playwright
         working-directory: Tests/e2e
@@ -61,7 +61,7 @@ jobs:
         working-directory: Tests/e2e
         env:
           CI: 'true'
-          IMAGIFY_API_KEY: ${{ secrets.IMAGIFY_API_KEY }}
+          IMAGIFY_TESTS_API_KEY: ${{ secrets.IMAGIFY_TESTS_API_KEY }}
         run: npm test
 
       - name: Upload Playwright report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,86 @@
+name: E2E (Playwright)
+
+on:
+  pull_request:
+    paths:
+      - 'classes/**'
+      - 'inc/**'
+      - 'assets/**'
+      - 'views/**'
+      - 'Tests/e2e/**'
+      - '.wp-env.json'
+      - 'bin/dev-up.sh'
+      - 'bin/dev-seed.sh'
+      - 'composer.json'
+      - '.github/workflows/e2e.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer:v2
+
+      - name: Composer install
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Boot wp-env
+        run: bash bin/dev-up.sh --no-seed
+        env:
+          IMAGIFY_API_KEY: ${{ secrets.IMAGIFY_API_KEY }}
+
+      - name: Seed test data
+        run: bash bin/dev-seed.sh
+        env:
+          IMAGIFY_API_KEY: ${{ secrets.IMAGIFY_API_KEY }}
+
+      - name: Install Playwright
+        working-directory: Tests/e2e
+        run: |
+          npm ci || npm install
+          npx playwright install --with-deps chromium
+
+      - name: Run Playwright
+        working-directory: Tests/e2e
+        env:
+          CI: 'true'
+          IMAGIFY_API_KEY: ${{ secrets.IMAGIFY_API_KEY }}
+        run: npm test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: Tests/e2e/playwright-report
+          retention-days: 14
+
+      - name: Capture wp-env debug.log
+        if: failure()
+        run: |
+          npx --yes @wordpress/env run cli "cat wp-content/debug.log" > debug.log || true
+
+      - name: Upload debug.log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wp-debug-log
+          path: debug.log
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 bin/strauss.phar
 composer.lock
 
+# Local env overrides (API keys, secrets — never commit)
+/.env.local
+
 # E2E testing
 /Tests/e2e/node_modules
 /Tests/e2e/playwright-report

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,12 @@
 .phpunit.result.cache
 bin/strauss.phar
 composer.lock
+
+# E2E testing
+/Tests/e2e/node_modules
+/Tests/e2e/playwright-report
+/Tests/e2e/test-results
+/.e2e-screenshots
+
+# Local issue sync
+/.TemporaryItems

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,14 @@
+{
+	"core": null,
+	"phpVersion": "8.2",
+	"mappings": {
+		"wp-content/plugins/imagify": "./"
+	},
+	"config": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_LOG": true,
+		"WP_DEBUG_DISPLAY": false,
+		"SCRIPT_DEBUG": true,
+		"WP_ENVIRONMENT_TYPE": "local"
+	}
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Full E2E testing documentation: [`docs/E2E_TESTING.md`](docs/E2E_TESTING.md)
 
 The test directory is `Tests/e2e/` (capital T, consistent with the existing `Tests/` PHPUnit directory).
 
-The E2E suite runs in CI via `.github/workflows/e2e.yml`. The `IMAGIFY_API_KEY` GitHub secret must be configured for optimization tests to run.
+The E2E suite runs in CI via `.github/workflows/e2e.yml`. The `IMAGIFY_TESTS_API_KEY` GitHub secret must be configured for optimization tests to run.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,128 @@
+# Imagify — AI Agent Instructions
+
+This file is read by AI coding agents (Claude Code, GitHub Copilot, etc.) to understand the project structure, conventions, and available skills.
+
+---
+
+## §1 — Repository identity
+
+- **Repo:** `wp-media/imagify-plugin`
+- **Plugin slug:** `imagify`
+- **Single edition** (no FREE/PRO split)
+- **PHP namespace root:** `Imagify\`
+- **PSR-4 root:** `classes/`
+
+---
+
+## §2 — Technology stack
+
+- PHP 7.3+ (strict types, PSR-4 autoloading via Composer)
+- WordPress plugin APIs (hooks, options, WP-CLI, AJAX)
+- League Container (DI container + service providers + event subscribers)
+- ActionScheduler (async background jobs)
+- Strauss (Composer dependency namespace prefixing → `Imagify\Dependencies\`)
+- JavaScript / Grunt (_dev/ pipeline → assets/)
+- Playwright + TypeScript for E2E testing
+
+---
+
+## §3 — Code structure
+
+```
+classes/          New PHP code goes here (PSR-4, Imagify\ namespace)
+inc/              Legacy PHP includes (procedural, no namespace)
+inc/classes/      Legacy class files migrating toward classes/
+assets/           Compiled frontend assets (do not edit directly)
+_dev/             Frontend source (JS, SCSS, Grunt config)
+views/            PHP view templates
+Tests/            PHPUnit tests
+Tests/e2e/        Playwright E2E tests (TypeScript)
+bin/              CLI scripts (dev-up, dev-down, dev-seed, build-knowledge-graph)
+docs/             Documentation (E2E_TESTING.md, etc.)
+.aiassistant/     Skill files for AI assistants
+.claude/agents/   Claude Code sub-agents (qa-engineer, e2e-qa-tester)
+```
+
+---
+
+## §4 — Architecture rules
+
+1. **New features** go in `classes/` with `declare(strict_types=1)` and `Imagify\` namespace.
+2. **Do not** add new uses of `InstanceGetterTrait` — new singletons should be registered in the DI container.
+3. **New admin functionality** must be an `EventSubscriberInterface` registered via a service provider.
+4. **Legacy `inc/`** — minimize changes; only bug fixes and small adjustments.
+5. **Strauss vendor** — never edit files under `vendor/` directly; they are overwritten on `composer install`.
+
+---
+
+## §5 — Skills
+
+The `.aiassistant/skills/` directory contains skill files that configure AI assistant behavior for specific tasks:
+
+| Skill | Activates when |
+|-------|----------------|
+| `imagify-architecture` | Writing or reviewing PHP code in `classes/` or `inc/` |
+| `wordpress-compliance` | Reviewing any PHP for WP coding standards |
+| `knowledge-graph` | Exploring dependencies via `dependency-graph.json` |
+| `issue-workflow` | Triaging or implementing a GitHub issue |
+
+---
+
+## §6 — E2E testing agents
+
+Two Claude Code sub-agents in `.claude/agents/` support QA workflows:
+
+| Agent | Use when |
+|-------|----------|
+| `qa-engineer` | Validating a PR against its ticket spec (strategy selection, test report) |
+| `e2e-qa-tester` | Driving the browser via Playwright, converting flows to spec files |
+
+Full E2E testing documentation: [`docs/E2E_TESTING.md`](docs/E2E_TESTING.md)
+
+The test directory is `Tests/e2e/` (capital T, consistent with the existing `Tests/` PHPUnit directory).
+
+The E2E suite runs in CI via `.github/workflows/e2e.yml`. The `IMAGIFY_API_KEY` GitHub secret must be configured for optimization tests to run.
+
+---
+
+## §7 — Local development
+
+```bash
+# Start the local WordPress environment (Docker via wp-env)
+bash bin/dev-up.sh
+
+# Stop the environment (preserves data)
+bash bin/dev-down.sh
+
+# Full wipe
+bash bin/dev-down.sh --clean
+
+# Seed test data (idempotent)
+bash bin/dev-seed.sh
+
+# Run E2E tests
+cd Tests/e2e && npm test
+```
+
+- Site: `http://localhost:8888`
+- Admin: `http://localhost:8888/wp-admin` — `admin` / `password`
+
+---
+
+## §8 — GitHub issue workflow
+
+Use the `issue-workflow` skill to triage and implement issues:
+
+```
+/issue-workflow <issue-number>
+```
+
+Issues are fetched from `wp-media/imagify-plugin` and cached to `.TemporaryItems/Issues/imagify-plugin/`.
+
+---
+
+## §9 — Commit conventions
+
+- No `Co-Authored-By` lines in commits.
+- Follow the commit style in `git log --oneline`.
+- No WIP commits on PRs targeting `develop`.

--- a/Tests/e2e/fixtures/auth.ts
+++ b/Tests/e2e/fixtures/auth.ts
@@ -1,0 +1,28 @@
+import { Page } from '@playwright/test';
+
+/**
+ * Default wp-env admin credentials. Override via env vars when running
+ * against a different environment.
+ */
+export const ADMIN_USER = process.env.IMAGIFY_ADMIN_USER ?? 'admin';
+export const ADMIN_PASS = process.env.IMAGIFY_ADMIN_PASS ?? 'password';
+
+/**
+ * Log in as the WordPress administrator. Idempotent: if a session cookie is
+ * already set, navigation hits /wp-admin/ directly and skips the form.
+ */
+export async function loginAsAdmin( page: Page ): Promise<void> {
+	await page.goto( '/wp-login.php', { waitUntil: 'networkidle' } );
+
+	// Already logged in? Cookie redirects to wp-admin.
+	if ( page.url().includes( '/wp-admin/' ) ) {
+		return;
+	}
+
+	await page.getByLabel( 'Username or Email Address' ).waitFor( { timeout: 5000 } );
+	await page.getByLabel( 'Username or Email Address' ).fill( ADMIN_USER );
+	await page.getByLabel( 'Password', { exact: true } ).fill( ADMIN_PASS );
+
+	await page.getByRole( 'button', { name: 'Log In' } ).click();
+	await page.waitForURL( /\/wp-admin\/?/, { timeout: 20000 } );
+}

--- a/Tests/e2e/fixtures/wp-cli.ts
+++ b/Tests/e2e/fixtures/wp-cli.ts
@@ -1,0 +1,29 @@
+import { execSync } from 'node:child_process';
+
+/**
+ * Run a WP-CLI command inside the wp-env `cli` container. Throws on non-zero
+ * exit. Used by tests for deterministic state setup (setting options, running
+ * crons, querying database state).
+ */
+export function wpCli( command: string ): string {
+	const root = `${ __dirname }/../../..`;
+	const cmd = `npx --yes @wordpress/env run cli wp ${ command }`;
+	return execSync( cmd, { cwd: root, encoding: 'utf-8', stdio: [ 'ignore', 'pipe', 'pipe' ] } );
+}
+
+/**
+ * Run an arbitrary shell command from the repo root. Intended for seed scripts
+ * and other repo-level tooling.
+ */
+export function runFromRepoRoot( command: string ): string {
+	const root = `${ __dirname }/../../..`;
+	return execSync( command, { cwd: root, encoding: 'utf-8', stdio: [ 'ignore', 'pipe', 'pipe' ] } );
+}
+
+/**
+ * Returns true if the IMAGIFY_API_KEY env var is set to a non-empty string.
+ * Use to skip tests that require a live API key.
+ */
+export function hasApiKey(): boolean {
+	return !! process.env.IMAGIFY_API_KEY;
+}

--- a/Tests/e2e/fixtures/wp-cli.ts
+++ b/Tests/e2e/fixtures/wp-cli.ts
@@ -21,9 +21,9 @@ export function runFromRepoRoot( command: string ): string {
 }
 
 /**
- * Returns true if the IMAGIFY_API_KEY env var is set to a non-empty string.
+ * Returns true if the IMAGIFY_TESTS_API_KEY env var is set to a non-empty string.
  * Use to skip tests that require a live API key.
  */
 export function hasApiKey(): boolean {
-	return !! process.env.IMAGIFY_API_KEY;
+	return !! process.env.IMAGIFY_TESTS_API_KEY;
 }

--- a/Tests/e2e/package.json
+++ b/Tests/e2e/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "imagify-e2e",
+	"private": true,
+	"version": "0.0.0",
+	"description": "End-to-end tests for the Imagify WordPress plugin, run against the wp-env stack booted via bin/dev-up.sh.",
+	"scripts": {
+		"test": "playwright test",
+		"test:headed": "playwright test --headed",
+		"test:ui": "playwright test --ui",
+		"report": "playwright show-report"
+	},
+	"devDependencies": {
+		"@playwright/test": "^1.49.0",
+		"@types/node": "^22.0.0",
+		"typescript": "^5.4.0"
+	}
+}

--- a/Tests/e2e/pages/bulk-optimization.ts
+++ b/Tests/e2e/pages/bulk-optimization.ts
@@ -1,0 +1,39 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the Imagify Bulk Optimization page.
+ * URL: /wp-admin/upload.php?page=imagify-bulk-optimization
+ */
+export class BulkOptimizationPage {
+	readonly page: Page;
+	readonly optimizeButton: Locator;
+	readonly progressBar: Locator;
+	readonly statsTable: Locator;
+
+	constructor( page: Page ) {
+		this.page = page;
+		this.optimizeButton = page.getByRole( 'button', { name: /optimize/i } ).first();
+		this.progressBar    = page.locator( '.imagify-bulk-optimization-progress, .imagify-progress' ).first();
+		this.statsTable     = page.locator( '.imagify-bulk-table, .imagify-stats-table' ).first();
+	}
+
+	async goto(): Promise<void> {
+		await this.page.goto( '/wp-admin/upload.php?page=imagify-bulk-optimization' );
+		await this.page.waitForLoadState( 'networkidle' );
+	}
+
+	async isLoaded(): Promise<boolean> {
+		const heading = this.page.locator( 'h1, h2' ).filter( { hasText: /bulk/i } );
+		return await heading.count() > 0;
+	}
+
+	async expectNoFatalError(): Promise<void> {
+		await expect( this.page.locator( '.wp-die-message, #error-page' ) ).toHaveCount( 0 );
+	}
+
+	async getOptimizedCount(): Promise<number> {
+		const text = await this.statsTable.textContent();
+		const match = text?.match( /(\d+)\s*(image|file)/i );
+		return match ? parseInt( match[ 1 ], 10 ) : 0;
+	}
+}

--- a/Tests/e2e/pages/bulk-optimization.ts
+++ b/Tests/e2e/pages/bulk-optimization.ts
@@ -18,6 +18,19 @@ export class BulkOptimizationPage {
 		this.statsTable     = page.locator( '.imagify-bulk-table' ).first();
 	}
 
+	async startOptimization(): Promise<void> {
+		await this.optimizeButton.click();
+		// On first run, Imagify shows a SweetAlert2 info modal before starting.
+		// Dismiss it so launchAllProcesses() is called.
+		const modal = this.page.locator( '.swal2-popup.imagify-before-bulk-infos' );
+		try {
+			await modal.waitFor( { state: 'visible', timeout: 3_000 } );
+			await modal.locator( '.swal2-confirm' ).click();
+		} catch {
+			// No modal — optimization started directly.
+		}
+	}
+
 	async goto(): Promise<void> {
 		await this.page.goto( '/wp-admin/upload.php?page=imagify-bulk-optimization' );
 		await this.page.waitForLoadState( 'networkidle' );

--- a/Tests/e2e/pages/bulk-optimization.ts
+++ b/Tests/e2e/pages/bulk-optimization.ts
@@ -20,12 +20,13 @@ export class BulkOptimizationPage {
 
 	async startOptimization(): Promise<void> {
 		await this.optimizeButton.click();
-		// On first run, Imagify shows a SweetAlert2 info modal before starting.
-		// Dismiss it so launchAllProcesses() is called.
-		const modal = this.page.locator( '.swal2-popup.imagify-before-bulk-infos' );
+		// On first run, Imagify shows a "before bulk" info modal. Dismiss it by
+		// clicking the confirm button. Use text matching so we're not tied to
+		// SweetAlert2's internal class names (they changed between v6 and v7).
+		const confirmButton = this.page.getByRole( 'button', { name: /start the optimization/i } );
 		try {
-			await modal.waitFor( { state: 'visible', timeout: 3_000 } );
-			await modal.locator( '.swal2-confirm' ).click();
+			await confirmButton.waitFor( { state: 'visible', timeout: 3_000 } );
+			await confirmButton.click();
 		} catch {
 			// No modal — optimization started directly.
 		}

--- a/Tests/e2e/pages/bulk-optimization.ts
+++ b/Tests/e2e/pages/bulk-optimization.ts
@@ -12,9 +12,10 @@ export class BulkOptimizationPage {
 
 	constructor( page: Page ) {
 		this.page = page;
-		this.optimizeButton = page.getByRole( 'button', { name: /optimize/i } ).first();
-		this.progressBar    = page.locator( '.imagify-bulk-optimization-progress, .imagify-progress' ).first();
-		this.statsTable     = page.locator( '.imagify-bulk-table, .imagify-stats-table' ).first();
+		// The main "Imagif'em all" button.
+		this.optimizeButton = page.locator( '#imagify-bulk-action' );
+		this.progressBar    = page.locator( '.imagify-row-progress' ).first();
+		this.statsTable     = page.locator( '.imagify-bulk-table' ).first();
 	}
 
 	async goto(): Promise<void> {

--- a/Tests/e2e/pages/media-library.ts
+++ b/Tests/e2e/pages/media-library.ts
@@ -12,8 +12,8 @@ export class MediaLibraryPage {
 
 	constructor( page: Page ) {
 		this.page = page;
-		// The column header injected by Imagify.
-		this.imagifyColumn = page.locator( 'th.column-imagify_status, th#imagify_status' ).first();
+		// The column header injected by Imagify. Key registered as 'imagify_optimized_file'.
+		this.imagifyColumn = page.locator( 'th#imagify_optimized_file, th.column-imagify_optimized_file' ).first();
 	}
 
 	async goto(): Promise<void> {
@@ -32,7 +32,7 @@ export class MediaLibraryPage {
 	}
 
 	async getFirstAttachmentStatus(): Promise<string> {
-		const status = this.page.locator( 'td.column-imagify_status' ).first();
+		const status = this.page.locator( 'td.column-imagify_optimized_file' ).first();
 		return ( await status.textContent() ) ?? '';
 	}
 

--- a/Tests/e2e/pages/media-library.ts
+++ b/Tests/e2e/pages/media-library.ts
@@ -1,0 +1,42 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the WordPress Media Library page (list view).
+ * URL: /wp-admin/upload.php?mode=list
+ *
+ * Imagify injects an "Optimization" column into the media library table.
+ */
+export class MediaLibraryPage {
+	readonly page: Page;
+	readonly imagifyColumn: Locator;
+
+	constructor( page: Page ) {
+		this.page = page;
+		// The column header injected by Imagify.
+		this.imagifyColumn = page.locator( 'th.column-imagify_status, th#imagify_status' ).first();
+	}
+
+	async goto(): Promise<void> {
+		// Force list mode so the table is rendered (grid mode has no column headers).
+		await this.page.goto( '/wp-admin/upload.php?mode=list' );
+		await this.page.waitForLoadState( 'networkidle' );
+	}
+
+	async isLoaded(): Promise<boolean> {
+		const table = this.page.locator( '#the-list, .media-list' );
+		return await table.count() > 0;
+	}
+
+	async hasImagifyColumn(): Promise<boolean> {
+		return await this.imagifyColumn.count() > 0;
+	}
+
+	async getFirstAttachmentStatus(): Promise<string> {
+		const status = this.page.locator( 'td.column-imagify_status' ).first();
+		return ( await status.textContent() ) ?? '';
+	}
+
+	async expectNoFatalError(): Promise<void> {
+		await expect( this.page.locator( '.wp-die-message, #error-page' ) ).toHaveCount( 0 );
+	}
+}

--- a/Tests/e2e/pages/settings.ts
+++ b/Tests/e2e/pages/settings.ts
@@ -13,7 +13,7 @@ export class SettingsPage {
 	constructor( page: Page ) {
 		this.page = page;
 		this.apiKeyInput  = page.locator( '#imagify-api-key, [name="imagify_settings[api_key]"]' ).first();
-		this.saveButton   = page.getByRole( 'button', { name: /save/i } );
+		this.saveButton   = page.locator( '#submit' );
 		this.successNotice = page.locator( '.notice-success, .updated' ).first();
 	}
 

--- a/Tests/e2e/pages/settings.ts
+++ b/Tests/e2e/pages/settings.ts
@@ -1,0 +1,43 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the Imagify Settings page.
+ * URL: /wp-admin/options-general.php?page=imagify
+ */
+export class SettingsPage {
+	readonly page: Page;
+	readonly apiKeyInput: Locator;
+	readonly saveButton: Locator;
+	readonly successNotice: Locator;
+
+	constructor( page: Page ) {
+		this.page = page;
+		this.apiKeyInput  = page.locator( '#imagify-api-key, [name="imagify_settings[api_key]"]' ).first();
+		this.saveButton   = page.getByRole( 'button', { name: /save/i } );
+		this.successNotice = page.locator( '.notice-success, .updated' ).first();
+	}
+
+	async goto(): Promise<void> {
+		await this.page.goto( '/wp-admin/options-general.php?page=imagify' );
+		await this.page.waitForLoadState( 'networkidle' );
+	}
+
+	async isLoaded(): Promise<boolean> {
+		const title = this.page.locator( 'h1, h2' ).filter( { hasText: /imagify/i } );
+		return await title.count() > 0;
+	}
+
+	async setApiKey( key: string ): Promise<void> {
+		await this.apiKeyInput.fill( key );
+		await this.saveButton.click();
+		await this.successNotice.waitFor( { timeout: 10_000 } );
+	}
+
+	async getApiKey(): Promise<string> {
+		return ( await this.apiKeyInput.inputValue() ) ?? '';
+	}
+
+	async expectNoFatalError(): Promise<void> {
+		await expect( this.page.locator( '.wp-die-message, #error-page' ) ).toHaveCount( 0 );
+	}
+}

--- a/Tests/e2e/playwright.config.ts
+++ b/Tests/e2e/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Imagify end-to-end test config.
+ *
+ * The suite runs against the wp-env stack booted via `bin/dev-up.sh` at the
+ * repository root. CI bootstraps the same stack before invoking
+ * `npx playwright test` in this directory.
+ */
+export default defineConfig( {
+	testDir: './specs',
+	fullyParallel: false, // Tests share a single WP install; isolate via reseed.
+	forbidOnly: !! process.env.CI,
+	retries: process.env.CI ? 1 : 0,
+	workers: 1, // Single-worker keeps the wp-env DB state predictable.
+	reporter: process.env.CI ? [ [ 'github' ], [ 'html', { open: 'never' } ] ] : 'list',
+
+	use: {
+		baseURL: process.env.IMAGIFY_BASE_URL ?? 'http://localhost:8888',
+		trace: 'retain-on-failure',
+		screenshot: 'only-on-failure',
+		video: 'retain-on-failure',
+		viewport: { width: 1440, height: 900 },
+	},
+
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices[ 'Desktop Chrome' ] },
+		},
+	],
+
+	expect: {
+		timeout: 10_000,
+	},
+	timeout: 60_000,
+} );

--- a/Tests/e2e/specs/account-connection.spec.ts
+++ b/Tests/e2e/specs/account-connection.spec.ts
@@ -20,17 +20,21 @@ test.describe( 'Imagify account connection', () => {
 	} );
 
 	test( 'Entering an invalid API key shows an error', async ( { page } ) => {
-		test.skip( !! process.env.CI && ! process.env.IMAGIFY_TESTS_API_KEY, 'Requires API key to validate response' );
+		// Imagify validates the key by calling its API, so an actual network call is
+		// required for the error notice to appear. Skip if no key is configured — we
+		// cannot reliably produce a "bad key" response without a real account.
+		test.skip( ! process.env.IMAGIFY_TESTS_API_KEY, 'IMAGIFY_TESTS_API_KEY not set — cannot produce a bad-key API response' );
 
 		const settings = new SettingsPage( page );
 		await settings.goto();
 
-		await settings.apiKeyInput.fill( 'invalid-key-000' );
+		// Submit a deliberately wrong key so the API rejects it.
+		await settings.apiKeyInput.fill( 'invalid-key-000000000000000000000000000000' );
 		await settings.saveButton.click();
 		await page.waitForLoadState( 'networkidle' );
 
-		// Imagify should render an error notice or inline validation message.
-		const error = page.locator( '.notice-error, .imagify-notice-error, .imagify-error' ).first();
+		// Imagify renders the "wrong API key" notice with a standard WP .notice.error class.
+		const error = page.locator( '.notice.error, .notice-error' ).first();
 		await expect( error ).toBeVisible( { timeout: 10_000 } );
 	} );
 

--- a/Tests/e2e/specs/account-connection.spec.ts
+++ b/Tests/e2e/specs/account-connection.spec.ts
@@ -33,8 +33,9 @@ test.describe( 'Imagify account connection', () => {
 		await settings.saveButton.click();
 		await page.waitForLoadState( 'networkidle' );
 
-		// Imagify renders the "wrong API key" notice with a standard WP .notice.error class.
-		const error = page.locator( '.notice.error, .notice-error' ).first();
+		// Imagify renders the invalid-key indicator as #imagify-check-api-container
+		// without the imagify-valid class (not a standard WP .notice-error).
+		const error = page.locator( '#imagify-check-api-container:not(.imagify-valid)' );
 		await expect( error ).toBeVisible( { timeout: 10_000 } );
 	} );
 

--- a/Tests/e2e/specs/account-connection.spec.ts
+++ b/Tests/e2e/specs/account-connection.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from '../fixtures/auth';
+import { SettingsPage } from '../pages/settings';
+
+/**
+ * Account connection tests.
+ *
+ * Tests that require a real API key are skipped when IMAGIFY_API_KEY is unset.
+ */
+test.describe( 'Imagify account connection', () => {
+	test.beforeEach( async ( { page } ) => {
+		await loginAsAdmin( page );
+	} );
+
+	test( 'Settings page contains the API key field', async ( { page } ) => {
+		const settings = new SettingsPage( page );
+		await settings.goto();
+
+		await expect( settings.apiKeyInput ).toBeVisible();
+	} );
+
+	test( 'Entering an invalid API key shows an error', async ( { page } ) => {
+		test.skip( !! process.env.CI && ! process.env.IMAGIFY_API_KEY, 'Requires API key to validate response' );
+
+		const settings = new SettingsPage( page );
+		await settings.goto();
+
+		await settings.apiKeyInput.fill( 'invalid-key-000' );
+		await settings.saveButton.click();
+		await page.waitForLoadState( 'networkidle' );
+
+		// Imagify should render an error notice or inline validation message.
+		const error = page.locator( '.notice-error, .imagify-notice-error, .imagify-error' ).first();
+		await expect( error ).toBeVisible( { timeout: 10_000 } );
+	} );
+
+	test( 'Valid API key connects the account', async ( { page } ) => {
+		test.skip( ! process.env.IMAGIFY_API_KEY, 'IMAGIFY_API_KEY not set — skipping live connection test' );
+
+		const settings = new SettingsPage( page );
+		await settings.goto();
+
+		await settings.apiKeyInput.fill( process.env.IMAGIFY_API_KEY! );
+		await settings.saveButton.click();
+		await page.waitForLoadState( 'networkidle' );
+
+		// After saving a valid key, Imagify shows account info or a success notice.
+		const success = page.locator( '.notice-success, .updated, .imagify-connected' ).first();
+		await expect( success ).toBeVisible( { timeout: 15_000 } );
+	} );
+} );

--- a/Tests/e2e/specs/account-connection.spec.ts
+++ b/Tests/e2e/specs/account-connection.spec.ts
@@ -5,7 +5,7 @@ import { SettingsPage } from '../pages/settings';
 /**
  * Account connection tests.
  *
- * Tests that require a real API key are skipped when IMAGIFY_API_KEY is unset.
+ * Tests that require a real API key are skipped when IMAGIFY_TESTS_API_KEY is unset.
  */
 test.describe( 'Imagify account connection', () => {
 	test.beforeEach( async ( { page } ) => {
@@ -20,7 +20,7 @@ test.describe( 'Imagify account connection', () => {
 	} );
 
 	test( 'Entering an invalid API key shows an error', async ( { page } ) => {
-		test.skip( !! process.env.CI && ! process.env.IMAGIFY_API_KEY, 'Requires API key to validate response' );
+		test.skip( !! process.env.CI && ! process.env.IMAGIFY_TESTS_API_KEY, 'Requires API key to validate response' );
 
 		const settings = new SettingsPage( page );
 		await settings.goto();
@@ -35,12 +35,12 @@ test.describe( 'Imagify account connection', () => {
 	} );
 
 	test( 'Valid API key connects the account', async ( { page } ) => {
-		test.skip( ! process.env.IMAGIFY_API_KEY, 'IMAGIFY_API_KEY not set — skipping live connection test' );
+		test.skip( ! process.env.IMAGIFY_TESTS_API_KEY, 'IMAGIFY_TESTS_API_KEY not set — skipping live connection test' );
 
 		const settings = new SettingsPage( page );
 		await settings.goto();
 
-		await settings.apiKeyInput.fill( process.env.IMAGIFY_API_KEY! );
+		await settings.apiKeyInput.fill( process.env.IMAGIFY_TESTS_API_KEY! );
 		await settings.saveButton.click();
 		await page.waitForLoadState( 'networkidle' );
 

--- a/Tests/e2e/specs/bulk-optimization.spec.ts
+++ b/Tests/e2e/specs/bulk-optimization.spec.ts
@@ -6,7 +6,7 @@ import { BulkOptimizationPage } from '../pages/bulk-optimization';
  * Bulk optimization page tests.
  *
  * The actual optimization trigger requires a valid API key. Tests that call
- * the Imagify API are skipped when IMAGIFY_API_KEY is unset.
+ * the Imagify API are skipped when IMAGIFY_TESTS_API_KEY is unset.
  */
 test.describe( 'Bulk optimization', () => {
 	test.beforeEach( async ( { page } ) => {
@@ -38,7 +38,7 @@ test.describe( 'Bulk optimization', () => {
 	} );
 
 	test( 'Starting bulk optimization triggers progress UI', async ( { page } ) => {
-		test.skip( ! process.env.IMAGIFY_API_KEY, 'IMAGIFY_API_KEY not set — skipping live optimization test' );
+		test.skip( ! process.env.IMAGIFY_TESTS_API_KEY, 'IMAGIFY_TESTS_API_KEY not set — skipping live optimization test' );
 
 		const bulk = new BulkOptimizationPage( page );
 		await bulk.goto();

--- a/Tests/e2e/specs/bulk-optimization.spec.ts
+++ b/Tests/e2e/specs/bulk-optimization.spec.ts
@@ -41,7 +41,7 @@ test.describe( 'Bulk optimization', () => {
 		const bulk = new BulkOptimizationPage( page );
 		await bulk.goto();
 
-		await bulk.optimizeButton.click();
+		await bulk.startOptimization();
 
 		// After starting, Imagify should show a progress indicator.
 		await expect( bulk.progressBar ).toBeVisible( { timeout: 15_000 } );

--- a/Tests/e2e/specs/bulk-optimization.spec.ts
+++ b/Tests/e2e/specs/bulk-optimization.spec.ts
@@ -32,9 +32,7 @@ test.describe( 'Bulk optimization', () => {
 		const bulk = new BulkOptimizationPage( page );
 		await bulk.goto();
 
-		// The stats table or summary block is always rendered (even with 0 optimized).
-		const statsArea = page.locator( '.imagify-bulk-stats, .imagify-stats, .imagify-data' ).first();
-		await expect( statsArea ).toBeVisible();
+		await expect( bulk.statsTable ).toBeVisible();
 	} );
 
 	test( 'Starting bulk optimization triggers progress UI', async ( { page } ) => {

--- a/Tests/e2e/specs/bulk-optimization.spec.ts
+++ b/Tests/e2e/specs/bulk-optimization.spec.ts
@@ -45,6 +45,10 @@ test.describe( 'Bulk optimization', () => {
 		);
 		test.skip( attachmentCount === 0, 'No media attachments in library — seed image did not upload' );
 
+		// Reset optimization state so there is always something to optimize,
+		// even if a previous run already processed all images.
+		wpCli( 'eval \'delete_post_meta_by_key("_imagify_data"); delete_post_meta_by_key("_imagify_status"); delete_post_meta_by_key("_imagify_optimization_level");\'' );
+
 		const bulk = new BulkOptimizationPage( page );
 		await bulk.goto();
 

--- a/Tests/e2e/specs/bulk-optimization.spec.ts
+++ b/Tests/e2e/specs/bulk-optimization.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from '../fixtures/auth';
+import { BulkOptimizationPage } from '../pages/bulk-optimization';
+
+/**
+ * Bulk optimization page tests.
+ *
+ * The actual optimization trigger requires a valid API key. Tests that call
+ * the Imagify API are skipped when IMAGIFY_API_KEY is unset.
+ */
+test.describe( 'Bulk optimization', () => {
+	test.beforeEach( async ( { page } ) => {
+		await loginAsAdmin( page );
+	} );
+
+	test( 'Bulk optimization page loads without errors', async ( { page } ) => {
+		const bulk = new BulkOptimizationPage( page );
+		await bulk.goto();
+
+		await bulk.expectNoFatalError();
+		await expect( page ).toHaveURL( /page=imagify-bulk-optimization/ );
+	} );
+
+	test( 'Bulk optimization page has an optimize button', async ( { page } ) => {
+		const bulk = new BulkOptimizationPage( page );
+		await bulk.goto();
+
+		await expect( bulk.optimizeButton ).toBeVisible();
+	} );
+
+	test( 'Bulk optimization page shows stats section', async ( { page } ) => {
+		const bulk = new BulkOptimizationPage( page );
+		await bulk.goto();
+
+		// The stats table or summary block is always rendered (even with 0 optimized).
+		const statsArea = page.locator( '.imagify-bulk-stats, .imagify-stats, .imagify-data' ).first();
+		await expect( statsArea ).toBeVisible();
+	} );
+
+	test( 'Starting bulk optimization triggers progress UI', async ( { page } ) => {
+		test.skip( ! process.env.IMAGIFY_API_KEY, 'IMAGIFY_API_KEY not set — skipping live optimization test' );
+
+		const bulk = new BulkOptimizationPage( page );
+		await bulk.goto();
+
+		await bulk.optimizeButton.click();
+
+		// After starting, Imagify should show a progress indicator.
+		await expect( bulk.progressBar ).toBeVisible( { timeout: 15_000 } );
+	} );
+} );

--- a/Tests/e2e/specs/bulk-optimization.spec.ts
+++ b/Tests/e2e/specs/bulk-optimization.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { loginAsAdmin } from '../fixtures/auth';
+import { wpCli } from '../fixtures/wp-cli';
 import { BulkOptimizationPage } from '../pages/bulk-optimization';
 
 /**
@@ -37,6 +38,12 @@ test.describe( 'Bulk optimization', () => {
 
 	test( 'Starting bulk optimization triggers progress UI', async ( { page } ) => {
 		test.skip( ! process.env.IMAGIFY_TESTS_API_KEY, 'IMAGIFY_TESTS_API_KEY not set — skipping live optimization test' );
+
+		const attachmentCount = parseInt(
+			wpCli( 'post list --post_type=attachment --post_status=inherit --format=count' ).trim(),
+			10
+		);
+		test.skip( attachmentCount === 0, 'No media attachments in library — seed image did not upload' );
 
 		const bulk = new BulkOptimizationPage( page );
 		await bulk.goto();

--- a/Tests/e2e/specs/media-library.spec.ts
+++ b/Tests/e2e/specs/media-library.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from '../fixtures/auth';
+import { MediaLibraryPage } from '../pages/media-library';
+
+/**
+ * Media library integration tests.
+ *
+ * Verifies that Imagify injects its optimization column and that the
+ * per-image optimization UI renders correctly.
+ *
+ * Optimization tests that call the API are skipped when IMAGIFY_API_KEY is unset.
+ */
+test.describe( 'Media library — Imagify column', () => {
+	test.beforeEach( async ( { page } ) => {
+		await loginAsAdmin( page );
+	} );
+
+	test( 'Media library (list mode) loads without errors', async ( { page } ) => {
+		const library = new MediaLibraryPage( page );
+		await library.goto();
+
+		await library.expectNoFatalError();
+	} );
+
+	test( 'Imagify column is present in media library table', async ( { page } ) => {
+		const library = new MediaLibraryPage( page );
+		await library.goto();
+
+		await expect( library.imagifyColumn ).toBeVisible();
+	} );
+
+	test( 'Media attachment detail page loads without errors', async ( { page } ) => {
+		// Navigate to media library and open the first attachment.
+		await page.goto( '/wp-admin/upload.php?mode=list' );
+		await page.waitForLoadState( 'networkidle' );
+
+		const firstLink = page.locator( 'td.title a.row-title' ).first();
+		const count = await firstLink.count();
+		if ( count === 0 ) {
+			test.skip( true, 'No media attachments in library — run bin/dev-seed.sh first' );
+			return;
+		}
+
+		await firstLink.click();
+		await page.waitForLoadState( 'networkidle' );
+
+		await expect( page.locator( '.wp-die-message, #error-page' ) ).toHaveCount( 0 );
+	} );
+} );

--- a/Tests/e2e/specs/media-library.spec.ts
+++ b/Tests/e2e/specs/media-library.spec.ts
@@ -8,7 +8,7 @@ import { MediaLibraryPage } from '../pages/media-library';
  * Verifies that Imagify injects its optimization column and that the
  * per-image optimization UI renders correctly.
  *
- * Optimization tests that call the API are skipped when IMAGIFY_API_KEY is unset.
+ * Optimization tests that call the API are skipped when IMAGIFY_TESTS_API_KEY is unset.
  */
 test.describe( 'Media library — Imagify column', () => {
 	test.beforeEach( async ( { page } ) => {

--- a/Tests/e2e/specs/settings.spec.ts
+++ b/Tests/e2e/specs/settings.spec.ts
@@ -5,8 +5,9 @@ import { SettingsPage } from '../pages/settings';
 /**
  * Imagify Settings page tests.
  *
- * Focuses on the settings UI rendering and saving behavior.
- * Does not depend on a live API key.
+ * Without a valid API key only the account section (API key input + save
+ * button) is visible. The Lossless, WebP/AVIF, and Library sections are
+ * hidden and require IMAGIFY_TESTS_API_KEY to be tested.
  */
 test.describe( 'Imagify settings', () => {
 	test.beforeEach( async ( { page } ) => {
@@ -28,21 +29,26 @@ test.describe( 'Imagify settings', () => {
 		await expect( settings.saveButton ).toBeVisible();
 	} );
 
-	test( 'Optimization level options are present', async ( { page } ) => {
+	test( 'Lossless compression option is present (requires API key)', async ( { page } ) => {
+		test.skip( ! process.env.IMAGIFY_TESTS_API_KEY, 'IMAGIFY_TESTS_API_KEY not set — settings sections hidden without valid key' );
+
 		const settings = new SettingsPage( page );
 		await settings.goto();
 
-		// Imagify exposes Normal, Aggressive, and Ultra levels.
-		const optionLabels = page.locator( 'label' ).filter( { hasText: /normal|aggressive|ultra/i } );
-		await expect( optionLabels ).not.toHaveCount( 0 );
+		// Imagify uses a "Lossless compression" checkbox, not Normal/Aggressive/Ultra labels.
+		const losslessLabel = page.locator( 'label' ).filter( { hasText: /lossless/i } );
+		await expect( losslessLabel ).toBeVisible();
 	} );
 
-	test( 'WebP/AVIF next-gen format toggles are present', async ( { page } ) => {
+	test( 'WebP/AVIF next-gen format toggles are present (requires API key)', async ( { page } ) => {
+		test.skip( ! process.env.IMAGIFY_TESTS_API_KEY, 'IMAGIFY_TESTS_API_KEY not set — settings sections hidden without valid key' );
+
 		const settings = new SettingsPage( page );
 		await settings.goto();
 
-		const webpOption = page.locator( 'input[name*="webp"], label' ).filter( { hasText: /webp/i } ).first();
-		await expect( webpOption ).toBeVisible();
+		// The format radio buttons use label[for="imagify_optimization_format_webp"] etc.
+		const webpLabel = page.locator( 'label[for="imagify_optimization_format_webp"]' );
+		await expect( webpLabel ).toBeVisible();
 	} );
 
 	test( 'Saving settings without changing values succeeds', async ( { page } ) => {

--- a/Tests/e2e/specs/settings.spec.ts
+++ b/Tests/e2e/specs/settings.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from '../fixtures/auth';
+import { SettingsPage } from '../pages/settings';
+
+/**
+ * Imagify Settings page tests.
+ *
+ * Focuses on the settings UI rendering and saving behavior.
+ * Does not depend on a live API key.
+ */
+test.describe( 'Imagify settings', () => {
+	test.beforeEach( async ( { page } ) => {
+		await loginAsAdmin( page );
+	} );
+
+	test( 'Settings page renders without fatal errors', async ( { page } ) => {
+		const settings = new SettingsPage( page );
+		await settings.goto();
+
+		await settings.expectNoFatalError();
+		await expect( page ).toHaveURL( /page=imagify/ );
+	} );
+
+	test( 'Settings page has a save button', async ( { page } ) => {
+		const settings = new SettingsPage( page );
+		await settings.goto();
+
+		await expect( settings.saveButton ).toBeVisible();
+	} );
+
+	test( 'Optimization level options are present', async ( { page } ) => {
+		const settings = new SettingsPage( page );
+		await settings.goto();
+
+		// Imagify exposes Normal, Aggressive, and Ultra levels.
+		const optionLabels = page.locator( 'label' ).filter( { hasText: /normal|aggressive|ultra/i } );
+		await expect( optionLabels ).not.toHaveCount( 0 );
+	} );
+
+	test( 'WebP/AVIF next-gen format toggles are present', async ( { page } ) => {
+		const settings = new SettingsPage( page );
+		await settings.goto();
+
+		const webpOption = page.locator( 'input[name*="webp"], label' ).filter( { hasText: /webp/i } ).first();
+		await expect( webpOption ).toBeVisible();
+	} );
+
+	test( 'Saving settings without changing values succeeds', async ( { page } ) => {
+		const settings = new SettingsPage( page );
+		await settings.goto();
+
+		await settings.saveButton.click();
+		await page.waitForLoadState( 'networkidle' );
+
+		await settings.expectNoFatalError();
+		// After save the page should redirect back to the settings page.
+		await expect( page ).toHaveURL( /page=imagify/ );
+	} );
+} );

--- a/Tests/e2e/specs/smoke.spec.ts
+++ b/Tests/e2e/specs/smoke.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from '../fixtures/auth';
+
+/**
+ * Smoke tests — verify core Imagify admin surfaces load without fatal errors.
+ * These tests do NOT require an API key and run in all environments.
+ */
+test.describe( 'Imagify smoke', () => {
+	test.beforeEach( async ( { page } ) => {
+		await loginAsAdmin( page );
+	} );
+
+	test( 'Settings page loads', async ( { page } ) => {
+		await page.goto( '/wp-admin/options-general.php?page=imagify' );
+		await page.waitForLoadState( 'networkidle' );
+
+		await expect( page.locator( '.wp-die-message, #error-page' ) ).toHaveCount( 0 );
+		await expect( page ).toHaveURL( /page=imagify/ );
+	} );
+
+	test( 'Bulk optimization page loads', async ( { page } ) => {
+		await page.goto( '/wp-admin/upload.php?page=imagify-bulk-optimization' );
+		await page.waitForLoadState( 'networkidle' );
+
+		await expect( page.locator( '.wp-die-message, #error-page' ) ).toHaveCount( 0 );
+		await expect( page ).toHaveURL( /page=imagify-bulk-optimization/ );
+	} );
+
+	test( 'Media library loads with Imagify column', async ( { page } ) => {
+		await page.goto( '/wp-admin/upload.php?mode=list' );
+		await page.waitForLoadState( 'networkidle' );
+
+		await expect( page.locator( '.wp-die-message, #error-page' ) ).toHaveCount( 0 );
+		// Imagify injects its optimization column into the media list table.
+		const imagifyCol = page.locator( 'th[id*="imagify"], th.column-imagify' ).first();
+		await expect( imagifyCol ).toBeVisible();
+	} );
+
+	test( 'Plugin can be deactivated and reactivated without errors', async ( { page } ) => {
+		// Deactivate.
+		await page.goto( '/wp-admin/plugins.php' );
+		const deactivateLink = page.locator( 'tr[data-slug="imagify"] a[href*="action=deactivate"]' );
+		await expect( deactivateLink ).toBeVisible();
+		await deactivateLink.click();
+		await page.waitForLoadState( 'networkidle' );
+		await expect( page.locator( '.wp-die-message, #error-page' ) ).toHaveCount( 0 );
+
+		// Reactivate.
+		const activateLink = page.locator( 'tr[data-slug="imagify"] a[href*="action=activate"]' );
+		await expect( activateLink ).toBeVisible();
+		await activateLink.click();
+		await page.waitForLoadState( 'networkidle' );
+		await expect( page.locator( '.wp-die-message, #error-page' ) ).toHaveCount( 0 );
+	} );
+} );

--- a/Tests/e2e/tsconfig.json
+++ b/Tests/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ES2022",
+		"moduleResolution": "Bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"types": [ "node" ]
+	},
+	"include": [ "**/*.ts" ]
+}

--- a/bin/dev-down.sh
+++ b/bin/dev-down.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Stop the local WordPress dev environment for Imagify.
+#
+# Usage:
+#   bin/dev-down.sh          # stop containers (preserves data)
+#   bin/dev-down.sh --clean  # destroy containers and volumes (full wipe)
+
+set -euo pipefail
+
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+cd "$ROOT_DIR"
+
+CLEAN=0
+for arg in "$@"; do
+	case "$arg" in
+		--clean) CLEAN=1 ;;
+		-h|--help)
+			sed -n '2,8p' "$0"
+			exit 0
+			;;
+		*) echo "Unknown arg: $arg" >&2; exit 1 ;;
+	esac
+done
+
+if [[ "$CLEAN" == "1" ]]; then
+	echo "▶ Destroying wp-env (volumes and containers)..."
+	npx --yes @wordpress/env destroy
+	echo "✅ Environment destroyed."
+else
+	echo "▶ Stopping wp-env..."
+	npx --yes @wordpress/env stop
+	echo "✅ Environment stopped. Data preserved. Run bin/dev-up.sh to restart."
+fi

--- a/bin/dev-seed.sh
+++ b/bin/dev-seed.sh
@@ -4,7 +4,7 @@
 # Idempotent: safe to re-run; conflicts are silently ignored.
 #
 # What it does:
-#   1. Sets the Imagify API key from IMAGIFY_API_KEY env var (if set).
+#   1. Sets the Imagify API key from IMAGIFY_TESTS_API_KEY env var (if set).
 #   2. Uploads a small test JPEG to the media library so optimization tests
 #      have something to act on.
 
@@ -15,16 +15,16 @@ wp() { npx --yes @wordpress/env run cli wp "$@"; }
 echo "  • Configuring Imagify options..."
 wp option update imagify_settings '{"api_key":""}' --format=json >/dev/null 2>&1 || true
 
-if [[ -n "${IMAGIFY_API_KEY:-}" ]]; then
-	echo "  • Setting API key from IMAGIFY_API_KEY..."
+if [[ -n "${IMAGIFY_TESTS_API_KEY:-}" ]]; then
+	echo "  • Setting API key from IMAGIFY_TESTS_API_KEY..."
 	wp eval "
 		\$settings = get_option( 'imagify_settings', [] );
-		\$settings['api_key'] = '${IMAGIFY_API_KEY}';
+		\$settings['api_key'] = '${IMAGIFY_TESTS_API_KEY}';
 		update_option( 'imagify_settings', \$settings );
 	" >/dev/null
 else
-	echo "  • IMAGIFY_API_KEY not set — skipping API key configuration."
-	echo "    Set IMAGIFY_API_KEY to enable optimization tests."
+	echo "  • IMAGIFY_TESTS_API_KEY not set — skipping API key configuration."
+	echo "    Set IMAGIFY_TESTS_API_KEY to enable optimization tests."
 fi
 
 echo "  • Uploading a test image to the media library..."

--- a/bin/dev-seed.sh
+++ b/bin/dev-seed.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Seed the local wp-env with the minimal state needed for Imagify E2E tests.
+#
+# Idempotent: safe to re-run; conflicts are silently ignored.
+#
+# What it does:
+#   1. Sets the Imagify API key from IMAGIFY_API_KEY env var (if set).
+#   2. Uploads a small test JPEG to the media library so optimization tests
+#      have something to act on.
+
+set -euo pipefail
+
+wp() { npx --yes @wordpress/env run cli wp "$@"; }
+
+echo "  • Configuring Imagify options..."
+wp option update imagify_settings '{"api_key":""}' --format=json >/dev/null 2>&1 || true
+
+if [[ -n "${IMAGIFY_API_KEY:-}" ]]; then
+	echo "  • Setting API key from IMAGIFY_API_KEY..."
+	wp eval "
+		\$settings = get_option( 'imagify_settings', [] );
+		\$settings['api_key'] = '${IMAGIFY_API_KEY}';
+		update_option( 'imagify_settings', \$settings );
+	" >/dev/null
+else
+	echo "  • IMAGIFY_API_KEY not set — skipping API key configuration."
+	echo "    Set IMAGIFY_API_KEY to enable optimization tests."
+fi
+
+echo "  • Uploading a test image to the media library..."
+# Download a small public-domain JPEG inside the container then import it.
+wp eval '
+	$url = "https://picsum.photos/seed/imagify-e2e/400/300";
+	$tmp = download_url( $url );
+	if ( is_wp_error( $tmp ) ) {
+		WP_CLI::warning( "Could not download test image: " . $tmp->get_error_message() );
+	} else {
+		$file_array = [
+			"name"     => "imagify-e2e-test.jpg",
+			"tmp_name" => $tmp,
+		];
+		$id = media_handle_sideload( $file_array, 0, "Imagify E2E test image" );
+		if ( is_wp_error( $id ) ) {
+			WP_CLI::warning( "Could not import test image: " . $id->get_error_message() );
+		} else {
+			WP_CLI::log( "Test image imported with ID " . $id );
+		}
+	}
+' 2>/dev/null || echo "  ⚠ Image import step skipped (network not reachable inside container)."
+
+echo "  ✓ Seed complete."

--- a/bin/dev-up.sh
+++ b/bin/dev-up.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Boot a local WordPress dev environment for Imagify.
+#
+# Requirements: Docker (Rancher Desktop / Docker Desktop), Node.js, Composer.
+#
+# Usage:
+#   bin/dev-up.sh           # boot + activate plugin + seed minimal data
+#   bin/dev-up.sh --no-seed # boot + activate plugin only
+#   bin/dev-up.sh --reset   # destroy existing env first, then boot fresh
+#
+# After it finishes:
+#   Site:    http://localhost:8888
+#   Admin:   http://localhost:8888/wp-admin  (admin / password)
+#   Tests:   http://localhost:8889 (used by phpunit; ignore for manual testing)
+
+set -euo pipefail
+
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+cd "$ROOT_DIR"
+
+SEED=1
+RESET=0
+for arg in "$@"; do
+	case "$arg" in
+		--no-seed) SEED=0 ;;
+		--reset)   RESET=1 ;;
+		-h|--help)
+			sed -n '2,16p' "$0"
+			exit 0
+			;;
+		*) echo "Unknown arg: $arg" >&2; exit 1 ;;
+	esac
+done
+
+# --- Pre-flight checks ---
+command -v docker    >/dev/null || { echo "❌ docker not found"; exit 1; }
+command -v node      >/dev/null || { echo "❌ node not found"; exit 1; }
+command -v composer  >/dev/null || { echo "❌ composer not found"; exit 1; }
+docker info >/dev/null 2>&1    || { echo "❌ Docker daemon not reachable (start Rancher Desktop / Docker Desktop)"; exit 1; }
+
+# --- Composer dependencies ---
+echo "▶ Installing composer dependencies..."
+composer install --no-interaction --quiet
+
+# --- wp-env ---
+if [[ "$RESET" == "1" ]]; then
+	echo "▶ Destroying existing wp-env..."
+	npx --yes @wordpress/env destroy --quiet || true
+fi
+
+echo "▶ Starting wp-env (this may take a few minutes on first run)..."
+npx --yes @wordpress/env start
+
+# --- Activate plugin ---
+echo "▶ Activating Imagify plugin..."
+npx --yes @wordpress/env run cli wp plugin activate imagify
+
+# --- Seed data ---
+if [[ "$SEED" == "1" ]]; then
+	echo "▶ Seeding demo content..."
+	"$ROOT_DIR/bin/dev-seed.sh"
+fi
+
+cat <<EOF
+
+✅ Imagify dev environment is up.
+
+   Site:    http://localhost:8888
+   Admin:   http://localhost:8888/wp-admin
+   Login:   admin / password
+
+   Tail logs:           npx @wordpress/env run cli "cat wp-content/debug.log"
+   Run WP-CLI:          npx @wordpress/env run cli wp <command>
+   Stop:                npx @wordpress/env stop
+   Destroy (full wipe): npx @wordpress/env destroy
+
+EOF

--- a/bin/test-e2e.sh
+++ b/bin/test-e2e.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Run the Playwright E2E suite against the local wp-env.
+#
+# Usage:
+#   bin/test-e2e.sh              # run all tests
+#   bin/test-e2e.sh --headed     # run with browser visible
+#   bin/test-e2e.sh --ui         # open Playwright UI mode
+#   bin/test-e2e.sh specs/smoke  # run a single spec file or pattern
+#
+# API key:
+#   Create .env.local at the repo root with:
+#     IMAGIFY_TESTS_API_KEY=your-key-here
+#   That file is gitignored and sourced automatically.
+#
+# First run:
+#   Make sure wp-env is running first:  bin/dev-up.sh
+
+set -euo pipefail
+
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+cd "$ROOT_DIR"
+
+# Load local secrets if present.
+if [[ -f "$ROOT_DIR/.env.local" ]]; then
+	set -o allexport
+	# shellcheck disable=SC1091
+	source "$ROOT_DIR/.env.local"
+	set +o allexport
+fi
+
+# Verify wp-env is reachable.
+if ! curl -sf http://localhost:8888 >/dev/null 2>&1; then
+	echo "❌ wp-env doesn't seem to be running on http://localhost:8888"
+	echo "   Run: bin/dev-up.sh"
+	exit 1
+fi
+
+cd "$ROOT_DIR/Tests/e2e"
+
+# Install deps if node_modules is missing.
+if [[ ! -d node_modules ]]; then
+	echo "▶ Installing Playwright dependencies..."
+	npm install
+	npx playwright install --with-deps chromium
+fi
+
+exec npx playwright test "$@"

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -39,7 +39,7 @@ All tests run against a local WordPress environment managed by `@wordpress/env` 
 ```bash
 # From the repository root
 bash bin/dev-up.sh       # Start wp-env + activate plugin + seed test data
-cd tests/e2e
+cd Tests/e2e
 npm install
 npx playwright install chromium
 ```
@@ -47,7 +47,7 @@ npx playwright install chromium
 ### Running
 
 ```bash
-cd tests/e2e
+cd Tests/e2e
 npm test                 # Headless, list reporter
 npm run test:headed      # With browser UI visible
 npm run test:ui          # Playwright interactive UI mode
@@ -61,9 +61,9 @@ npm run report           # Open the last HTML report
 | `IMAGIFY_BASE_URL` | `http://localhost:8888` | Override the WordPress base URL |
 | `IMAGIFY_ADMIN_USER` | `admin` | WP admin username |
 | `IMAGIFY_ADMIN_PASS` | `password` | WP admin password |
-| `IMAGIFY_API_KEY` | _(unset)_ | Real Imagify API key — required for optimization tests |
+| `IMAGIFY_TESTS_API_KEY` | _(unset)_ | Real Imagify API key — required for optimization tests |
 
-Set `IMAGIFY_API_KEY` to run tests that call the Imagify API. Without it, those tests are automatically skipped.
+Set `IMAGIFY_TESTS_API_KEY` to run tests that call the Imagify API. Without it, those tests are automatically skipped.
 
 ---
 
@@ -77,7 +77,7 @@ Each major admin surface has a Page Object class. Use them instead of raw select
 import { SettingsPage } from '../pages/settings';
 const settings = new SettingsPage( page );
 await settings.goto();
-await settings.setApiKey( process.env.IMAGIFY_API_KEY! );
+await settings.setApiKey( process.env.IMAGIFY_TESTS_API_KEY! );
 ```
 
 Key members: `apiKeyInput`, `saveButton`, `successNotice`, `goto()`, `setApiKey()`, `getApiKey()`, `expectNoFatalError()`.
@@ -130,11 +130,11 @@ const value = wpCli( 'option get imagify_settings --format=json' );
 
 ### `hasApiKey()` — `Tests/e2e/fixtures/wp-cli.ts`
 
-Returns `true` if `IMAGIFY_API_KEY` is set. Use with `test.skip` to gate API-dependent tests:
+Returns `true` if `IMAGIFY_TESTS_API_KEY` is set. Use with `test.skip` to gate API-dependent tests:
 
 ```typescript
 import { hasApiKey } from '../fixtures/wp-cli';
-test.skip( ! hasApiKey(), 'IMAGIFY_API_KEY not set' );
+test.skip( ! hasApiKey(), 'IMAGIFY_TESTS_API_KEY not set' );
 ```
 
 ---
@@ -153,7 +153,7 @@ Any test that triggers image optimization through the Imagify API must be guarde
 
 ```typescript
 test( 'Optimizing an image succeeds', async ( { page } ) => {
-    test.skip( ! process.env.IMAGIFY_API_KEY, 'IMAGIFY_API_KEY not set — skipping live optimization test' );
+    test.skip( ! process.env.IMAGIFY_TESTS_API_KEY, 'IMAGIFY_TESTS_API_KEY not set — skipping live optimization test' );
     // ... test body
 } );
 ```
@@ -218,7 +218,7 @@ The E2E workflow (`.github/workflows/e2e.yml`) runs on pull requests that touch:
 - `.wp-env.json`, `bin/dev-up.sh`, `bin/dev-seed.sh` — environment config
 - `composer.json`, `.github/workflows/e2e.yml`
 
-The `IMAGIFY_API_KEY` secret must be set in the GitHub repository settings for API-dependent tests to run. Without it, those tests are automatically skipped and the suite still passes.
+The `IMAGIFY_TESTS_API_KEY` secret must be set in the GitHub repository settings for API-dependent tests to run. Without it, those tests are automatically skipped and the suite still passes.
 
 ---
 

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -1,0 +1,233 @@
+# Imagify — End-to-End Testing
+
+This document is the canonical reference for the Imagify Playwright E2E test suite. **Read this before writing any new tests.**
+
+---
+
+## Architecture overview
+
+| Layer | Path | Purpose |
+|-------|------|---------|
+| Config | `Tests/e2e/playwright.config.ts` | Playwright base config (baseURL, reporters, timeouts) |
+| Fixtures | `Tests/e2e/fixtures/` | Shared helpers: login, WP-CLI wrapper, API key guard |
+| Page objects | `Tests/e2e/pages/` | One class per major admin surface |
+| Specs | `Tests/e2e/specs/` | Test files, one per feature area |
+| Dev scripts | `bin/dev-up.sh`, `bin/dev-down.sh`, `bin/dev-seed.sh` | Local environment lifecycle |
+| CI | `.github/workflows/e2e.yml` | Automated runs on pull requests |
+
+
+All tests run against a local WordPress environment managed by `@wordpress/env` (Docker). The environment maps the plugin root directly into the container at `wp-content/plugins/imagify`.
+
+---
+
+## Admin URLs
+
+| Surface | URL |
+|---------|-----|
+| Settings | `/wp-admin/options-general.php?page=imagify` |
+| Bulk optimization | `/wp-admin/upload.php?page=imagify-bulk-optimization` |
+| Custom folders | `/wp-admin/upload.php?page=imagify-files` |
+| Media library (list) | `/wp-admin/upload.php?mode=list` |
+| Plugins list | `/wp-admin/plugins.php` |
+
+---
+
+## Running tests locally
+
+### One-time setup
+
+```bash
+# From the repository root
+bash bin/dev-up.sh       # Start wp-env + activate plugin + seed test data
+cd tests/e2e
+npm install
+npx playwright install chromium
+```
+
+### Running
+
+```bash
+cd tests/e2e
+npm test                 # Headless, list reporter
+npm run test:headed      # With browser UI visible
+npm run test:ui          # Playwright interactive UI mode
+npm run report           # Open the last HTML report
+```
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `IMAGIFY_BASE_URL` | `http://localhost:8888` | Override the WordPress base URL |
+| `IMAGIFY_ADMIN_USER` | `admin` | WP admin username |
+| `IMAGIFY_ADMIN_PASS` | `password` | WP admin password |
+| `IMAGIFY_API_KEY` | _(unset)_ | Real Imagify API key — required for optimization tests |
+
+Set `IMAGIFY_API_KEY` to run tests that call the Imagify API. Without it, those tests are automatically skipped.
+
+---
+
+## Page objects
+
+Each major admin surface has a Page Object class. Use them instead of raw selectors — they centralize selector maintenance.
+
+### `SettingsPage` (`Tests/e2e/pages/settings.ts`)
+
+```typescript
+import { SettingsPage } from '../pages/settings';
+const settings = new SettingsPage( page );
+await settings.goto();
+await settings.setApiKey( process.env.IMAGIFY_API_KEY! );
+```
+
+Key members: `apiKeyInput`, `saveButton`, `successNotice`, `goto()`, `setApiKey()`, `getApiKey()`, `expectNoFatalError()`.
+
+### `BulkOptimizationPage` (`Tests/e2e/pages/bulk-optimization.ts`)
+
+```typescript
+import { BulkOptimizationPage } from '../pages/bulk-optimization';
+const bulk = new BulkOptimizationPage( page );
+await bulk.goto();
+await expect( bulk.optimizeButton ).toBeVisible();
+```
+
+Key members: `optimizeButton`, `progressBar`, `statsTable`, `goto()`, `expectNoFatalError()`.
+
+### `MediaLibraryPage` (`Tests/e2e/pages/media-library.ts`)
+
+```typescript
+import { MediaLibraryPage } from '../pages/media-library';
+const library = new MediaLibraryPage( page );
+await library.goto();
+await expect( library.imagifyColumn ).toBeVisible();
+```
+
+Key members: `imagifyColumn`, `goto()`, `hasImagifyColumn()`, `getFirstAttachmentStatus()`, `expectNoFatalError()`.
+
+---
+
+## Fixtures
+
+### `loginAsAdmin( page )` — `Tests/e2e/fixtures/auth.ts`
+
+Logs in as the WordPress administrator. Idempotent: skips the login form if a session cookie is already active.
+
+```typescript
+import { loginAsAdmin } from '../fixtures/auth';
+test.beforeEach( async ( { page } ) => {
+    await loginAsAdmin( page );
+} );
+```
+
+### `wpCli( command )` — `Tests/e2e/fixtures/wp-cli.ts`
+
+Runs a WP-CLI command inside the wp-env `cli` container. Returns stdout as a string.
+
+```typescript
+import { wpCli } from '../fixtures/wp-cli';
+const value = wpCli( 'option get imagify_settings --format=json' );
+```
+
+### `hasApiKey()` — `Tests/e2e/fixtures/wp-cli.ts`
+
+Returns `true` if `IMAGIFY_API_KEY` is set. Use with `test.skip` to gate API-dependent tests:
+
+```typescript
+import { hasApiKey } from '../fixtures/wp-cli';
+test.skip( ! hasApiKey(), 'IMAGIFY_API_KEY not set' );
+```
+
+---
+
+## Writing new tests
+
+### Determinism rules
+
+- **Never** use `setTimeout` or `waitForTimeout`. Use web-first assertions (`toBeVisible`, `toHaveValue`, `toHaveURL`, etc.) which have built-in retry.
+- **Never** assert on volatile values (timestamps, auto-increment IDs) without normalization.
+- **Always** seed state before tests that depend on specific DB content.
+
+### API key guard
+
+Any test that triggers image optimization through the Imagify API must be guarded:
+
+```typescript
+test( 'Optimizing an image succeeds', async ( { page } ) => {
+    test.skip( ! process.env.IMAGIFY_API_KEY, 'IMAGIFY_API_KEY not set — skipping live optimization test' );
+    // ... test body
+} );
+```
+
+### Adding a new page object
+
+Create `Tests/e2e/pages/<feature>.ts`:
+
+```typescript
+import { Page, Locator, expect } from '@playwright/test';
+
+export class FeaturePage {
+    readonly page: Page;
+    // locators...
+
+    constructor( page: Page ) {
+        this.page = page;
+        // initialize locators
+    }
+
+    async goto(): Promise<void> {
+        await this.page.goto( '/wp-admin/...' );
+        await this.page.waitForLoadState( 'networkidle' );
+    }
+
+    async expectNoFatalError(): Promise<void> {
+        await expect( this.page.locator( '.wp-die-message, #error-page' ) ).toHaveCount( 0 );
+    }
+}
+```
+
+### Adding a new spec
+
+Create `Tests/e2e/specs/<feature>.spec.ts`. Follow this template:
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from '../fixtures/auth';
+import { FeaturePage } from '../pages/<feature>';
+
+test.describe( 'Feature area', () => {
+    test.beforeEach( async ( { page } ) => {
+        await loginAsAdmin( page );
+    } );
+
+    test( 'Something works', async ( { page } ) => {
+        const featurePage = new FeaturePage( page );
+        await featurePage.goto();
+        await featurePage.expectNoFatalError();
+        // assertions...
+    } );
+} );
+```
+
+---
+
+## CI
+
+The E2E workflow (`.github/workflows/e2e.yml`) runs on pull requests that touch:
+- `classes/**`, `inc/**`, `assets/**`, `views/**` — PHP/JS plugin code
+- `Tests/e2e/**` — test files themselves
+- `.wp-env.json`, `bin/dev-up.sh`, `bin/dev-seed.sh` — environment config
+- `composer.json`, `.github/workflows/e2e.yml`
+
+The `IMAGIFY_API_KEY` secret must be set in the GitHub repository settings for API-dependent tests to run. Without it, those tests are automatically skipped and the suite still passes.
+
+---
+
+## Known coverage gaps
+
+The following areas are not yet covered by automated E2E tests (good places to contribute):
+
+- Custom folders optimization workflow
+- WP-CLI bulk-optimize and bulk-restore commands (use `wpCli()` fixture)
+- Admin notices (API quota reached, outdated plugin)
+- Network mode (proxy URL, login/password settings)
+- Multisite network activation


### PR DESCRIPTION
## Summary

- Adds a complete Playwright E2E test scaffold for the Imagify plugin
- Introduces `@wordpress/env` (Docker) as the local test environment via `.wp-env.json`
- Sets up `Tests/e2e/` (parallel to existing `Tests/` PHPUnit suite) with config, fixtures, page objects, and 5 spec files
- Adds `bin/dev-up.sh` / `bin/dev-down.sh` / `bin/dev-seed.sh` lifecycle scripts
- Adds `.github/workflows/e2e.yml` CI workflow that runs on relevant path changes
- Adds `.claude/agents/` with `qa-engineer` and `e2e-qa-tester` sub-agents for AI-assisted QA
- Adds `docs/E2E_TESTING.md` as the canonical architecture reference
- Adds `AGENTS.md` with project conventions for AI coding agents

## Test coverage added

| Spec | Tests |
|------|-------|
| `smoke.spec.ts` | Settings, bulk, media library pages load; plugin activate/deactivate |
| `account-connection.spec.ts` | API key field visible; invalid key shows error; valid key connects (requires `IMAGIFY_API_KEY`) |
| `settings.spec.ts` | Page renders; save button present; optimization levels present; WebP toggle present; save succeeds |
| `media-library.spec.ts` | List mode loads; Imagify column present; attachment detail loads |
| `bulk-optimization.spec.ts` | Page loads; optimize button present; stats visible; progress UI appears on start (requires `IMAGIFY_API_KEY`) |

Tests that require a live API key skip automatically when `IMAGIFY_API_KEY` is not set.

## How to test locally

```bash
# Requires Docker (Rancher Desktop or Docker Desktop)
bash bin/dev-up.sh          # boot wp-env + activate plugin + seed

cd Tests/e2e
npm install
npx playwright install chromium
npm test
```

## CI setup required

Add the `IMAGIFY_API_KEY` secret to the GitHub repository settings to enable optimization tests in CI. Without it, the suite still passes (API-dependent tests skip).

## Test plan

- [ ] Run `bash bin/dev-up.sh` successfully
- [ ] Run `npm test` in `Tests/e2e/` — all non-API tests pass
- [ ] Confirm `smoke.spec.ts` passes (no API key needed)
- [ ] Confirm `settings.spec.ts` passes (no API key needed)
- [ ] Confirm `media-library.spec.ts` passes (no API key needed)
- [ ] (Optional) Set `IMAGIFY_API_KEY` and confirm API-gated tests also pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)