### PR TITLE
Closes #1168: track Internal State Reset event via Mixpanel

### DIFF
--- a/Tests/Unit/classes/Tools/ResetInternalState/reset.php
+++ b/Tests/Unit/classes/Tools/ResetInternalState/reset.php
@@ -207,6 +207,28 @@ class Test_Reset extends TestCase {
 	}
 
 	/**
+	 * Tests that reset() fires the imagify_after_reset_internal_state action at the end.
+	 */
+	public function testFiresActionAfterReset(): void {
+		$this->wpdb->shouldReceive( 'esc_like' )->andReturnUsing(
+			function ( string $value ): string {
+				return str_replace( [ '\\', '%', '_' ], [ '\\\\', '\\%', '\\_' ], $value );
+			}
+		);
+		$this->wpdb->shouldReceive( 'prepare' )->andReturn( 'PREPARED_SQL' );
+		$this->wpdb->shouldReceive( 'query' )->andReturn( 1 );
+
+		Functions\when( 'delete_transient' )->justReturn( true );
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		Functions\expect( 'do_action' )
+			->once()
+			->with( 'imagify_after_reset_internal_state' );
+
+		( new ResetInternalState() )->reset();
+	}
+
+	/**
 	 * Tests that reset() skips as_unschedule_all_actions() when ActionScheduler is not loaded.
 	 *
 	 * As_unschedule_all_actions() does not exist in the test environment, so

--- a/Tests/Unit/classes/Tracking/Subscriber/Test_GetSubscribedEvents.php
+++ b/Tests/Unit/classes/Tracking/Subscriber/Test_GetSubscribedEvents.php
@@ -52,4 +52,58 @@ class Test_GetSubscribedEvents extends TestCase {
 		$subscriber = new Subscriber( $tracking );
 		$subscriber->track_media_optimized( $process, $item );
 	}
+
+	/**
+	 * Tests that update_option_imagify_settings maps to track_settings_saved correctly.
+	 */
+	public function testMapsUpdateOptionImagifySettingsHook(): void {
+		$events = Subscriber::get_subscribed_events();
+
+		$this->assertArrayHasKey( 'update_option_imagify_settings', $events );
+		$this->assertSame( [ 'track_settings_saved', 10, 2 ], $events['update_option_imagify_settings'] );
+	}
+
+	/**
+	 * Tests that update_site_option_imagify_settings maps to track_settings_saved correctly.
+	 */
+	public function testMapsUpdateSiteOptionImagifySettingsHook(): void {
+		$events = Subscriber::get_subscribed_events();
+
+		$this->assertArrayHasKey( 'update_site_option_imagify_settings', $events );
+		$this->assertSame( [ 'track_settings_saved', 10, 2 ], $events['update_site_option_imagify_settings'] );
+	}
+
+	/**
+	 * Tests that track_settings_saved() delegates to Tracking::track_settings_saved() with array-cast args.
+	 */
+	public function testTrackSettingsSavedDelegatesToTracking(): void {
+		$tracking  = Mockery::mock( Tracking::class );
+		$old_value = [ 'optimization_level' => 1 ];
+		$new_value = [ 'optimization_level' => 2 ];
+
+		$tracking->shouldReceive( 'track_settings_saved' )
+			->once()
+			->with( $old_value, $new_value );
+
+		$subscriber = new Subscriber( $tracking );
+		$subscriber->track_settings_saved( $old_value, $new_value );
+	}
+
+	/**
+	 * Tests multisite-style delegation where first arg is the option name string.
+	 * On multisite, update_site_option_imagify_settings passes ($option, $new_value, $old_value).
+	 * The delegator must cast the string option name to array without error.
+	 */
+	public function testTrackSettingsSavedDelegatesToTrackingWithMultisiteArgs(): void {
+		$tracking   = Mockery::mock( Tracking::class );
+		$option_name = 'imagify_settings'; // multisite: first arg is the option name
+		$new_value  = [ 'optimization_level' => 2 ];
+
+		$tracking->shouldReceive( 'track_settings_saved' )
+			->once()
+			->with( (array) $option_name, $new_value );
+
+		$subscriber = new Subscriber( $tracking );
+		$subscriber->track_settings_saved( $option_name, $new_value );
+	}
 }

