### PR TITLE
Closes #1142: validate attachment post type in OptimizeMedia::execute()

### DIFF
--- a/Tests/Unit/classes/Abilities/OptimizeMedia/execute.php
+++ b/Tests/Unit/classes/Abilities/OptimizeMedia/execute.php
@@ -18,6 +18,15 @@ use WP_Error;
 class Test_Execute extends TestCase {
 
 	/**
+	 * Stub get_post() and get_post_type() as a valid attachment.
+	 * Shared by tests that need to pass the early validation checks.
+	 */
+	private function stubValidAttachment(): void {
+		Functions\when( 'get_post' )->justReturn( Mockery::mock( 'WP_Post' ) );
+		Functions\when( 'get_post_type' )->justReturn( 'attachment' );
+	}
+
+	/**
 	 * Tests that execute() returns an error response when media_id is missing.
 	 */
 	public function testReturnsErrorWhenMediaIdIsMissing(): void {
@@ -79,9 +88,7 @@ class Test_Execute extends TestCase {
 	 * Tests that execute() returns an error response when the post is not an attachment.
 	 */
 	public function testReturnsErrorWhenPostIsNotAnAttachment(): void {
-		$post = Mockery::mock( 'WP_Post' );
-
-		Functions\when( 'get_post' )->justReturn( $post );
+		Functions\when( 'get_post' )->justReturn( Mockery::mock( 'WP_Post' ) );
 		Functions\when( 'get_post_type' )->justReturn( 'post' );
 
 		$ability = new OptimizeMedia();
@@ -98,10 +105,7 @@ class Test_Execute extends TestCase {
 	 * Tests that execute() uses the provided optimization_level when optimizing.
 	 */
 	public function testPassesOptimizationLevelToOptimizeWhenNotOptimized(): void {
-		$post = Mockery::mock( 'WP_Post' );
-
-		Functions\when( 'get_post' )->justReturn( $post );
-		Functions\when( 'get_post_type' )->justReturn( 'attachment' );
+		$this->stubValidAttachment();
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
 		$data    = Mockery::mock( 'Imagify\Optimization\Data\DataInterface' );
@@ -143,10 +147,7 @@ class Test_Execute extends TestCase {
 	 * Tests that execute() uses reoptimize() when media is already optimized.
 	 */
 	public function testCallsReoptimizeWhenMediaIsOptimized(): void {
-		$post = Mockery::mock( 'WP_Post' );
-
-		Functions\when( 'get_post' )->justReturn( $post );
-		Functions\when( 'get_post_type' )->justReturn( 'attachment' );
+		$this->stubValidAttachment();
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
 		$data    = Mockery::mock( 'Imagify\Optimization\Data\DataInterface' );
@@ -179,10 +180,7 @@ class Test_Execute extends TestCase {
 	 * Tests that execute() returns an error response when optimize() returns a WP_Error.
 	 */
 	public function testReturnsErrorWhenOptimizeReturnsWpError(): void {
-		$post = Mockery::mock( 'WP_Post' );
-
-		Functions\when( 'get_post' )->justReturn( $post );
-		Functions\when( 'get_post_type' )->justReturn( 'attachment' );
+		$this->stubValidAttachment();
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
 		$data    = Mockery::mock( 'Imagify\Optimization\Data\DataInterface' );
@@ -212,10 +210,7 @@ class Test_Execute extends TestCase {
 	 * Tests that execute() returns a success response with correct shape on successful optimization.
 	 */
 	public function testReturnsSuccessResponseOnSuccessfulOptimization(): void {
-		$post = Mockery::mock( 'WP_Post' );
-
-		Functions\when( 'get_post' )->justReturn( $post );
-		Functions\when( 'get_post_type' )->justReturn( 'attachment' );
+		$this->stubValidAttachment();
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
 		$data    = Mockery::mock( 'Imagify\Optimization\Data\DataInterface' );
@@ -226,7 +221,6 @@ class Test_Execute extends TestCase {
 
 		Functions\when( 'imagify_get_optimization_process' )->justReturn( $process );
 
-		// Mock the protected methods by creating a partial mock.
 		$ability = Mockery::mock( OptimizeMedia::class )->makePartial();
 		$ability->shouldAllowMockingProtectedMethods();
 		$ability->shouldReceive( 'get_media_original_size' )->andReturn( 1000 );
@@ -246,10 +240,7 @@ class Test_Execute extends TestCase {
 	 * Tests that execute() returns a success response with null savings_percent when original_size is 0.
 	 */
 	public function testReturnsSavingsPercentNullWhenOriginalSizeIsZero(): void {
-		$post = Mockery::mock( 'WP_Post' );
-
-		Functions\when( 'get_post' )->justReturn( $post );
-		Functions\when( 'get_post_type' )->justReturn( 'attachment' );
+		$this->stubValidAttachment();
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
 		$data    = Mockery::mock( 'Imagify\Optimization\Data\DataInterface' );
@@ -260,7 +251,6 @@ class Test_Execute extends TestCase {
 
 		Functions\when( 'imagify_get_optimization_process' )->justReturn( $process );
 
-		// Mock the protected methods.
 		$ability = Mockery::mock( OptimizeMedia::class )->makePartial();
 		$ability->shouldAllowMockingProtectedMethods();
 		$ability->shouldReceive( 'get_media_original_size' )->andReturn( 0 );
@@ -276,10 +266,7 @@ class Test_Execute extends TestCase {
 	 * Tests that execute() returns a success response with null savings_percent when optimized_size is null.
 	 */
 	public function testReturnsSavingsPercentNullWhenOptimizedSizeIsNull(): void {
-		$post = Mockery::mock( 'WP_Post' );
-
-		Functions\when( 'get_post' )->justReturn( $post );
-		Functions\when( 'get_post_type' )->justReturn( 'attachment' );
+		$this->stubValidAttachment();
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
 		$data    = Mockery::mock( 'Imagify\Optimization\Data\DataInterface' );
@@ -290,7 +277,6 @@ class Test_Execute extends TestCase {
 
 		Functions\when( 'imagify_get_optimization_process' )->justReturn( $process );
 
-		// Mock the protected methods.
 		$ability = Mockery::mock( OptimizeMedia::class )->makePartial();
 		$ability->shouldAllowMockingProtectedMethods();
 		$ability->shouldReceive( 'get_media_original_size' )->andReturn( 1000 );

--- a/Tests/Unit/classes/Abilities/OptimizeMedia/execute.php
+++ b/Tests/Unit/classes/Abilities/OptimizeMedia/execute.php
@@ -76,12 +76,32 @@ class Test_Execute extends TestCase {
 	}
 
 	/**
+	 * Tests that execute() returns an error response when the post is not an attachment.
+	 */
+	public function testReturnsErrorWhenPostIsNotAnAttachment(): void {
+		$post = Mockery::mock( 'WP_Post' );
+
+		Functions\when( 'get_post' )->justReturn( $post );
+		Functions\when( 'get_post_type' )->justReturn( 'post' );
+
+		$ability = new OptimizeMedia();
+		$result  = $ability->execute( [ 'media_id' => 123 ] );
+
+		$this->assertSame( 'error', $result['status'] );
+		$this->assertNull( $result['original_size'] );
+		$this->assertNull( $result['optimized_size'] );
+		$this->assertNull( $result['savings_percent'] );
+		$this->assertIsString( $result['error_message'] );
+	}
+
+	/**
 	 * Tests that execute() uses the provided optimization_level when optimizing.
 	 */
 	public function testPassesOptimizationLevelToOptimizeWhenNotOptimized(): void {
 		$post = Mockery::mock( 'WP_Post' );
 
 		Functions\when( 'get_post' )->justReturn( $post );
+		Functions\when( 'get_post_type' )->justReturn( 'attachment' );
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
 		$data    = Mockery::mock( 'Imagify\Optimization\Data\DataInterface' );
@@ -126,6 +146,7 @@ class Test_Execute extends TestCase {
 		$post = Mockery::mock( 'WP_Post' );
 
 		Functions\when( 'get_post' )->justReturn( $post );
+		Functions\when( 'get_post_type' )->justReturn( 'attachment' );
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
 		$data    = Mockery::mock( 'Imagify\Optimization\Data\DataInterface' );
@@ -161,6 +182,7 @@ class Test_Execute extends TestCase {
 		$post = Mockery::mock( 'WP_Post' );
 
 		Functions\when( 'get_post' )->justReturn( $post );
+		Functions\when( 'get_post_type' )->justReturn( 'attachment' );
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
 		$data    = Mockery::mock( 'Imagify\Optimization\Data\DataInterface' );
@@ -193,6 +215,7 @@ class Test_Execute extends TestCase {
 		$post = Mockery::mock( 'WP_Post' );
 
 		Functions\when( 'get_post' )->justReturn( $post );
+		Functions\when( 'get_post_type' )->justReturn( 'attachment' );
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
 		$data    = Mockery::mock( 'Imagify\Optimization\Data\DataInterface' );
@@ -226,6 +249,7 @@ class Test_Execute extends TestCase {
 		$post = Mockery::mock( 'WP_Post' );
 
 		Functions\when( 'get_post' )->justReturn( $post );
+		Functions\when( 'get_post_type' )->justReturn( 'attachment' );
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
 		$data    = Mockery::mock( 'Imagify\Optimization\Data\DataInterface' );
@@ -255,6 +279,7 @@ class Test_Execute extends TestCase {
 		$post = Mockery::mock( 'WP_Post' );
 
 		Functions\when( 'get_post' )->justReturn( $post );
+		Functions\when( 'get_post_type' )->justReturn( 'attachment' );
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
 		$data    = Mockery::mock( 'Imagify\Optimization\Data\DataInterface' );

--- a/classes/Abilities/OptimizeMedia.php
+++ b/classes/Abilities/OptimizeMedia.php
@@ -114,8 +114,14 @@ class OptimizeMedia implements AbilitiesInterface {
 		}
 
 		// Verify the attachment exists.
-		if ( ! get_post( $media_id ) ) {
+		$post = get_post( $media_id );
+		if ( ! $post ) {
 			return $this->error_response( 'Invalid media.' );
+		}
+
+		// Verify the post is an attachment.
+		if ( 'attachment' !== get_post_type( $post ) ) {
+			return $this->error_response( 'The provided ID is not a media attachment.' );
 		}
 
 		// Determine optimization level.


### PR DESCRIPTION
# Description

Fixes #1142

`OptimizeMedia::execute()` verified that a post ID existed via `get_post()` but never checked whether the post was actually an attachment. Passing the ID of a page, post, or custom post type would silently pass validation and reach `imagify_get_optimization_process()`, which behaves unexpectedly for non-media posts.

This fix adds a `get_post_type()` guard that rejects any non-attachment with a clear error response.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

**Automated:** New unit test `testReturnsErrorWhenPostIsNotAnAttachment` verifies that passing a `post`-type ID returns an error response. All 10 passing unit tests for `execute()` still pass.

### How to test

1. In a WordPress environment with Imagify active, call the `imagify/optimize-media` MCP ability with the ID of a page or regular post (not an attachment).
2. Verify the response has `status: "error"` and `error_message: "The provided ID is not a media attachment."`.
3. Call it with a valid attachment ID — verify it optimizes normally.

### Affected Features & Quality Assurance Scope

`OptimizeMedia` MCP ability (`imagify/optimize-media`) — validation path only; the optimization logic itself is unchanged.

## Technical description

### Documentation

After `get_post()` confirms the post exists, a `get_post_type()` check is added before reaching the optimization process:

```php
$post = get_post( $media_id );
if ( ! $post ) {
    return $this->error_response( 'Invalid media.' );
}
if ( 'attachment' !== get_post_type( $post ) ) {
    return $this->error_response( 'The provided ID is not a media attachment.' );
}
```

### New dependencies

None.

### Risks

None. The check is a strict guard added before any side-effecting code; it cannot affect the happy path for valid attachment IDs.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A

# Additional Checks

- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
