### PR TITLE
Closes #1138: Reject version key in UpdateSettings::execute()

### DIFF
--- a/Tests/Unit/classes/Abilities/UpdateSettings/execute.php
+++ b/Tests/Unit/classes/Abilities/UpdateSettings/execute.php
@@ -115,6 +115,25 @@ class Test_Execute extends TestCase {
 	}
 
 	/**
+	 * Tests that execute() returns WP_Error with code imagify_unknown_setting when version is supplied.
+	 */
+	public function testRejectsVersionKey(): void {
+		Functions\when( '__' )->returnArg();
+
+		$ability = $this->make_testable_ability(
+			$this->defaults,
+			$this->defaults,
+			$this->defaults,
+			false
+		);
+
+		$result = $ability->execute( [ 'version' => '2.3.0' ] );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'imagify_unknown_setting', $result->get_error_code() );
+	}
+
+	/**
 	 * Tests that execute() returns an array with 'updated' and 'settings' keys on valid input.
 	 */
 	public function testResponseShapeContainsUpdatedAndSettings(): void {

--- a/classes/Abilities/UpdateSettings.php
+++ b/classes/Abilities/UpdateSettings.php
@@ -261,6 +261,17 @@ class UpdateSettings implements AbilitiesInterface {
 				);
 			}
 
+			if ( 'version' === $key ) {
+				return new \WP_Error(
+					'imagify_unknown_setting',
+					sprintf(
+						/* translators: %s: the unknown setting key name. */
+						__( '"%s" is not a valid Imagify setting key.', 'imagify' ),
+						$key
+					)
+				);
+			}
+
 			if ( 'api_key' === $key && defined( 'IMAGIFY_API_KEY' ) && IMAGIFY_API_KEY ) {
 				return new \WP_Error(
 					'imagify_api_key_immutable',


### PR DESCRIPTION
> [!NOTE]
> 🤖 This pull request was generated by an AI delivery pipeline (Claude Sonnet 4.6). Review all changes carefully before merging.

# Description

Closes #1138

The `UpdateSettings::execute()` method now rejects the `version` key alongside `api_key`, preventing silent acceptance of immutable settings through the MCP ability.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Summary

- **classes/Abilities/UpdateSettings.php**: Added guard clause in `execute()` to reject `version` key with `imagify_unknown_setting` error code
- **Tests/Unit/classes/Abilities/UpdateSettings/execute.php**: Added `testRejectsVersionKey()` unit test to verify rejection behavior

## Detailed scenario

### What was tested

- Unit test verifies `version` key returns `imagify_unknown_setting` error
- Existing tests continue to pass
- No regression in API key immutability logic

### How to test

1. Checkout branch `fix/1138-updatesettings-mcp-ability-silently`
2. Run `composer test-unit`
3. Verify `testRejectsVersionKey` passes and no regressions

### Affected Features & Quality Assurance Scope

- UpdateSettings MCP ability
- Settings validation logic in `execute()`

## Technical description

### Documentation

The `execute()` method now includes a guard clause that checks for the `version` key before processing any setting updates. If `version` is supplied, the method returns a `WP_Error` with code `imagify_unknown_setting`, consistent with the existing behavior for the `api_key` immutability guard.

### New dependencies

None

### Risks

None identified — this is additive validation that rejects a previously silently-accepted invalid input.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)