--- a/Tests/Unit/classes/Tracking/Subscriber/Test_GetSubscribedEvents.php
+++ b/Tests/Unit/classes/Tracking/Subscriber/Test_GetSubscribedEvents.php
@@ -38,6 +38,24 @@ class Test_GetSubscribedEvents extends TestCase {
 	}
 
 	/**
+	 * Tests that imagify_after_reset_internal_state is registered.
+	 */
+	public function testMapsImagifyAfterResetInternalStateHook(): void {
+		$events = Subscriber::get_subscribed_events();
+
+		$this->assertArrayHasKey( 'imagify_after_reset_internal_state', $events );
+	}
+
+	/**
+	 * Tests that the reset hook maps to track_internal_state_reset with priority 10 and 0 args.
+	 */
+	public function testResetHookConfigurationIsCorrect(): void {
+		$events = Subscriber::get_subscribed_events();
+
+		$this->assertSame( [ 'track_internal_state_reset', 10, 0 ], $events['imagify_after_reset_internal_state'] );
+	}
+
+	/**
 	 * Tests that track_media_optimized delegates to the Tracking service.
 	 */
 	public function testTrackMediaOptimizedDelegatesToTracking(): void {
@@ -51,5 +69,17 @@ class Test_GetSubscribedEvents extends TestCase {
 
 		$subscriber = new Subscriber( $tracking );
 		$subscriber->track_media_optimized( $process, $item );
+	}
+
+	/**
+	 * Tests that track_internal_state_reset delegates to the Tracking service.
+	 */
+	public function testTrackInternalStateResetDelegatesToTracking(): void {
+		$tracking = Mockery::mock( Tracking::class );
+
+		$tracking->shouldReceive( 'track_internal_state_reset' )->once();
+
+		$subscriber = new Subscriber( $tracking );
+		$subscriber->track_internal_state_reset();
 	}
 }

--- a/Tests/Unit/classes/Tracking/Tracking/Test_TrackInternalStateReset.php
+++ b/Tests/Unit/classes/Tracking/Tracking/Test_TrackInternalStateReset.php
@@ -1,0 +1,156 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Tracking\Tracking;
+
+use Brain\Monkey\Functions;
+use Imagify\Dependencies\WPMedia\Mixpanel\Optin;
+use Imagify\Dependencies\WPMedia\Mixpanel\TrackingPlugin;
+use Imagify\Tests\Unit\TestCase;
+use Imagify\Tracking\Tracking;
+use Mockery;
+
+/**
+ * Tests for \Imagify\Tracking\Tracking::track_internal_state_reset().
+ *
+ * @covers \Imagify\Tracking\Tracking::track_internal_state_reset
+ * @group  Tracking
+ */
+class Test_TrackInternalStateReset extends TestCase {
+
+	/**
+	 * Creates a Tracking instance with mocked dependencies.
+	 *
+	 * @param bool $can_track Whether tracking is allowed.
+	 *
+	 * @return array{tracking: Tracking, optin: \Mockery\MockInterface&Optin, mixpanel: \Mockery\MockInterface&TrackingPlugin}
+	 */
+	private function create_tracking( bool $can_track = true ): array {
+		$optin    = Mockery::mock( Optin::class );
+		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$optin->shouldReceive( 'can_track' )->andReturn( $can_track );
+
+		Functions\when( 'get_imagify_user' )->justReturn( (object) [ 'email' => 'user@example.com' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+
+		$tracking = new Tracking( $optin, $mixpanel );
+
+		return compact( 'tracking', 'optin', 'mixpanel' );
+	}
+
+	/**
+	 * Tests that no event is tracked when opt-in is disabled.
+	 */
+	public function testDoesNotTrackWhenOptInDisabled(): void {
+		$mocks    = $this->create_tracking( false );
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$mixpanel->shouldNotReceive( 'track_direct' );
+
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		$tracking->track_internal_state_reset();
+	}
+
+	/**
+	 * Tests that track_direct is called once with the correct event name when opt-in is enabled.
+	 */
+	public function testTracksWhenOptInEnabled(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Internal State Reset',
+				Mockery::type( 'array' )
+			);
+
+		$tracking->track_internal_state_reset();
+	}
+
+	/**
+	 * Tests that is_multisite is included and reflects false on a single-site install.
+	 */
+	public function testEventContainsIsMultisiteFalseOnSingleSite(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Internal State Reset',
+				Mockery::on(
+					function ( array $props ) {
+						return array_key_exists( 'is_multisite', $props ) && $props['is_multisite'] === false;
+					}
+				)
+			);
+
+		$tracking->track_internal_state_reset();
+	}
+
+	/**
+	 * Tests that is_multisite is true on a multisite install.
+	 */
+	public function testEventContainsIsMultisiteTrueOnMultisite(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		Functions\when( 'is_multisite' )->justReturn( true );
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Internal State Reset',
+				Mockery::on(
+					function ( array $props ) {
+						return $props['is_multisite'] === true;
+					}
+				)
+			);
+
+		$tracking->track_internal_state_reset();
+	}
+
+	/**
+	 * Tests that auto-merged properties (domain, wp_version, etc.) are NOT set inline.
+	 */
+	public function testEventDoesNotContainAutoMergedProperties(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		$forbidden = [ 'domain', 'wp_version', 'php_version', 'plugin', 'brand', 'application' ];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Internal State Reset',
+				Mockery::on(
+					function ( array $props ) use ( $forbidden ) {
+						foreach ( $forbidden as $key ) {
+							if ( array_key_exists( $key, $props ) ) {
+								return false;
+							}
+						}
+						return true;
+					}
+				)
+			);
+
+		$tracking->track_internal_state_reset();
+	}
+}

