### PR TITLE
Closes #1143: add check_permissions() unit tests for all 7 MCP abilities

### DIFF
--- a/Tests/Unit/classes/Abilities/GetAccount/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/GetAccount/check_permissions.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Abilities\GetAccount;
+
+use Brain\Monkey\Functions;
+use Imagify\Abilities\GetAccount;
+use Imagify\Tests\Unit\TestCase;
+
+/**
+ * Tests for \Imagify\Abilities\GetAccount::check_permissions().
+ *
+ * @covers \Imagify\Abilities\GetAccount::check_permissions
+ * @group  GetAccount
+ */
+class Test_CheckPermissions extends TestCase {
+
+	public function testReturnsTrueWhenUserHasManageOptionsCapability(): void {
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$ability = new GetAccount();
+		$this->assertTrue( $ability->check_permissions() );
+	}
+
+	public function testReturnsFalseWhenUserLacksManageOptionsCapability(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$ability = new GetAccount();
+		$this->assertFalse( $ability->check_permissions() );
+	}
+}

--- a/Tests/Unit/classes/Abilities/GetAccount/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/GetAccount/check_permissions.php
@@ -15,6 +15,9 @@ use Imagify\Tests\Unit\TestCase;
  */
 class Test_CheckPermissions extends TestCase {
 
+	/**
+	 * Tests that check_permissions() returns true when the user has the manage_options capability.
+	 */
 	public function testReturnsTrueWhenUserHasManageOptionsCapability(): void {
 		Functions\when( 'current_user_can' )->justReturn( true );
 
@@ -22,6 +25,9 @@ class Test_CheckPermissions extends TestCase {
 		$this->assertTrue( $ability->check_permissions() );
 	}
 
+	/**
+	 * Tests that check_permissions() returns false when the user lacks the manage_options capability.
+	 */
 	public function testReturnsFalseWhenUserLacksManageOptionsCapability(): void {
 		Functions\when( 'current_user_can' )->justReturn( false );
 

--- a/Tests/Unit/classes/Abilities/GetMediaStatus/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/GetMediaStatus/check_permissions.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Abilities\GetMediaStatus;
+
+use Brain\Monkey\Functions;
+use Imagify\Abilities\GetMediaStatus;
+use Imagify\Tests\Unit\TestCase;
+
+/**
+ * Tests for \Imagify\Abilities\GetMediaStatus::check_permissions().
+ *
+ * @covers \Imagify\Abilities\GetMediaStatus::check_permissions
+ * @group  GetMediaStatus
+ */
+class Test_CheckPermissions extends TestCase {
+
+	public function testReturnsTrueWhenUserHasManageOptionsCapability(): void {
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$ability = new GetMediaStatus();
+		$this->assertTrue( $ability->check_permissions() );
+	}
+
+	public function testReturnsFalseWhenUserLacksManageOptionsCapability(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$ability = new GetMediaStatus();
+		$this->assertFalse( $ability->check_permissions() );
+	}
+}

--- a/Tests/Unit/classes/Abilities/GetMediaStatus/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/GetMediaStatus/check_permissions.php
@@ -15,6 +15,9 @@ use Imagify\Tests\Unit\TestCase;
  */
 class Test_CheckPermissions extends TestCase {
 
+	/**
+	 * Tests that check_permissions() returns true when the user has the manage_options capability.
+	 */
 	public function testReturnsTrueWhenUserHasManageOptionsCapability(): void {
 		Functions\when( 'current_user_can' )->justReturn( true );
 
@@ -22,6 +25,9 @@ class Test_CheckPermissions extends TestCase {
 		$this->assertTrue( $ability->check_permissions() );
 	}
 
+	/**
+	 * Tests that check_permissions() returns false when the user lacks the manage_options capability.
+	 */
 	public function testReturnsFalseWhenUserLacksManageOptionsCapability(): void {
 		Functions\when( 'current_user_can' )->justReturn( false );
 

--- a/Tests/Unit/classes/Abilities/GetNextgenCoverage/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/GetNextgenCoverage/check_permissions.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Abilities\GetNextgenCoverage;
+
+use Brain\Monkey\Functions;
+use Imagify\Abilities\GetNextgenCoverage;
+use Imagify\Stats\StatInterface;
+use Imagify\Tests\Unit\TestCase;
+use Mockery;
+
+/**
+ * Tests for \Imagify\Abilities\GetNextgenCoverage::check_permissions().
+ *
+ * @covers \Imagify\Abilities\GetNextgenCoverage::check_permissions
+ * @group  GetNextgenCoverage
+ */
+class Test_CheckPermissions extends TestCase {
+
+	public function testReturnsTrueWhenUserHasManageOptionsCapability(): void {
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$ability = new GetNextgenCoverage( Mockery::mock( StatInterface::class ) );
+		$this->assertTrue( $ability->check_permissions() );
+	}
+
+	public function testReturnsFalseWhenUserLacksManageOptionsCapability(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$ability = new GetNextgenCoverage( Mockery::mock( StatInterface::class ) );
+		$this->assertFalse( $ability->check_permissions() );
+	}
+}

--- a/Tests/Unit/classes/Abilities/GetNextgenCoverage/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/GetNextgenCoverage/check_permissions.php
@@ -17,6 +17,9 @@ use Mockery;
  */
 class Test_CheckPermissions extends TestCase {
 
+	/**
+	 * Tests that check_permissions() returns true when the user has the manage_options capability.
+	 */
 	public function testReturnsTrueWhenUserHasManageOptionsCapability(): void {
 		Functions\when( 'current_user_can' )->justReturn( true );
 
@@ -24,6 +27,9 @@ class Test_CheckPermissions extends TestCase {
 		$this->assertTrue( $ability->check_permissions() );
 	}
 
+	/**
+	 * Tests that check_permissions() returns false when the user lacks the manage_options capability.
+	 */
 	public function testReturnsFalseWhenUserLacksManageOptionsCapability(): void {
 		Functions\when( 'current_user_can' )->justReturn( false );
 

--- a/Tests/Unit/classes/Abilities/GetSettings/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/GetSettings/check_permissions.php
@@ -15,6 +15,9 @@ use Imagify\Tests\Unit\TestCase;
  */
 class Test_CheckPermissions extends TestCase {
 
+	/**
+	 * Tests that check_permissions() returns true when the user has the manage_options capability.
+	 */
 	public function testReturnsTrueWhenUserHasManageOptionsCapability(): void {
 		Functions\when( 'current_user_can' )->justReturn( true );
 
@@ -22,6 +25,9 @@ class Test_CheckPermissions extends TestCase {
 		$this->assertTrue( $ability->check_permissions() );
 	}
 
+	/**
+	 * Tests that check_permissions() returns false when the user lacks the manage_options capability.
+	 */
 	public function testReturnsFalseWhenUserLacksManageOptionsCapability(): void {
 		Functions\when( 'current_user_can' )->justReturn( false );
 

--- a/Tests/Unit/classes/Abilities/GetSettings/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/GetSettings/check_permissions.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Abilities\GetSettings;
+
+use Brain\Monkey\Functions;
+use Imagify\Abilities\GetSettings;
+use Imagify\Tests\Unit\TestCase;
+
+/**
+ * Tests for \Imagify\Abilities\GetSettings::check_permissions().
+ *
+ * @covers \Imagify\Abilities\GetSettings::check_permissions
+ * @group  GetSettings
+ */
+class Test_CheckPermissions extends TestCase {
+
+	public function testReturnsTrueWhenUserHasManageOptionsCapability(): void {
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$ability = new GetSettings();
+		$this->assertTrue( $ability->check_permissions() );
+	}
+
+	public function testReturnsFalseWhenUserLacksManageOptionsCapability(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$ability = new GetSettings();
+		$this->assertFalse( $ability->check_permissions() );
+	}
+}

--- a/Tests/Unit/classes/Abilities/GetStats/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/GetStats/check_permissions.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Abilities\GetStats;
+
+use Brain\Monkey\Functions;
+use Imagify\Abilities\GetStats;
+use Imagify\Tests\Unit\TestCase;
+
+/**
+ * Tests for \Imagify\Abilities\GetStats::check_permissions().
+ *
+ * @covers \Imagify\Abilities\GetStats::check_permissions
+ * @group  GetStats
+ */
+class Test_CheckPermissions extends TestCase {
+
+	public function testReturnsTrueWhenUserHasManageOptionsCapability(): void {
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$ability = new GetStats();
+		$this->assertTrue( $ability->check_permissions() );
+	}
+
+	public function testReturnsFalseWhenUserLacksManageOptionsCapability(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$ability = new GetStats();
+		$this->assertFalse( $ability->check_permissions() );
+	}
+}

--- a/Tests/Unit/classes/Abilities/GetStats/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/GetStats/check_permissions.php
@@ -15,6 +15,9 @@ use Imagify\Tests\Unit\TestCase;
  */
 class Test_CheckPermissions extends TestCase {
 
+	/**
+	 * Tests that check_permissions() returns true when the user has the manage_options capability.
+	 */
 	public function testReturnsTrueWhenUserHasManageOptionsCapability(): void {
 		Functions\when( 'current_user_can' )->justReturn( true );
 
@@ -22,6 +25,9 @@ class Test_CheckPermissions extends TestCase {
 		$this->assertTrue( $ability->check_permissions() );
 	}
 
+	/**
+	 * Tests that check_permissions() returns false when the user lacks the manage_options capability.
+	 */
 	public function testReturnsFalseWhenUserLacksManageOptionsCapability(): void {
 		Functions\when( 'current_user_can' )->justReturn( false );
 

--- a/Tests/Unit/classes/Abilities/OptimizeMedia/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/OptimizeMedia/check_permissions.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Abilities\OptimizeMedia;
+
+use Brain\Monkey\Functions;
+use Imagify\Abilities\OptimizeMedia;
+use Imagify\Tests\Unit\TestCase;
+
+/**
+ * Tests for \Imagify\Abilities\OptimizeMedia::check_permissions().
+ *
+ * @covers \Imagify\Abilities\OptimizeMedia::check_permissions
+ * @group  OptimizeMedia
+ */
+class Test_CheckPermissions extends TestCase {
+
+	public function testReturnsTrueWhenUserHasManageOptionsCapability(): void {
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$ability = new OptimizeMedia();
+		$this->assertTrue( $ability->check_permissions() );
+	}
+
+	public function testReturnsFalseWhenUserLacksManageOptionsCapability(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$ability = new OptimizeMedia();
+		$this->assertFalse( $ability->check_permissions() );
+	}
+}

--- a/Tests/Unit/classes/Abilities/OptimizeMedia/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/OptimizeMedia/check_permissions.php
@@ -15,6 +15,9 @@ use Imagify\Tests\Unit\TestCase;
  */
 class Test_CheckPermissions extends TestCase {
 
+	/**
+	 * Tests that check_permissions() returns true when the user has the manage_options capability.
+	 */
 	public function testReturnsTrueWhenUserHasManageOptionsCapability(): void {
 		Functions\when( 'current_user_can' )->justReturn( true );
 
@@ -22,6 +25,9 @@ class Test_CheckPermissions extends TestCase {
 		$this->assertTrue( $ability->check_permissions() );
 	}
 
+	/**
+	 * Tests that check_permissions() returns false when the user lacks the manage_options capability.
+	 */
 	public function testReturnsFalseWhenUserLacksManageOptionsCapability(): void {
 		Functions\when( 'current_user_can' )->justReturn( false );
 

--- a/Tests/Unit/classes/Abilities/UpdateSettings/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/UpdateSettings/check_permissions.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Abilities\UpdateSettings;
+
+use Brain\Monkey\Functions;
+use Imagify\Abilities\UpdateSettings;
+use Imagify\Tests\Unit\TestCase;
+
+/**
+ * Tests for \Imagify\Abilities\UpdateSettings::check_permissions().
+ *
+ * @covers \Imagify\Abilities\UpdateSettings::check_permissions
+ * @group  UpdateSettings
+ */
+class Test_CheckPermissions extends TestCase {
+
+	public function testReturnsTrueWhenUserHasManageOptionsCapability(): void {
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$ability = new UpdateSettings();
+		$this->assertTrue( $ability->check_permissions() );
+	}
+
+	public function testReturnsFalseWhenUserLacksManageOptionsCapability(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$ability = new UpdateSettings();
+		$this->assertFalse( $ability->check_permissions() );
+	}
+}

--- a/Tests/Unit/classes/Abilities/UpdateSettings/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/UpdateSettings/check_permissions.php
@@ -15,6 +15,9 @@ use Imagify\Tests\Unit\TestCase;
  */
 class Test_CheckPermissions extends TestCase {
 
+	/**
+	 * Tests that check_permissions() returns true when the user has the manage_options capability.
+	 */
 	public function testReturnsTrueWhenUserHasManageOptionsCapability(): void {
 		Functions\when( 'current_user_can' )->justReturn( true );
 
@@ -22,6 +25,9 @@ class Test_CheckPermissions extends TestCase {
 		$this->assertTrue( $ability->check_permissions() );
 	}
 
+	/**
+	 * Tests that check_permissions() returns false when the user lacks the manage_options capability.
+	 */
 	public function testReturnsFalseWhenUserLacksManageOptionsCapability(): void {
 		Functions\when( 'current_user_can' )->justReturn( false );
 


### PR DESCRIPTION
# Description

Closes #1143

None of the 7 MCP ability classes had unit test coverage for `check_permissions()`. This PR adds two test cases per ability (capability granted → `true`, capability denied → `false`), covering all 7 abilities: `GetAccount`, `GetMediaStatus`, `GetNextgenCoverage`, `GetSettings`, `GetStats`, `OptimizeMedia`, `UpdateSettings`.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

**Automated:** 14 new unit tests — 2 per ability. All pass.

### How to test

```
cd Tests/Unit && php ../../vendor/bin/phpunit --testsuite unit --filter "CheckPermissions" --testdox
```

Expected: 14 tests, 14 assertions, OK.

### Affected Features & Quality Assurance Scope

Test-only change. No production code modified.

## Technical description

### Documentation

Each ability gets a `check_permissions.php` test file alongside its existing `execute.php`. The tests stub `current_user_can` via Brain\Monkey and assert the return value directly. `GetNextgenCoverage` requires a `StatInterface` constructor argument, so a Mockery mock is passed.

### New dependencies

None.

### Risks

None. Test-only change.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A

# Additional Checks

- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

Additional checks are unticked — this is a test-only PR with no complex logic and no I/O.