### PR TITLE
fix: correct GetSettings docblock slug (#1139)

### DIFF
--- a/classes/Abilities/GetSettings.php
+++ b/classes/Abilities/GetSettings.php
@@ -7,7 +7,7 @@ namespace Imagify\Abilities;
  * MCP ability: returns the current Imagify configuration settings.
  *
  * Registers itself with the WP Abilities API under the slug
- * `imagify_get_settings` and returns all user-facing options
+ * `imagify/get-settings` and returns all user-facing options
  * (stripping the internal `version` key and redacting `api_key`).
  *
  * @since 2.3.0


### PR DESCRIPTION
> [!NOTE]
> 🤖 This pull request was generated by an AI delivery pipeline (Claude Sonnet 4.6). Review carefully before merging.

Closes #1139

# Description

Corrects a documentation bug where the class-level docblock in `classes/Abilities/GetSettings.php` incorrectly stated the ability registers under the slug `imagify_get_settings` (underscore format) when the actual registered slug is `imagify/get-settings` (kebab-case with slash). This discrepancy was misleading to developers reading the docblock.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [x] Chore
- [ ] Release

## Detailed scenario

### What was tested

Manually verified:
1. Opened `classes/Abilities/GetSettings.php` — confirmed line 10 docblock now reads `` `imagify/get-settings` `` (was `` `imagify_get_settings` ``).
2. Confirmed the `wp_register_ability('imagify/get-settings', ...)` call at line 30 remains unchanged.
3. Confirmed only 1 line changed in the diff (`git diff develop..HEAD`).
4. Ran PHPCS on the changed file — 0 violations.
5. Verified the existing integration test `Tests/Integration/classes/Abilities/GetSettings/RegisterAbilityTest.php` references the correct slug `imagify/get-settings`.

### How to test

1. Open `classes/Abilities/GetSettings.php`
2. Verify line 10 docblock now correctly states `` `imagify/get-settings` ``
3. Confirm this matches the `wp_register_ability()` call at line 30
4. Run `composer run-tests -- --filter='RegisterAbilityTest'` — all tests should pass

### Affected Features & Quality Assurance Scope

- MCP/Abilities: GetSettings ability — documentation only, no functional impact

## Technical description

### Documentation

This is a docstring-only fix. The registered slug is correct at `imagify/get-settings`; the class-level docblock was inaccurate. No functional code was changed.

### New dependencies

None.

### Risks

None. Documentation-only fix with zero runtime impact.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. Docblock slug updated from `imagify_get_settings` to `imagify/get-settings` — confirmed in GetSettings.php.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices. This is a PHP comment line; it has no runtime execution path.
- [x] I implemented built-in tests to cover the new/changed code. Existing `RegisterAbilityTest` covers the registered slug; no new tests needed for a comment change.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs. N/A — no code logic changed.
- [x] I did not introduce unnecessary complexity. Single-line docblock fix.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable. N/A — no output messages changed.

## Unticked items justification

All mandatory items are relevant and ticked. The test coverage item is satisfied by the existing `RegisterAbilityTest` integration test which validates the correct slug.

# Additional Checks

- [x] In the case of complex code, I wrote comments to explain it. N/A — no complex code added.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.). N/A — documentation fix only.
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.). N/A — no function calls changed.

## Follow-up tickets

None.