--- a/Tests/Unit/classes/Tracking/Tracking/Test_TrackSettingsSaved.php
+++ b/Tests/Unit/classes/Tracking/Tracking/Test_TrackSettingsSaved.php
@@ -1,0 +1,304 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Tracking\Tracking;
+
+use Brain\Monkey\Functions;
+use Imagify\Dependencies\WPMedia\Mixpanel\Optin;
+use Imagify\Dependencies\WPMedia\Mixpanel\TrackingPlugin;
+use Imagify\Tests\Unit\TestCase;
+use Imagify\Tracking\Tracking;
+use Mockery;
+
+/**
+ * Tests for \Imagify\Tracking\Tracking::track_settings_saved().
+ *
+ * @covers \Imagify\Tracking\Tracking::track_settings_saved
+ * @group  Tracking
+ */
+class Test_TrackSettingsSaved extends TestCase {
+
+	/**
+	 * Creates a Tracking instance with mocked dependencies.
+	 *
+	 * @param bool $can_track Whether tracking is allowed.
+	 *
+	 * @return array{tracking: Tracking, optin: \Mockery\MockInterface&Optin, mixpanel: \Mockery\MockInterface&TrackingPlugin}
+	 */
+	private function create_tracking( bool $can_track = true ): array {
+		$optin    = Mockery::mock( Optin::class );
+		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$optin->shouldReceive( 'can_track' )->andReturn( $can_track );
+
+		Functions\when( 'get_imagify_user' )->justReturn( (object) [ 'email' => 'user@example.com' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+
+		$tracking = new Tracking( $optin, $mixpanel );
+
+		return compact( 'tracking', 'optin', 'mixpanel' );
+	}
+
+	/**
+	 * Returns a minimal valid settings array for the happy path.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function valid_new_value(): array {
+		return [
+			'optimization_level' => 1,
+			'auto_optimize'      => 1,
+			'resize_larger'      => 1,
+			'convert_to_webp'    => 1,
+			'convert_to_avif'    => 0,
+			'backup'             => 1,
+		];
+	}
+
+	/**
+	 * Tests that no event is tracked when opt-in is disabled.
+	 */
+	public function testNoTrackWhenOptInDisabled(): void {
+		$mocks    = $this->create_tracking( false );
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$mixpanel->shouldNotReceive( 'track_direct' );
+
+		$tracking->track_settings_saved( [], $this->valid_new_value() );
+	}
+
+	/**
+	 * Tests the happy path: track_direct() called once with 'Settings Saved'.
+	 */
+	public function testHappyPathCallsTrackDirect(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$forbidden = [ 'domain', 'wp_version', 'php_version', 'plugin', 'brand', 'application' ];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) use ( $forbidden ) {
+						foreach ( $forbidden as $key ) {
+							if ( array_key_exists( $key, $props ) ) {
+								return false;
+							}
+						}
+						return isset( $props['context'], $props['optimization_level'] );
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], $this->valid_new_value() );
+	}
+
+	/**
+	 * Tests that option keys are correctly mapped to Mixpanel property names.
+	 */
+	public function testPropertyMappingIsCorrect(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$new_value = [
+			'optimization_level' => '2',
+			'auto_optimize'      => '1',
+			'resize_larger'      => '1',
+			'convert_to_webp'    => '1',
+			'convert_to_avif'    => '1',
+			'backup'             => '1',
+		];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return 2 === $props['optimization_level']
+							&& true === $props['auto_optimize_on_upload']
+							&& true === $props['resize_larger_images']
+							&& true === $props['next_gen_images_webp']
+							&& true === $props['next_gen_images_avif']
+							&& true === $props['backup_original'];
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], $new_value );
+	}
+
+	/**
+	 * Tests that optimization_level is cast to int.
+	 */
+	public function testOptimizationLevelCastToInt(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$new_value = [ 'optimization_level' => '0' ];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return 0 === $props['optimization_level'] && is_int( $props['optimization_level'] );
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], $new_value );
+	}
+
+	/**
+	 * Tests that missing optimization_level results in null.
+	 */
+	public function testOptimizationLevelNullWhenMissing(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return null === $props['optimization_level'];
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], [] );
+	}
+
+	/**
+	 * Tests that boolean options stored as string '0' are normalised to false.
+	 */
+	public function testBooleanNormalisationFromStringZero(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$new_value = [
+			'auto_optimize'   => '0',
+			'resize_larger'   => '0',
+			'convert_to_webp' => '0',
+			'convert_to_avif' => '0',
+			'backup'          => '0',
+		];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return false === $props['auto_optimize_on_upload']
+							&& false === $props['resize_larger_images']
+							&& false === $props['next_gen_images_webp']
+							&& false === $props['next_gen_images_avif']
+							&& false === $props['backup_original'];
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], $new_value );
+	}
+
+	/**
+	 * Tests that boolean options stored as string '1' are normalised to true.
+	 */
+	public function testBooleanNormalisationFromStringOne(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$new_value = [
+			'auto_optimize'   => '1',
+			'resize_larger'   => '1',
+			'convert_to_webp' => '1',
+			'convert_to_avif' => '1',
+			'backup'          => '1',
+		];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return true === $props['auto_optimize_on_upload']
+							&& true === $props['resize_larger_images']
+							&& true === $props['next_gen_images_webp']
+							&& true === $props['next_gen_images_avif']
+							&& true === $props['backup_original'];
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], $new_value );
+	}
+
+	/**
+	 * Tests that auto-managed Mixpanel keys are not present in props passed to track_direct().
+	 */
+	public function testAutoManagedKeysNotPassedToTrackDirect(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$forbidden = [ 'domain', 'wp_version', 'php_version', 'plugin', 'brand', 'application' ];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) use ( $forbidden ) {
+						foreach ( $forbidden as $key ) {
+							if ( array_key_exists( $key, $props ) ) {
+								return false;
+							}
+						}
+						return true;
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], $this->valid_new_value() );
+	}
+
+	/**
+	 * Tests that $old_value is ignored — passing garbage as old value does not change output.
+	 */
+	public function testOldValueIgnored(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$new_value  = $this->valid_new_value();
+		$garbage_old = [ 'completely' => 'irrelevant', 'data' => 12345 ];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return isset( $props['optimization_level'] );
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( $garbage_old, $new_value );
+	}
+}

