### PR TITLE
fix(ngg): guard against null meta_data in get_media_files()

### DIFF
--- a/inc/3rd-party/nextgen-gallery/classes/Media/NGG.php
+++ b/inc/3rd-party/nextgen-gallery/classes/Media/NGG.php
@@ -449,7 +449,7 @@ class NGG extends \Imagify\Media\AbstractMedia {
 
 		// Remove common values (that have no value for us here, lol). Also remove 'full' and 'backup'.
 		$image_data = array_diff_key(
-			$this->image->meta_data,
+			is_array( $this->image->meta_data ) ? $this->image->meta_data : [],
 			[
 				'full'              => 1,
 				'backup'            => 1,


### PR DESCRIPTION
# Description

Discovered during QA of #1084 (NGG v3 regression test on PHP 8.2).

\`$this->image->meta_data\` can be \`null\` for a freshly inserted NextGEN Gallery image that has not been processed yet. Passing \`null\` as the first argument of \`array_diff_key()\` is a **fatal TypeError on PHP 8.0+** (silent warning on PHP 7.x), causing optimization to crash for any NGG image uploaded but never processed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

**PHP 8.2 + NGG v3.59.9:** Before fix — \`Fatal error: array_diff_key(): Argument #1 must be of type array, null given\` at \`Media/NGG.php:451\`. After fix — optimization completes, debug.log clean.

**PHP 7.4 + NGG v3.59.9:** Before fix — \`PHP Warning: array_diff_key()\` ×3, optimization completed with warnings. After fix — clean run.

### How to test

Environment: NGG v3.59.9 installed, Imagify active, PHP 8.2.

1. Create a NextGEN gallery (NGG admin > Gallery > Add Gallery).
2. Upload a fresh image — do not optimize it yet.
3. In the NGG gallery image list, click the Imagify optimize button.
4. Check \`wp-content/debug.log\`.

Expected: optimization completes, no \`TypeError\` or \`Warning\` from \`array_diff_key()\`.

### Affected Features & Quality Assurance Scope

- NextGEN Gallery integration — \`inc/3rd-party/nextgen-gallery/classes/Media/NGG.php\`
- Per-image and bulk optimization for NGG images

## Technical description

### Documentation

\`get_media_files()\` calls \`array_diff_key(\$this->image->meta_data, [...])\` to strip EXIF keys. For a freshly inserted NGG image that NGG has not yet processed, \`meta_data\` is \`null\`. Null-coalescing to \`[]\` means no thumbnail sizes are registered yet — the function returns only the \`full\` size entry, which is correct.

\`\`\`php
// Before
\$image_data = array_diff_key(
    \$this->image->meta_data,

// After
\$image_data = array_diff_key(
    \$this->image->meta_data ?? [],
\`\`\`

### New dependencies

None.

### Risks

None — null-coalesce only activates when \`meta_data\` is absent. Fully processed images are unaffected.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote self-explanatory code.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages are explicit enough for users.

## Unticked items justification

**Built-in tests:** The NGG compat layer has no unit test infrastructure (noted as HIGH risk in #1084). Adding NGG media object coverage requires a full NGG test bootstrap — out of scope for this one-line fix.

**Output messages:** No new output introduced.

# Additional Checks
- [x] I added error handling logic when using functions that could throw errors.