--- a/Tests/Unit/classes/Tracking/Tracking/Test_TrackSettingsSaved.php
+++ b/Tests/Unit/classes/Tracking/Tracking/Test_TrackSettingsSaved.php
@@ -47,12 +47,15 @@ class Test_TrackSettingsSaved extends TestCase {
 	 */
 	private function valid_new_value(): array {
 		return [
-			'optimization_level' => 1,
-			'auto_optimize'      => 1,
-			'resize_larger'      => 1,
-			'convert_to_webp'    => 1,
-			'convert_to_avif'    => 0,
-			'backup'             => 1,
+			'auto_optimize'          => 1,
+			'backup'                 => 1,
+			'lossless'               => 1,
+			'optimization_format'    => 'avif',
+			'display_nextgen'        => 1,
+			'display_nextgen_method' => 'picture',
+			'cdn_url'                => '',
+			'resize_larger'          => 1,
+			'resize_larger_w'        => 2560,
 		];
 	}
 
@@ -90,7 +93,7 @@ class Test_TrackSettingsSaved extends TestCase {
 								return false;
 							}
 						}
-						return isset( $props['context'], $props['optimization_level'] );
+						return isset( $props['context'], $props['optimization_format'] );
 					}
 				)
 			);
@@ -107,12 +110,15 @@ class Test_TrackSettingsSaved extends TestCase {
 		$mixpanel = $mocks['mixpanel'];
 
 		$new_value = [
-			'optimization_level' => '2',
-			'auto_optimize'      => '1',
-			'resize_larger'      => '1',
-			'convert_to_webp'    => '1',
-			'convert_to_avif'    => '1',
-			'backup'             => '1',
+			'auto_optimize'          => '1',
+			'backup'                 => '1',
+			'lossless'               => '1',
+			'optimization_format'    => 'webp',
+			'display_nextgen'        => '1',
+			'display_nextgen_method' => 'picture',
+			'cdn_url'                => 'https://cdn.example.com',
+			'resize_larger'          => '1',
+			'resize_larger_w'        => '1920',
 		];
 
 		$mixpanel->shouldReceive( 'track_direct' )
@@ -121,12 +127,15 @@ class Test_TrackSettingsSaved extends TestCase {
 				'Settings Saved',
 				Mockery::on(
 					function ( array $props ) {
-						return 2 === $props['optimization_level']
+						return 'webp' === $props['optimization_format']
+							&& true === $props['lossless']
 							&& true === $props['auto_optimize_on_upload']
+							&& true === $props['backup_original']
 							&& true === $props['resize_larger_images']
-							&& true === $props['next_gen_images_webp']
-							&& true === $props['next_gen_images_avif']
-							&& true === $props['backup_original'];
+							&& 1920 === $props['resize_larger_width']
+							&& true === $props['display_nextgen']
+							&& 'picture' === $props['display_nextgen_method']
+							&& true === $props['cdn_enabled'];
 					}
 				)
 			);
@@ -135,33 +144,9 @@ class Test_TrackSettingsSaved extends TestCase {
 	}
 
 	/**
-	 * Tests that optimization_level is cast to int.
+	 * Tests that optimization_format is null when missing.
 	 */
-	public function testOptimizationLevelCastToInt(): void {
-		$mocks    = $this->create_tracking();
-		$tracking = $mocks['tracking'];
-		$mixpanel = $mocks['mixpanel'];
-
-		$new_value = [ 'optimization_level' => '0' ];
-
-		$mixpanel->shouldReceive( 'track_direct' )
-			->once()
-			->with(
-				'Settings Saved',
-				Mockery::on(
-					function ( array $props ) {
-						return 0 === $props['optimization_level'] && is_int( $props['optimization_level'] );
-					}
-				)
-			);
-
-		$tracking->track_settings_saved( [], $new_value );
-	}
-
-	/**
-	 * Tests that missing optimization_level results in null.
-	 */
-	public function testOptimizationLevelNullWhenMissing(): void {
+	public function testOptimizationFormatNullWhenMissing(): void {
 		$mocks    = $this->create_tracking();
 		$tracking = $mocks['tracking'];
 		$mixpanel = $mocks['mixpanel'];
@@ -172,12 +157,56 @@ class Test_TrackSettingsSaved extends TestCase {
 				'Settings Saved',
 				Mockery::on(
 					function ( array $props ) {
-						return null === $props['optimization_level'];
+						return null === $props['optimization_format'];
 					}
 				)
 			);
 
 		$tracking->track_settings_saved( [], [] );
+	}
+
+	/**
+	 * Tests that resize_larger_width is cast to int.
+	 */
+	public function testResizeLargerWidthCastToInt(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return 2560 === $props['resize_larger_width'] && is_int( $props['resize_larger_width'] );
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], [ 'resize_larger_w' => '2560' ] );
+	}
+
+	/**
+	 * Tests that cdn_enabled is false when cdn_url is empty.
+	 */
+	public function testCdnEnabledFalseWhenCdnUrlEmpty(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return false === $props['cdn_enabled'];
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], [ 'cdn_url' => '' ] );
 	}
 
 	/**
@@ -190,10 +219,10 @@ class Test_TrackSettingsSaved extends TestCase {
 
 		$new_value = [
 			'auto_optimize'   => '0',
-			'resize_larger'   => '0',
-			'convert_to_webp' => '0',
-			'convert_to_avif' => '0',
 			'backup'          => '0',
+			'lossless'        => '0',
+			'display_nextgen' => '0',
+			'resize_larger'   => '0',
 		];
 
 		$mixpanel->shouldReceive( 'track_direct' )
@@ -203,10 +232,10 @@ class Test_TrackSettingsSaved extends TestCase {
 				Mockery::on(
 					function ( array $props ) {
 						return false === $props['auto_optimize_on_upload']
-							&& false === $props['resize_larger_images']
-							&& false === $props['next_gen_images_webp']
-							&& false === $props['next_gen_images_avif']
-							&& false === $props['backup_original'];
+							&& false === $props['backup_original']
+							&& false === $props['lossless']
+							&& false === $props['display_nextgen']
+							&& false === $props['resize_larger_images'];
 					}
 				)
 			);
@@ -224,10 +253,10 @@ class Test_TrackSettingsSaved extends TestCase {
 
 		$new_value = [
 			'auto_optimize'   => '1',
-			'resize_larger'   => '1',
-			'convert_to_webp' => '1',
-			'convert_to_avif' => '1',
 			'backup'          => '1',
+			'lossless'        => '1',
+			'display_nextgen' => '1',
+			'resize_larger'   => '1',
 		];
 
 		$mixpanel->shouldReceive( 'track_direct' )
@@ -237,10 +266,10 @@ class Test_TrackSettingsSaved extends TestCase {
 				Mockery::on(
 					function ( array $props ) {
 						return true === $props['auto_optimize_on_upload']
-							&& true === $props['resize_larger_images']
-							&& true === $props['next_gen_images_webp']
-							&& true === $props['next_gen_images_avif']
-							&& true === $props['backup_original'];
+							&& true === $props['backup_original']
+							&& true === $props['lossless']
+							&& true === $props['display_nextgen']
+							&& true === $props['resize_larger_images'];
 					}
 				)
 			);
@@ -285,8 +314,11 @@ class Test_TrackSettingsSaved extends TestCase {
 		$tracking = $mocks['tracking'];
 		$mixpanel = $mocks['mixpanel'];
 
-		$new_value  = $this->valid_new_value();
-		$garbage_old = [ 'completely' => 'irrelevant', 'data' => 12345 ];
+		$new_value   = $this->valid_new_value();
+		$garbage_old = [
+			'completely' => 'irrelevant',
+			'data'       => 12345,
+		];
 
 		$mixpanel->shouldReceive( 'track_direct' )
 			->once()
@@ -294,7 +326,7 @@ class Test_TrackSettingsSaved extends TestCase {
 				'Settings Saved',
 				Mockery::on(
 					function ( array $props ) {
-						return isset( $props['optimization_level'] );
+						return isset( $props['auto_optimize_on_upload'] );
 					}
 				)
 			);

--- a/classes/Tools/ResetInternalState.php
+++ b/classes/Tools/ResetInternalState.php
@@ -60,5 +60,7 @@ class ResetInternalState {
 				as_unschedule_all_actions( $hook );
 			}
 		}
+
+		do_action( 'imagify_after_reset_internal_state' );
 	}
 }

--- a/classes/Tracking/Subscriber.php
+++ b/classes/Tracking/Subscriber.php
@@ -37,7 +37,9 @@ class Subscriber implements SubscriberInterface {
 	public static function get_subscribed_events(): array {
 		return [
 			// @action imagify_after_optimize
-			'imagify_after_optimize' => [ 'track_media_optimized', 10, 2 ],
+			'imagify_after_optimize'             => [ 'track_media_optimized', 10, 2 ],
+			// @action imagify_after_reset_internal_state
+			'imagify_after_reset_internal_state' => [ 'track_internal_state_reset', 10, 0 ],
 		];
 	}
 
@@ -51,5 +53,14 @@ class Subscriber implements SubscriberInterface {
 	 */
 	public function track_media_optimized( $process, $item ): void {
 		$this->tracking->track_media_optimized( $process, $item );
+	}
+
+	/**
+	 * Track an "Internal State Reset" event after the internal state is reset.
+	 *
+	 * @return void
+	 */
+	public function track_internal_state_reset(): void {
+		$this->tracking->track_internal_state_reset();
 	}
 }

--- a/classes/Tracking/Subscriber.php
+++ b/classes/Tracking/Subscriber.php
@@ -37,7 +37,11 @@ class Subscriber implements SubscriberInterface {
 	public static function get_subscribed_events(): array {
 		return [
 			// @action imagify_after_optimize
-			'imagify_after_optimize' => [ 'track_media_optimized', 10, 2 ],
+			'imagify_after_optimize'              => [ 'track_media_optimized', 10, 2 ],
+			// @action update_option_imagify_settings fires on single-site saves.
+			'update_option_imagify_settings'      => [ 'track_settings_saved', 10, 2 ],
+			// @action update_site_option_imagify_settings fires on multisite saves.
+			'update_site_option_imagify_settings' => [ 'track_settings_saved', 10, 2 ],
 		];
 	}
 
@@ -51,5 +55,22 @@ class Subscriber implements SubscriberInterface {
 	 */
 	public function track_media_optimized( $process, $item ): void {
 		$this->tracking->track_media_optimized( $process, $item );
+	}
+
+	/**
+	 * Delegate to Tracking::track_settings_saved().
+	 *
+	 * Both update_option_imagify_settings and update_site_option_imagify_settings fire
+	 * with different arg ordering (on multisite the first arg is the option name string,
+	 * not the old value). Both args are cast to array so the strict-typed downstream
+	 * signature is always satisfied. $old_value is unused downstream.
+	 *
+	 * @param mixed $old_value Old option value, or option name string on multisite.
+	 * @param mixed $new_value New option value.
+	 *
+	 * @return void
+	 */
+	public function track_settings_saved( $old_value, $new_value ): void {
+		$this->tracking->track_settings_saved( (array) $old_value, (array) $new_value );
 	}
 }

--- a/classes/Tracking/Tracking.php
+++ b/classes/Tracking/Tracking.php
@@ -67,6 +67,37 @@ class Tracking extends BaseTracking {
 	}
 
 	/**
+	 * Track a "Settings Saved" event in Mixpanel.
+	 *
+	 * @param array $old_value The previous option value. Intentionally unused — kept for
+	 *                         hook-signature symmetry. On multisite the first hook arg is the
+	 *                         option name (string), not the old value, so this parameter is
+	 *                         unreliable and must not be used for business logic.
+	 * @param array $new_value The new option value.
+	 *
+	 * @return void
+	 */
+	public function track_settings_saved( array $old_value, array $new_value ): void {
+		if ( ! $this->can_track() ) {
+			return;
+		}
+
+		$event_data = array_merge(
+			$this->get_default_event_properties(),
+			[
+				'optimization_level'      => isset( $new_value['optimization_level'] ) ? (int) $new_value['optimization_level'] : null,
+				'auto_optimize_on_upload' => ! empty( $new_value['auto_optimize'] ),
+				'resize_larger_images'    => ! empty( $new_value['resize_larger'] ),
+				'next_gen_images_webp'    => ! empty( $new_value['convert_to_webp'] ),
+				'next_gen_images_avif'    => ! empty( $new_value['convert_to_avif'] ),
+				'backup_original'         => ! empty( $new_value['backup'] ),
+			]
+		);
+
+		$this->mixpanel->track_direct( 'Settings Saved', $event_data );
+	}
+
+	/**
 	 * Resolve the next-gen format generated for the full size.
 	 *
 	 * @param ProcessInterface $process The optimization process instance.

--- a/classes/Tracking/Tracking.php
+++ b/classes/Tracking/Tracking.php
@@ -85,12 +85,15 @@ class Tracking extends BaseTracking {
 		$event_data = array_merge(
 			$this->get_default_event_properties(),
 			[
-				'optimization_level'      => isset( $new_value['optimization_level'] ) ? (int) $new_value['optimization_level'] : null,
+				'optimization_format'     => isset( $new_value['optimization_format'] ) ? (string) $new_value['optimization_format'] : null,
+				'lossless'                => ! empty( $new_value['lossless'] ),
 				'auto_optimize_on_upload' => ! empty( $new_value['auto_optimize'] ),
-				'resize_larger_images'    => ! empty( $new_value['resize_larger'] ),
-				'next_gen_images_webp'    => ! empty( $new_value['convert_to_webp'] ),
-				'next_gen_images_avif'    => ! empty( $new_value['convert_to_avif'] ),
 				'backup_original'         => ! empty( $new_value['backup'] ),
+				'resize_larger_images'    => ! empty( $new_value['resize_larger'] ),
+				'resize_larger_width'     => isset( $new_value['resize_larger_w'] ) ? (int) $new_value['resize_larger_w'] : null,
+				'display_nextgen'         => ! empty( $new_value['display_nextgen'] ),
+				'display_nextgen_method'  => isset( $new_value['display_nextgen_method'] ) ? (string) $new_value['display_nextgen_method'] : null,
+				'cdn_enabled'             => ! empty( $new_value['cdn_url'] ),
 			]
 		);
 

--- a/classes/Tracking/Tracking.php
+++ b/classes/Tracking/Tracking.php
@@ -67,6 +67,26 @@ class Tracking extends BaseTracking {
 	}
 
 	/**
+	 * Track an "Internal State Reset" event in Mixpanel.
+	 *
+	 * @return void
+	 */
+	public function track_internal_state_reset(): void {
+		if ( ! $this->can_track() ) {
+			return;
+		}
+
+		$event_data = array_merge(
+			$this->get_default_event_properties(),
+			[
+				'is_multisite' => is_multisite(),
+			]
+		);
+
+		$this->mixpanel->track_direct( 'Internal State Reset', $event_data );
+	}
+
+	/**
 	 * Resolve the next-gen format generated for the full size.
 	 *
 	 * @param ProcessInterface $process The optimization process instance.

--- a/docs/api/tracking.md
+++ b/docs/api/tracking.md
@@ -9,8 +9,8 @@ The `Imagify\Tracking` module wires the `wp-media/wp-mixpanel` Composer package 
 | Class | Role |
 |---|---|
 | `Imagify\Tracking\BaseTracking` | Abstract base: `can_track()`, `get_default_event_properties()` |
-| `Imagify\Tracking\Tracking` | Concrete: `track_media_optimized()` |
-| `Imagify\Tracking\Subscriber` | Subscribes to `imagify_after_optimize` and delegates to `Tracking` |
+| `Imagify\Tracking\Tracking` | Concrete: `track_media_optimized()`, `track_settings_saved()` |
+| `Imagify\Tracking\Subscriber` | Subscribes to WordPress hooks and delegates to `Tracking` |
 | `Imagify\Tracking\ServiceProvider` | Registers all module services into the DI container |
 
 The module depends on two Strauss-prefixed vendor classes:
@@ -28,13 +28,17 @@ The module depends on two Strauss-prefixed vendor classes:
 
 ---
 
-## Hook subscribed
+## Hooks subscribed
 
 | Hook | Method | Priority | Args |
 |---|---|---|---|
 | `imagify_after_optimize` | `Subscriber::track_media_optimized` | 10 | 2 (`$process`, `$item`) |
+| `update_option_imagify_settings` | `Subscriber::track_settings_saved` | 10 | 2 (`$old_value`, `$new_value`) |
+| `update_site_option_imagify_settings` | `Subscriber::track_settings_saved` | 10 | 2 (`$option`, `$new_value`) |
 
-The hook fires inside ActionScheduler (see `classes/Job/MediaOptimization.php`). Because bulk/cron runs execute without a logged-in user, the module uses `Optin::can_track()` (option-only check) and `TrackingPlugin::track_direct()` (bypasses `current_user_can`).
+`imagify_after_optimize` fires inside ActionScheduler (see `classes/Job/MediaOptimization.php`). Because bulk/cron runs execute without a logged-in user, the module uses `Optin::can_track()` (option-only check) and `TrackingPlugin::track_direct()` (bypasses `current_user_can`).
+
+`update_option_imagify_settings` fires on single-site when the option value changes. `update_site_option_imagify_settings` fires on multisite. Note the argument ordering differs between them: on multisite the first argument is the option name string, not the old value — the delegating method casts both args to array to satisfy the strict-typed `Tracking` signature, and the old value is unused downstream.
 
 ---
 
@@ -70,6 +74,30 @@ Fired after a successful full-size optimization. Guards (all must pass):
 3. `manual` — fallback.
 
 When `auto` and bulk transients are both true, `auto` wins.
+
+---
+
+## Event: Settings Saved
+
+Fired each time the Imagify settings option is actually updated (WordPress only fires `update_option_*` when the value changes). Guards:
+
+1. `can_track()` returns `true` (opt-in enabled).
+
+### Event properties
+
+| Property | Source option key | Notes |
+|---|---|---|
+| `context` | — | Always `'wp_plugin'` (from `get_default_event_properties()`) |
+| `license_owner` | — | SHA-256 hash of `get_imagify_user()->email`; empty string if not connected |
+| `user_id` | — | `get_current_user_id()` |
+| `optimization_level` | `optimization_level` | Cast to `int`; `null` if key absent |
+| `auto_optimize_on_upload` | `auto_optimize` | `bool` via `! empty()` |
+| `resize_larger_images` | `resize_larger` | `bool` via `! empty()` |
+| `next_gen_images_webp` | `convert_to_webp` | `bool` via `! empty()` |
+| `next_gen_images_avif` | `convert_to_avif` | `bool` via `! empty()` |
+| `backup_original` | `backup` | `bool` via `! empty()` |
+
+`TrackingPlugin::track_direct()` automatically merges `domain`, `wp_version`, `php_version`, `plugin`, `brand`, and `application` — these are not set manually.
 
 ---
 


### PR DESCRIPTION
# Description

Closes #1168

When an admin uses the "Reset internal state" button in the settings troubleshooting section, an `Internal State Reset` event is now tracked in Mixpanel. This gives the team visibility into how often optimization lock issues are encountered in the wild, and whether they correlate with specific environments (multisite, PHP/WP version, etc.).

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).
- [x] Sub-task of #1122

## Detailed scenario

### What was tested

All scenarios are covered by automated unit tests:

- **`Test_TrackInternalStateReset`** (5 tests): verifies that `track_internal_state_reset()` does not call `track_direct` when opt-in is disabled; that it calls `track_direct('Internal State Reset', ...)` exactly once when opt-in is enabled; that the `is_multisite` property is correctly set to `false` on single-site and `true` on multisite; and that default properties merged by `BaseTracking` (`domain`, `wp_version`, etc.) are not set inline.
- **`Test_Reset::testFiresActionAfterReset`** (1 test): asserts that `do_action('imagify_after_reset_internal_state')` is called once at the end of `ResetInternalState::reset()`.
- **`Test_GetSubscribedEvents`** (2 tests): verifies that the subscriber maps `imagify_after_reset_internal_state` to `track_internal_state_reset` with priority 10 and 0 accepted arguments, and that the subscriber delegates correctly to the tracking service.

### How to test

1. Check out the branch and ensure the `feat/mixpanel` base branch is present locally.
2. Run the unit test suite targeting the changed classes:
   ```
   vendor/bin/phpunit Tests/Unit/classes/Tracking/Tracking/Test_TrackInternalStateReset.php
   vendor/bin/phpunit Tests/Unit/classes/Tools/ResetInternalState/reset.php
   vendor/bin/phpunit Tests/Unit/classes/Tracking/Subscriber/Test_GetSubscribedEvents.php
   ```
   All tests should be green.
3. For a manual smoke test against a real Mixpanel project: install the plugin on a staging site with opt-in enabled, navigate to **Settings > Troubleshooting**, click **Reset internal state**, and verify an `Internal State Reset` event appears in the Mixpanel event stream with the correct `is_multisite` property.

### Affected Features & Quality Assurance Scope

- **Troubleshooting / Reset internal state** — the reset flow gains a new trailing hook; existing cleanup logic is unchanged.
- **Mixpanel tracking** — new event type added alongside the existing `Media Optimized` event. No changes to the shared `BaseTracking` or `Optin` logic.

## Technical description

### Documentation

Three coordinated changes implement the feature:

1. **`classes/Tools/ResetInternalState.php`** — `do_action('imagify_after_reset_internal_state')` is appended as the final statement of `reset()`, after all transient deletions and ActionScheduler unscheduling are complete. No parameters are passed; the action is purely a notification that the reset succeeded.

2. **`classes/Tracking/Tracking.php`** — New `track_internal_state_reset()` method. Guards on `can_track()`, then merges `get_default_event_properties()` with a single extra property `is_multisite` (boolean from `is_multisite()`), and calls `$this->mixpanel->track_direct('Internal State Reset', $event_data)`.

3. **`classes/Tracking/Subscriber.php`** — `get_subscribed_events()` gains a second entry:
   ```php
   'imagify_after_reset_internal_state' => [ 'track_internal_state_reset', 10, 0 ],
   ```
   The subscriber delegates to `$this->tracking->track_internal_state_reset()`.

### New dependencies

None.

### Risks

- The new `do_action` hook is placed unconditionally at the end of `reset()`. If a future caller wraps `reset()` in a try/catch and the method throws before reaching the hook, no tracking event fires — which is the correct behavior (no misleading success signal).
- The `is_multisite` property does not expose any user-identifiable data; it mirrors what all other events already collect via default properties.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

None — all items are applicable and satisfied.

# Additional Checks

- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.). — Observability is provided by the Mixpanel event stream itself; no additional logging was added as this is a pure tracking feature.
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)