### PR TITLE
Closes #1166: track Media Restored event via Mixpanel

### DIFF
--- a/Tests/Fixtures/classes/Tracking/Tracking/Test_TrackMediaRestored.php
+++ b/Tests/Fixtures/classes/Tracking/Tracking/Test_TrackMediaRestored.php
@@ -1,0 +1,127 @@
+<?php
+
+return [
+	'test_data' => [
+
+		// ── Guard: opt-in disabled ────────────────────────────────────────────
+		'noEventWhenOptInDisabled' => [
+			'config'   => [
+				'can_track' => false,
+				'response'  => true,
+				'data'      => [],
+				'context'   => 'wp',
+			],
+			'expected' => [
+				'track_direct_called' => false,
+			],
+		],
+
+		// ── Guard: WP_Error response ──────────────────────────────────────────
+		'noEventWhenResponseIsWpError' => [
+			'config'   => [
+				'can_track' => true,
+				'response'  => 'wp_error',
+				'data'      => [],
+				'context'   => 'wp',
+			],
+			'expected' => [
+				'track_direct_called' => false,
+			],
+		],
+
+		// ── Happy path: basic success ─────────────────────────────────────────
+		'happyPathFiresMediaRestored' => [
+			'config'   => [
+				'can_track' => true,
+				'response'  => true,
+				'data'      => [ 'level' => 1, 'sizes' => [] ],
+				'context'   => 'wp',
+			],
+			'expected' => [
+				'track_direct_called' => true,
+				'media_context'       => 'wp',
+				'optimization_level'  => 1,
+				'next_gen_format'     => null,
+			],
+		],
+
+		// ── optimization_level: false stored value ────────────────────────────
+		'optimizationLevelNullWhenLevelIsFalse' => [
+			'config'   => [
+				'can_track' => true,
+				'response'  => true,
+				'data'      => [ 'level' => false, 'sizes' => [] ],
+				'context'   => 'wp',
+			],
+			'expected' => [
+				'track_direct_called' => true,
+				'optimization_level'  => null,
+				'next_gen_format'     => null,
+			],
+		],
+
+		// ── optimization_level: key absent ───────────────────────────────────
+		'optimizationLevelNullWhenLevelMissing' => [
+			'config'   => [
+				'can_track' => true,
+				'response'  => true,
+				'data'      => [ 'sizes' => [] ],
+				'context'   => 'wp',
+			],
+			'expected' => [
+				'track_direct_called' => true,
+				'optimization_level'  => null,
+				'next_gen_format'     => null,
+			],
+		],
+
+		// ── next_gen_format: AVIF succeeds ───────────────────────────────────
+		'nextGenFormatIsAvifWhenAvifSucceeds' => [
+			'config'   => [
+				'can_track' => true,
+				'response'  => true,
+				'data'      => [
+					'level' => 1,
+					'sizes' => [ 'full@imagify-avif' => [ 'success' => true ] ],
+				],
+				'context'   => 'wp',
+			],
+			'expected' => [
+				'track_direct_called' => true,
+				'next_gen_format'     => 'avif',
+			],
+		],
+
+		// ── next_gen_format: WebP succeeds (AVIF absent) ─────────────────────
+		'nextGenFormatIsWebpWhenOnlyWebpSucceeds' => [
+			'config'   => [
+				'can_track' => true,
+				'response'  => true,
+				'data'      => [
+					'level' => 1,
+					'sizes' => [ 'full@imagify-webp' => [ 'success' => true ] ],
+				],
+				'context'   => 'wp',
+			],
+			'expected' => [
+				'track_direct_called' => true,
+				'next_gen_format'     => 'webp',
+			],
+		],
+
+		// ── next_gen_format: none succeeded ──────────────────────────────────
+		'nextGenFormatIsNullWhenNoneSucceeded' => [
+			'config'   => [
+				'can_track' => true,
+				'response'  => true,
+				'data'      => [ 'level' => 1, 'sizes' => [] ],
+				'context'   => 'custom-folders',
+			],
+			'expected' => [
+				'track_direct_called' => true,
+				'next_gen_format'     => null,
+				'media_context'       => 'custom-folders',
+			],
+		],
+	],
+];

--- a/Tests/Integration/classes/Tracking/ServiceProvider/Test_GetSubscribers.php
+++ b/Tests/Integration/classes/Tracking/ServiceProvider/Test_GetSubscribers.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Integration\classes\Tracking\ServiceProvider;
+
+use Imagify\Tests\Integration\TestCase;
+use Imagify\Tracking\ServiceProvider;
+use Imagify\Tracking\Subscriber;
+use Imagify\Tracking\Tracking;
+
+/**
+ * Tests for \Imagify\Tracking\ServiceProvider::get_subscribers() and provides(),
+ * and for the hook wiring introduced by the Subscriber.
+ *
+ * These tests live in the Integration suite because ServiceProvider extends
+ * Imagify\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider
+ * (a Strauss-prefixed vendored class). The Unit bootstrap uses a hand-listed
+ * file set — NOT the full vendor autoloader — so the prefixed base class is not
+ * available there. The Integration suite bootstraps the full WP environment with
+ * the complete autoloader, making the class resolvable.
+ *
+ * @covers \Imagify\Tracking\ServiceProvider::get_subscribers
+ * @covers \Imagify\Tracking\ServiceProvider::provides
+ * @group  Tracking
+ */
+class Test_GetSubscribers extends TestCase {
+
+	/**
+	 * Whether to use the Imagify API for these tests.
+	 *
+	 * @var bool
+	 */
+	protected $useApi = false; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+
+	/**
+	 * Tests that get_subscribers() includes Subscriber::class.
+	 */
+	public function testReturnsTrackingSubscriber(): void {
+		$provider    = new ServiceProvider();
+		$subscribers = $provider->get_subscribers();
+
+		$this->assertContains( Subscriber::class, $subscribers );
+	}
+
+	/**
+	 * Tests that provides() returns true for Tracking::class.
+	 */
+	public function testProvidesTrueForTracking(): void {
+		$provider = new ServiceProvider();
+
+		$this->assertTrue( $provider->provides( Tracking::class ) );
+	}
+
+	/**
+	 * Tests that provides() returns true for Subscriber::class.
+	 */
+	public function testProvidesTrueForSubscriber(): void {
+		$provider = new ServiceProvider();
+
+		$this->assertTrue( $provider->provides( Subscriber::class ) );
+	}
+
+	/**
+	 * Tests that provides() returns false for an unknown service.
+	 */
+	public function testProvidesFalseForUnknownService(): void {
+		$provider = new ServiceProvider();
+
+		$this->assertFalse( $provider->provides( 'some_unknown_service' ) );
+	}
+
+	/**
+	 * Tests that imagify_after_restore_media is hooked with priority 10 and 4 accepted args.
+	 *
+	 * This verifies end-to-end wiring: the Subscriber registered by the ServiceProvider
+	 * must connect our tracking method to the hook exactly as get_subscribed_events() declares.
+	 */
+	public function testRestoreHookIsWiredCorrectly(): void {
+		$this->assertSame(
+			10,
+			has_action( 'imagify_after_restore_media', [ $this->get_subscriber(), 'track_media_restored' ] ),
+			'imagify_after_restore_media should be hooked at priority 10.'
+		);
+	}
+
+	/**
+	 * Tests that imagify_after_optimize is still hooked with priority 10 (regression guard).
+	 */
+	public function testOptimizeHookIsStillWiredCorrectly(): void {
+		$this->assertSame(
+			10,
+			has_action( 'imagify_after_optimize', [ $this->get_subscriber(), 'track_media_optimized' ] ),
+			'imagify_after_optimize should still be hooked at priority 10.'
+		);
+	}
+
+	/**
+	 * Retrieves the Subscriber instance registered by the plugin's DI container.
+	 *
+	 * @return Subscriber
+	 */
+	private function get_subscriber(): Subscriber {
+		return imagify()->get( Subscriber::class );
+	}
+}

--- a/Tests/Unit/classes/Tools/ResetInternalState/reset.php
+++ b/Tests/Unit/classes/Tools/ResetInternalState/reset.php
@@ -207,6 +207,28 @@ class Test_Reset extends TestCase {
 	}
 
 	/**
+	 * Tests that reset() fires the imagify_after_reset_internal_state action at the end.
+	 */
+	public function testFiresActionAfterReset(): void {
+		$this->wpdb->shouldReceive( 'esc_like' )->andReturnUsing(
+			function ( string $value ): string {
+				return str_replace( [ '\\', '%', '_' ], [ '\\\\', '\\%', '\\_' ], $value );
+			}
+		);
+		$this->wpdb->shouldReceive( 'prepare' )->andReturn( 'PREPARED_SQL' );
+		$this->wpdb->shouldReceive( 'query' )->andReturn( 1 );
+
+		Functions\when( 'delete_transient' )->justReturn( true );
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		Functions\expect( 'do_action' )
+			->once()
+			->with( 'imagify_after_reset_internal_state' );
+
+		( new ResetInternalState() )->reset();
+	}
+
+	/**
 	 * Tests that reset() skips as_unschedule_all_actions() when ActionScheduler is not loaded.
 	 *
 	 * As_unschedule_all_actions() does not exist in the test environment, so

--- a/Tests/Unit/classes/Tracking/Subscriber/Test_GetSubscribedEvents.php
+++ b/Tests/Unit/classes/Tracking/Subscriber/Test_GetSubscribedEvents.php
@@ -52,4 +52,58 @@ class Test_GetSubscribedEvents extends TestCase {
 		$subscriber = new Subscriber( $tracking );
 		$subscriber->track_media_optimized( $process, $item );
 	}
+
+	/**
+	 * Tests that update_option_imagify_settings maps to track_settings_saved correctly.
+	 */
+	public function testMapsUpdateOptionImagifySettingsHook(): void {
+		$events = Subscriber::get_subscribed_events();
+
+		$this->assertArrayHasKey( 'update_option_imagify_settings', $events );
+		$this->assertSame( [ 'track_settings_saved', 10, 2 ], $events['update_option_imagify_settings'] );
+	}
+
+	/**
+	 * Tests that update_site_option_imagify_settings maps to track_settings_saved correctly.
+	 */
+	public function testMapsUpdateSiteOptionImagifySettingsHook(): void {
+		$events = Subscriber::get_subscribed_events();
+
+		$this->assertArrayHasKey( 'update_site_option_imagify_settings', $events );
+		$this->assertSame( [ 'track_settings_saved', 10, 2 ], $events['update_site_option_imagify_settings'] );
+	}
+
+	/**
+	 * Tests that track_settings_saved() delegates to Tracking::track_settings_saved() with array-cast args.
+	 */
+	public function testTrackSettingsSavedDelegatesToTracking(): void {
+		$tracking  = Mockery::mock( Tracking::class );
+		$old_value = [ 'optimization_level' => 1 ];
+		$new_value = [ 'optimization_level' => 2 ];
+
+		$tracking->shouldReceive( 'track_settings_saved' )
+			->once()
+			->with( $old_value, $new_value );
+
+		$subscriber = new Subscriber( $tracking );
+		$subscriber->track_settings_saved( $old_value, $new_value );
+	}
+
+	/**
+	 * Tests multisite-style delegation where first arg is the option name string.
+	 * On multisite, update_site_option_imagify_settings passes ($option, $new_value, $old_value).
+	 * The delegator must cast the string option name to array without error.
+	 */
+	public function testTrackSettingsSavedDelegatesToTrackingWithMultisiteArgs(): void {
+		$tracking   = Mockery::mock( Tracking::class );
+		$option_name = 'imagify_settings'; // multisite: first arg is the option name
+		$new_value  = [ 'optimization_level' => 2 ];
+
+		$tracking->shouldReceive( 'track_settings_saved' )
+			->once()
+			->with( (array) $option_name, $new_value );
+
+		$subscriber = new Subscriber( $tracking );
+		$subscriber->track_settings_saved( $option_name, $new_value );
+	}
 }

--- a/Tests/Unit/classes/Tracking/Subscriber/Test_GetSubscribedEvents.php
+++ b/Tests/Unit/classes/Tracking/Subscriber/Test_GetSubscribedEvents.php
@@ -38,6 +38,24 @@ class Test_GetSubscribedEvents extends TestCase {
 	}
 
 	/**
+	 * Tests that imagify_after_reset_internal_state is registered.
+	 */
+	public function testMapsImagifyAfterResetInternalStateHook(): void {
+		$events = Subscriber::get_subscribed_events();
+
+		$this->assertArrayHasKey( 'imagify_after_reset_internal_state', $events );
+	}
+
+	/**
+	 * Tests that the reset hook maps to track_internal_state_reset with priority 10 and 0 args.
+	 */
+	public function testResetHookConfigurationIsCorrect(): void {
+		$events = Subscriber::get_subscribed_events();
+
+		$this->assertSame( [ 'track_internal_state_reset', 10, 0 ], $events['imagify_after_reset_internal_state'] );
+	}
+
+	/**
 	 * Tests that track_media_optimized delegates to the Tracking service.
 	 */
 	public function testTrackMediaOptimizedDelegatesToTracking(): void {
@@ -51,5 +69,17 @@ class Test_GetSubscribedEvents extends TestCase {
 
 		$subscriber = new Subscriber( $tracking );
 		$subscriber->track_media_optimized( $process, $item );
+	}
+
+	/**
+	 * Tests that track_internal_state_reset delegates to the Tracking service.
+	 */
+	public function testTrackInternalStateResetDelegatesToTracking(): void {
+		$tracking = Mockery::mock( Tracking::class );
+
+		$tracking->shouldReceive( 'track_internal_state_reset' )->once();
+
+		$subscriber = new Subscriber( $tracking );
+		$subscriber->track_internal_state_reset();
 	}
 }

--- a/Tests/Unit/classes/Tracking/Subscriber/Test_GetSubscribedEvents.php
+++ b/Tests/Unit/classes/Tracking/Subscriber/Test_GetSubscribedEvents.php
@@ -52,4 +52,40 @@ class Test_GetSubscribedEvents extends TestCase {
 		$subscriber = new Subscriber( $tracking );
 		$subscriber->track_media_optimized( $process, $item );
 	}
+
+	/**
+	 * Tests that get_subscribed_events() maps imagify_after_restore_media correctly.
+	 */
+	public function testMapsImagifyAfterRestoreMediaHook(): void {
+		$events = Subscriber::get_subscribed_events();
+
+		$this->assertArrayHasKey( 'imagify_after_restore_media', $events );
+	}
+
+	/**
+	 * Tests that the restore hook maps to track_media_restored with priority 10 and 4 args.
+	 */
+	public function testRestoreHookConfigurationIsCorrect(): void {
+		$events  = Subscriber::get_subscribed_events();
+		$mapping = $events['imagify_after_restore_media'];
+
+		$this->assertSame( [ 'track_media_restored', 10, 4 ], $mapping );
+	}
+
+	/**
+	 * Tests that track_media_restored delegates to the Tracking service.
+	 */
+	public function testTrackMediaRestoredDelegatesToTracking(): void {
+		$tracking = Mockery::mock( Tracking::class );
+		$process  = Mockery::mock( ProcessInterface::class );
+		$files    = [];
+		$data     = [ 'level' => 1, 'sizes' => [] ];
+
+		$tracking->shouldReceive( 'track_media_restored' )
+			->once()
+			->with( $process, true, $files, $data );
+
+		$subscriber = new Subscriber( $tracking );
+		$subscriber->track_media_restored( $process, true, $files, $data );
+	}
 }

--- a/Tests/Unit/classes/Tracking/Tracking/Test_TrackInternalStateReset.php
+++ b/Tests/Unit/classes/Tracking/Tracking/Test_TrackInternalStateReset.php
@@ -1,0 +1,156 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Tracking\Tracking;
+
+use Brain\Monkey\Functions;
+use Imagify\Dependencies\WPMedia\Mixpanel\Optin;
+use Imagify\Dependencies\WPMedia\Mixpanel\TrackingPlugin;
+use Imagify\Tests\Unit\TestCase;
+use Imagify\Tracking\Tracking;
+use Mockery;
+
+/**
+ * Tests for \Imagify\Tracking\Tracking::track_internal_state_reset().
+ *
+ * @covers \Imagify\Tracking\Tracking::track_internal_state_reset
+ * @group  Tracking
+ */
+class Test_TrackInternalStateReset extends TestCase {
+
+	/**
+	 * Creates a Tracking instance with mocked dependencies.
+	 *
+	 * @param bool $can_track Whether tracking is allowed.
+	 *
+	 * @return array{tracking: Tracking, optin: \Mockery\MockInterface&Optin, mixpanel: \Mockery\MockInterface&TrackingPlugin}
+	 */
+	private function create_tracking( bool $can_track = true ): array {
+		$optin    = Mockery::mock( Optin::class );
+		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$optin->shouldReceive( 'can_track' )->andReturn( $can_track );
+
+		Functions\when( 'get_imagify_user' )->justReturn( (object) [ 'email' => 'user@example.com' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+
+		$tracking = new Tracking( $optin, $mixpanel );
+
+		return compact( 'tracking', 'optin', 'mixpanel' );
+	}
+
+	/**
+	 * Tests that no event is tracked when opt-in is disabled.
+	 */
+	public function testDoesNotTrackWhenOptInDisabled(): void {
+		$mocks    = $this->create_tracking( false );
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$mixpanel->shouldNotReceive( 'track_direct' );
+
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		$tracking->track_internal_state_reset();
+	}
+
+	/**
+	 * Tests that track_direct is called once with the correct event name when opt-in is enabled.
+	 */
+	public function testTracksWhenOptInEnabled(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Internal State Reset',
+				Mockery::type( 'array' )
+			);
+
+		$tracking->track_internal_state_reset();
+	}
+
+	/**
+	 * Tests that is_multisite is included and reflects false on a single-site install.
+	 */
+	public function testEventContainsIsMultisiteFalseOnSingleSite(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Internal State Reset',
+				Mockery::on(
+					function ( array $props ) {
+						return array_key_exists( 'is_multisite', $props ) && $props['is_multisite'] === false;
+					}
+				)
+			);
+
+		$tracking->track_internal_state_reset();
+	}
+
+	/**
+	 * Tests that is_multisite is true on a multisite install.
+	 */
+	public function testEventContainsIsMultisiteTrueOnMultisite(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		Functions\when( 'is_multisite' )->justReturn( true );
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Internal State Reset',
+				Mockery::on(
+					function ( array $props ) {
+						return $props['is_multisite'] === true;
+					}
+				)
+			);
+
+		$tracking->track_internal_state_reset();
+	}
+
+	/**
+	 * Tests that auto-merged properties (domain, wp_version, etc.) are NOT set inline.
+	 */
+	public function testEventDoesNotContainAutoMergedProperties(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		$forbidden = [ 'domain', 'wp_version', 'php_version', 'plugin', 'brand', 'application' ];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Internal State Reset',
+				Mockery::on(
+					function ( array $props ) use ( $forbidden ) {
+						foreach ( $forbidden as $key ) {
+							if ( array_key_exists( $key, $props ) ) {
+								return false;
+							}
+						}
+						return true;
+					}
+				)
+			);
+
+		$tracking->track_internal_state_reset();
+	}
+}

--- a/Tests/Unit/classes/Tracking/Tracking/Test_TrackMediaRestored.php
+++ b/Tests/Unit/classes/Tracking/Tracking/Test_TrackMediaRestored.php
@@ -22,229 +22,66 @@ use WP_Error;
 class Test_TrackMediaRestored extends TestCase {
 
 	/**
-	 * Creates a Tracking instance with mocked dependencies.
-	 *
-	 * @param bool $can_track Whether tracking is allowed.
-	 *
-	 * @return array{tracking: Tracking, optin: \Mockery\MockInterface&Optin, mixpanel: \Mockery\MockInterface&TrackingPlugin}
+	 * @dataProvider configTestData
 	 */
-	private function create_tracking( bool $can_track = true ): array {
+	public function testShouldBehaveAsExpected( array $config, array $expected ): void {
 		$optin    = Mockery::mock( Optin::class );
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
 
-		$optin->shouldReceive( 'can_track' )->andReturn( $can_track );
+		$optin->shouldReceive( 'can_track' )->andReturn( $config['can_track'] );
 
 		Functions\when( 'get_imagify_user' )->justReturn( (object) [ 'email' => 'user@example.com' ] );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 		Functions\when( 'is_wp_error' )->alias( function ( $thing ) {
 			return $thing instanceof WP_Error;
 		} );
-		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 
 		$tracking = new Tracking( $optin, $mixpanel );
 
-		return compact( 'tracking', 'optin', 'mixpanel' );
-	}
+		$response = $config['response'] === 'wp_error'
+			? new WP_Error( 'restore_failed', 'Failed.' )
+			: $config['response'];
 
-	/**
-	 * Creates a minimal process mock with a media context.
-	 *
-	 * @param string $context The media context ('wp', 'custom-folders', etc.).
-	 *
-	 * @return ProcessInterface&\Mockery\MockInterface
-	 */
-	private function create_process( string $context = 'wp' ) {
 		$media   = Mockery::mock( MediaInterface::class );
 		$process = Mockery::mock( ProcessInterface::class );
-
-		$media->shouldReceive( 'get_context' )->andReturn( $context );
+		$media->shouldReceive( 'get_context' )->andReturn( $config['context'] );
 		$process->shouldReceive( 'get_media' )->andReturn( $media );
-
-		return $process;
-	}
-
-	/**
-	 * Tests that no event is tracked when opt-in is disabled.
-	 */
-	public function testNoTrackWhenOptInDisabled(): void {
-		$mocks    = $this->create_tracking( false );
-		$tracking = $mocks['tracking'];
-		$mixpanel = $mocks['mixpanel'];
-
-		$mixpanel->shouldNotReceive( 'track_direct' );
-
-		$process = Mockery::mock( ProcessInterface::class );
-
-		$tracking->track_media_restored( $process, true, [], [] );
-	}
-
-	/**
-	 * Tests that no event is tracked when the response is a WP_Error.
-	 */
-	public function testNoTrackWhenResponseIsWpError(): void {
-		$mocks    = $this->create_tracking();
-		$tracking = $mocks['tracking'];
-		$mixpanel = $mocks['mixpanel'];
-
-		$mixpanel->shouldNotReceive( 'track_direct' );
-
-		$process = Mockery::mock( ProcessInterface::class );
-
-		$tracking->track_media_restored( $process, new WP_Error( 'copy_failed', 'Failed.' ), [], [] );
-	}
-
-	/**
-	 * Tests the happy path: track_direct is called once with 'Media Restored' and expected properties.
-	 * Also asserts that auto-injected properties (domain, wp_version, etc.) are NOT set inline.
-	 */
-	public function testHappyPathCallsTrackDirect(): void {
-		$mocks    = $this->create_tracking();
-		$tracking = $mocks['tracking'];
-		$mixpanel = $mocks['mixpanel'];
-
-		$process = $this->create_process( 'wp' );
-
-		$data = [
-			'level'  => 1,
-			'status' => 'optimized',
-			'sizes'  => [],
-		];
 
 		$forbidden = [ 'domain', 'wp_version', 'php_version', 'plugin', 'brand', 'application' ];
 
-		$mixpanel->shouldReceive( 'track_direct' )
-			->once()
-			->with(
-				'Media Restored',
-				Mockery::on(
-					function ( array $props ) use ( $forbidden ) {
-						foreach ( $forbidden as $key ) {
-							if ( array_key_exists( $key, $props ) ) {
+		if ( ! $expected['track_direct_called'] ) {
+			$mixpanel->shouldNotReceive( 'track_direct' );
+		} else {
+			$mixpanel->shouldReceive( 'track_direct' )
+				->once()
+				->with(
+					'Media Restored',
+					Mockery::on(
+						function ( array $props ) use ( $expected, $forbidden ) {
+							foreach ( $forbidden as $key ) {
+								if ( array_key_exists( $key, $props ) ) {
+									return false;
+								}
+							}
+
+							if ( isset( $expected['media_context'] ) && $props['media_context'] !== $expected['media_context'] ) {
 								return false;
 							}
+
+							if ( array_key_exists( 'optimization_level', $expected ) && $props['optimization_level'] !== $expected['optimization_level'] ) {
+								return false;
+							}
+
+							if ( array_key_exists( 'next_gen_format', $expected ) && $props['next_gen_format'] !== $expected['next_gen_format'] ) {
+								return false;
+							}
+
+							return true;
 						}
-						return isset( $props['context'], $props['media_context'] )
-							&& $props['media_context'] === 'wp'
-							&& $props['optimization_level'] === 1;
-					}
-				)
-			);
+					)
+				);
+		}
 
-		$tracking->track_media_restored( $process, true, [], $data );
-	}
-
-	/**
-	 * Tests that optimization_level is null when $data['level'] is not an integer.
-	 */
-	public function testOptimizationLevelIsNullWhenLevelIsFalse(): void {
-		$mocks    = $this->create_tracking();
-		$tracking = $mocks['tracking'];
-		$mixpanel = $mocks['mixpanel'];
-
-		$process = $this->create_process();
-
-		$data = [ 'level' => false, 'sizes' => [] ];
-
-		$mixpanel->shouldReceive( 'track_direct' )
-			->once()
-			->with(
-				'Media Restored',
-				Mockery::on( fn( array $props ) => $props['optimization_level'] === null )
-			);
-
-		$tracking->track_media_restored( $process, true, [], $data );
-	}
-
-	/**
-	 * Tests that optimization_level is null when $data has no 'level' key.
-	 */
-	public function testOptimizationLevelIsNullWhenLevelMissing(): void {
-		$mocks    = $this->create_tracking();
-		$tracking = $mocks['tracking'];
-		$mixpanel = $mocks['mixpanel'];
-
-		$process = $this->create_process();
-
-		$mixpanel->shouldReceive( 'track_direct' )
-			->once()
-			->with(
-				'Media Restored',
-				Mockery::on( fn( array $props ) => $props['optimization_level'] === null )
-			);
-
-		$tracking->track_media_restored( $process, true, [], [] );
-	}
-
-	/**
-	 * Tests that next_gen_format is 'avif' when the AVIF size succeeded.
-	 */
-	public function testNextGenFormatIsAvifWhenAvifSucceeds(): void {
-		$mocks    = $this->create_tracking();
-		$tracking = $mocks['tracking'];
-		$mixpanel = $mocks['mixpanel'];
-
-		$process = $this->create_process();
-
-		$avif_key = 'full' . ProcessInterface::AVIF_SUFFIX;
-		$data     = [
-			'level' => 1,
-			'sizes' => [ $avif_key => [ 'success' => true ] ],
-		];
-
-		$mixpanel->shouldReceive( 'track_direct' )
-			->once()
-			->with(
-				'Media Restored',
-				Mockery::on( fn( array $props ) => $props['next_gen_format'] === 'avif' )
-			);
-
-		$tracking->track_media_restored( $process, true, [], $data );
-	}
-
-	/**
-	 * Tests that next_gen_format is 'webp' when only the WebP size succeeded.
-	 */
-	public function testNextGenFormatIsWebpWhenWebpSucceeds(): void {
-		$mocks    = $this->create_tracking();
-		$tracking = $mocks['tracking'];
-		$mixpanel = $mocks['mixpanel'];
-
-		$process = $this->create_process();
-
-		$webp_key = 'full' . ProcessInterface::WEBP_SUFFIX;
-		$data     = [
-			'level' => 1,
-			'sizes' => [ $webp_key => [ 'success' => true ] ],
-		];
-
-		$mixpanel->shouldReceive( 'track_direct' )
-			->once()
-			->with(
-				'Media Restored',
-				Mockery::on( fn( array $props ) => $props['next_gen_format'] === 'webp' )
-			);
-
-		$tracking->track_media_restored( $process, true, [], $data );
-	}
-
-	/**
-	 * Tests that next_gen_format is null when neither AVIF nor WebP succeeded.
-	 */
-	public function testNextGenFormatIsNullWhenNoNextGenSucceeded(): void {
-		$mocks    = $this->create_tracking();
-		$tracking = $mocks['tracking'];
-		$mixpanel = $mocks['mixpanel'];
-
-		$process = $this->create_process();
-
-		$data = [ 'level' => 1, 'sizes' => [] ];
-
-		$mixpanel->shouldReceive( 'track_direct' )
-			->once()
-			->with(
-				'Media Restored',
-				Mockery::on( fn( array $props ) => $props['next_gen_format'] === null )
-			);
-
-		$tracking->track_media_restored( $process, true, [], $data );
+		$tracking->track_media_restored( $process, $response, [], $config['data'] );
 	}
 }

--- a/Tests/Unit/classes/Tracking/Tracking/Test_TrackMediaRestored.php
+++ b/Tests/Unit/classes/Tracking/Tracking/Test_TrackMediaRestored.php
@@ -1,0 +1,250 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Tracking\Tracking;
+
+use Brain\Monkey\Functions;
+use Imagify\Dependencies\WPMedia\Mixpanel\Optin;
+use Imagify\Dependencies\WPMedia\Mixpanel\TrackingPlugin;
+use Imagify\Media\MediaInterface;
+use Imagify\Optimization\Process\ProcessInterface;
+use Imagify\Tests\Unit\TestCase;
+use Imagify\Tracking\Tracking;
+use Mockery;
+use WP_Error;
+
+/**
+ * Tests for \Imagify\Tracking\Tracking::track_media_restored().
+ *
+ * @covers \Imagify\Tracking\Tracking::track_media_restored
+ * @group  Tracking
+ */
+class Test_TrackMediaRestored extends TestCase {
+
+	/**
+	 * Creates a Tracking instance with mocked dependencies.
+	 *
+	 * @param bool $can_track Whether tracking is allowed.
+	 *
+	 * @return array{tracking: Tracking, optin: \Mockery\MockInterface&Optin, mixpanel: \Mockery\MockInterface&TrackingPlugin}
+	 */
+	private function create_tracking( bool $can_track = true ): array {
+		$optin    = Mockery::mock( Optin::class );
+		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$optin->shouldReceive( 'can_track' )->andReturn( $can_track );
+
+		Functions\when( 'get_imagify_user' )->justReturn( (object) [ 'email' => 'user@example.com' ] );
+		Functions\when( 'is_wp_error' )->alias( function ( $thing ) {
+			return $thing instanceof WP_Error;
+		} );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+
+		$tracking = new Tracking( $optin, $mixpanel );
+
+		return compact( 'tracking', 'optin', 'mixpanel' );
+	}
+
+	/**
+	 * Creates a minimal process mock with a media context.
+	 *
+	 * @param string $context The media context ('wp', 'custom-folders', etc.).
+	 *
+	 * @return ProcessInterface&\Mockery\MockInterface
+	 */
+	private function create_process( string $context = 'wp' ) {
+		$media   = Mockery::mock( MediaInterface::class );
+		$process = Mockery::mock( ProcessInterface::class );
+
+		$media->shouldReceive( 'get_context' )->andReturn( $context );
+		$process->shouldReceive( 'get_media' )->andReturn( $media );
+
+		return $process;
+	}
+
+	/**
+	 * Tests that no event is tracked when opt-in is disabled.
+	 */
+	public function testNoTrackWhenOptInDisabled(): void {
+		$mocks    = $this->create_tracking( false );
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$mixpanel->shouldNotReceive( 'track_direct' );
+
+		$process = Mockery::mock( ProcessInterface::class );
+
+		$tracking->track_media_restored( $process, true, [], [] );
+	}
+
+	/**
+	 * Tests that no event is tracked when the response is a WP_Error.
+	 */
+	public function testNoTrackWhenResponseIsWpError(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$mixpanel->shouldNotReceive( 'track_direct' );
+
+		$process = Mockery::mock( ProcessInterface::class );
+
+		$tracking->track_media_restored( $process, new WP_Error( 'copy_failed', 'Failed.' ), [], [] );
+	}
+
+	/**
+	 * Tests the happy path: track_direct is called once with 'Media Restored' and expected properties.
+	 * Also asserts that auto-injected properties (domain, wp_version, etc.) are NOT set inline.
+	 */
+	public function testHappyPathCallsTrackDirect(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$process = $this->create_process( 'wp' );
+
+		$data = [
+			'level'  => 1,
+			'status' => 'optimized',
+			'sizes'  => [],
+		];
+
+		$forbidden = [ 'domain', 'wp_version', 'php_version', 'plugin', 'brand', 'application' ];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Media Restored',
+				Mockery::on(
+					function ( array $props ) use ( $forbidden ) {
+						foreach ( $forbidden as $key ) {
+							if ( array_key_exists( $key, $props ) ) {
+								return false;
+							}
+						}
+						return isset( $props['context'], $props['media_context'] )
+							&& $props['media_context'] === 'wp'
+							&& $props['optimization_level'] === 1;
+					}
+				)
+			);
+
+		$tracking->track_media_restored( $process, true, [], $data );
+	}
+
+	/**
+	 * Tests that optimization_level is null when $data['level'] is not an integer.
+	 */
+	public function testOptimizationLevelIsNullWhenLevelIsFalse(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$process = $this->create_process();
+
+		$data = [ 'level' => false, 'sizes' => [] ];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Media Restored',
+				Mockery::on( fn( array $props ) => $props['optimization_level'] === null )
+			);
+
+		$tracking->track_media_restored( $process, true, [], $data );
+	}
+
+	/**
+	 * Tests that optimization_level is null when $data has no 'level' key.
+	 */
+	public function testOptimizationLevelIsNullWhenLevelMissing(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$process = $this->create_process();
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Media Restored',
+				Mockery::on( fn( array $props ) => $props['optimization_level'] === null )
+			);
+
+		$tracking->track_media_restored( $process, true, [], [] );
+	}
+
+	/**
+	 * Tests that next_gen_format is 'avif' when the AVIF size succeeded.
+	 */
+	public function testNextGenFormatIsAvifWhenAvifSucceeds(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$process = $this->create_process();
+
+		$avif_key = 'full' . ProcessInterface::AVIF_SUFFIX;
+		$data     = [
+			'level' => 1,
+			'sizes' => [ $avif_key => [ 'success' => true ] ],
+		];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Media Restored',
+				Mockery::on( fn( array $props ) => $props['next_gen_format'] === 'avif' )
+			);
+
+		$tracking->track_media_restored( $process, true, [], $data );
+	}
+
+	/**
+	 * Tests that next_gen_format is 'webp' when only the WebP size succeeded.
+	 */
+	public function testNextGenFormatIsWebpWhenWebpSucceeds(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$process = $this->create_process();
+
+		$webp_key = 'full' . ProcessInterface::WEBP_SUFFIX;
+		$data     = [
+			'level' => 1,
+			'sizes' => [ $webp_key => [ 'success' => true ] ],
+		];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Media Restored',
+				Mockery::on( fn( array $props ) => $props['next_gen_format'] === 'webp' )
+			);
+
+		$tracking->track_media_restored( $process, true, [], $data );
+	}
+
+	/**
+	 * Tests that next_gen_format is null when neither AVIF nor WebP succeeded.
+	 */
+	public function testNextGenFormatIsNullWhenNoNextGenSucceeded(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$process = $this->create_process();
+
+		$data = [ 'level' => 1, 'sizes' => [] ];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Media Restored',
+				Mockery::on( fn( array $props ) => $props['next_gen_format'] === null )
+			);
+
+		$tracking->track_media_restored( $process, true, [], $data );
+	}
+}

--- a/Tests/Unit/classes/Tracking/Tracking/Test_TrackSettingsSaved.php
+++ b/Tests/Unit/classes/Tracking/Tracking/Test_TrackSettingsSaved.php
@@ -1,0 +1,304 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Tracking\Tracking;
+
+use Brain\Monkey\Functions;
+use Imagify\Dependencies\WPMedia\Mixpanel\Optin;
+use Imagify\Dependencies\WPMedia\Mixpanel\TrackingPlugin;
+use Imagify\Tests\Unit\TestCase;
+use Imagify\Tracking\Tracking;
+use Mockery;
+
+/**
+ * Tests for \Imagify\Tracking\Tracking::track_settings_saved().
+ *
+ * @covers \Imagify\Tracking\Tracking::track_settings_saved
+ * @group  Tracking
+ */
+class Test_TrackSettingsSaved extends TestCase {
+
+	/**
+	 * Creates a Tracking instance with mocked dependencies.
+	 *
+	 * @param bool $can_track Whether tracking is allowed.
+	 *
+	 * @return array{tracking: Tracking, optin: \Mockery\MockInterface&Optin, mixpanel: \Mockery\MockInterface&TrackingPlugin}
+	 */
+	private function create_tracking( bool $can_track = true ): array {
+		$optin    = Mockery::mock( Optin::class );
+		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$optin->shouldReceive( 'can_track' )->andReturn( $can_track );
+
+		Functions\when( 'get_imagify_user' )->justReturn( (object) [ 'email' => 'user@example.com' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+
+		$tracking = new Tracking( $optin, $mixpanel );
+
+		return compact( 'tracking', 'optin', 'mixpanel' );
+	}
+
+	/**
+	 * Returns a minimal valid settings array for the happy path.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function valid_new_value(): array {
+		return [
+			'optimization_level' => 1,
+			'auto_optimize'      => 1,
+			'resize_larger'      => 1,
+			'convert_to_webp'    => 1,
+			'convert_to_avif'    => 0,
+			'backup'             => 1,
+		];
+	}
+
+	/**
+	 * Tests that no event is tracked when opt-in is disabled.
+	 */
+	public function testNoTrackWhenOptInDisabled(): void {
+		$mocks    = $this->create_tracking( false );
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$mixpanel->shouldNotReceive( 'track_direct' );
+
+		$tracking->track_settings_saved( [], $this->valid_new_value() );
+	}
+
+	/**
+	 * Tests the happy path: track_direct() called once with 'Settings Saved'.
+	 */
+	public function testHappyPathCallsTrackDirect(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$forbidden = [ 'domain', 'wp_version', 'php_version', 'plugin', 'brand', 'application' ];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) use ( $forbidden ) {
+						foreach ( $forbidden as $key ) {
+							if ( array_key_exists( $key, $props ) ) {
+								return false;
+							}
+						}
+						return isset( $props['context'], $props['optimization_level'] );
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], $this->valid_new_value() );
+	}
+
+	/**
+	 * Tests that option keys are correctly mapped to Mixpanel property names.
+	 */
+	public function testPropertyMappingIsCorrect(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$new_value = [
+			'optimization_level' => '2',
+			'auto_optimize'      => '1',
+			'resize_larger'      => '1',
+			'convert_to_webp'    => '1',
+			'convert_to_avif'    => '1',
+			'backup'             => '1',
+		];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return 2 === $props['optimization_level']
+							&& true === $props['auto_optimize_on_upload']
+							&& true === $props['resize_larger_images']
+							&& true === $props['next_gen_images_webp']
+							&& true === $props['next_gen_images_avif']
+							&& true === $props['backup_original'];
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], $new_value );
+	}
+
+	/**
+	 * Tests that optimization_level is cast to int.
+	 */
+	public function testOptimizationLevelCastToInt(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$new_value = [ 'optimization_level' => '0' ];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return 0 === $props['optimization_level'] && is_int( $props['optimization_level'] );
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], $new_value );
+	}
+
+	/**
+	 * Tests that missing optimization_level results in null.
+	 */
+	public function testOptimizationLevelNullWhenMissing(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return null === $props['optimization_level'];
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], [] );
+	}
+
+	/**
+	 * Tests that boolean options stored as string '0' are normalised to false.
+	 */
+	public function testBooleanNormalisationFromStringZero(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$new_value = [
+			'auto_optimize'   => '0',
+			'resize_larger'   => '0',
+			'convert_to_webp' => '0',
+			'convert_to_avif' => '0',
+			'backup'          => '0',
+		];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return false === $props['auto_optimize_on_upload']
+							&& false === $props['resize_larger_images']
+							&& false === $props['next_gen_images_webp']
+							&& false === $props['next_gen_images_avif']
+							&& false === $props['backup_original'];
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], $new_value );
+	}
+
+	/**
+	 * Tests that boolean options stored as string '1' are normalised to true.
+	 */
+	public function testBooleanNormalisationFromStringOne(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$new_value = [
+			'auto_optimize'   => '1',
+			'resize_larger'   => '1',
+			'convert_to_webp' => '1',
+			'convert_to_avif' => '1',
+			'backup'          => '1',
+		];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return true === $props['auto_optimize_on_upload']
+							&& true === $props['resize_larger_images']
+							&& true === $props['next_gen_images_webp']
+							&& true === $props['next_gen_images_avif']
+							&& true === $props['backup_original'];
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], $new_value );
+	}
+
+	/**
+	 * Tests that auto-managed Mixpanel keys are not present in props passed to track_direct().
+	 */
+	public function testAutoManagedKeysNotPassedToTrackDirect(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$forbidden = [ 'domain', 'wp_version', 'php_version', 'plugin', 'brand', 'application' ];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) use ( $forbidden ) {
+						foreach ( $forbidden as $key ) {
+							if ( array_key_exists( $key, $props ) ) {
+								return false;
+							}
+						}
+						return true;
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], $this->valid_new_value() );
+	}
+
+	/**
+	 * Tests that $old_value is ignored — passing garbage as old value does not change output.
+	 */
+	public function testOldValueIgnored(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$new_value  = $this->valid_new_value();
+		$garbage_old = [ 'completely' => 'irrelevant', 'data' => 12345 ];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return isset( $props['optimization_level'] );
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( $garbage_old, $new_value );
+	}
+}

--- a/Tests/Unit/classes/Tracking/Tracking/Test_TrackSettingsSaved.php
+++ b/Tests/Unit/classes/Tracking/Tracking/Test_TrackSettingsSaved.php
@@ -47,12 +47,15 @@ class Test_TrackSettingsSaved extends TestCase {
 	 */
 	private function valid_new_value(): array {
 		return [
-			'optimization_level' => 1,
-			'auto_optimize'      => 1,
-			'resize_larger'      => 1,
-			'convert_to_webp'    => 1,
-			'convert_to_avif'    => 0,
-			'backup'             => 1,
+			'auto_optimize'          => 1,
+			'backup'                 => 1,
+			'lossless'               => 1,
+			'optimization_format'    => 'avif',
+			'display_nextgen'        => 1,
+			'display_nextgen_method' => 'picture',
+			'cdn_url'                => '',
+			'resize_larger'          => 1,
+			'resize_larger_w'        => 2560,
 		];
 	}
 
@@ -90,7 +93,7 @@ class Test_TrackSettingsSaved extends TestCase {
 								return false;
 							}
 						}
-						return isset( $props['context'], $props['optimization_level'] );
+						return isset( $props['context'], $props['optimization_format'] );
 					}
 				)
 			);
@@ -107,12 +110,15 @@ class Test_TrackSettingsSaved extends TestCase {
 		$mixpanel = $mocks['mixpanel'];
 
 		$new_value = [
-			'optimization_level' => '2',
-			'auto_optimize'      => '1',
-			'resize_larger'      => '1',
-			'convert_to_webp'    => '1',
-			'convert_to_avif'    => '1',
-			'backup'             => '1',
+			'auto_optimize'          => '1',
+			'backup'                 => '1',
+			'lossless'               => '1',
+			'optimization_format'    => 'webp',
+			'display_nextgen'        => '1',
+			'display_nextgen_method' => 'picture',
+			'cdn_url'                => 'https://cdn.example.com',
+			'resize_larger'          => '1',
+			'resize_larger_w'        => '1920',
 		];
 
 		$mixpanel->shouldReceive( 'track_direct' )
@@ -121,12 +127,15 @@ class Test_TrackSettingsSaved extends TestCase {
 				'Settings Saved',
 				Mockery::on(
 					function ( array $props ) {
-						return 2 === $props['optimization_level']
+						return 'webp' === $props['optimization_format']
+							&& true === $props['lossless']
 							&& true === $props['auto_optimize_on_upload']
+							&& true === $props['backup_original']
 							&& true === $props['resize_larger_images']
-							&& true === $props['next_gen_images_webp']
-							&& true === $props['next_gen_images_avif']
-							&& true === $props['backup_original'];
+							&& 1920 === $props['resize_larger_width']
+							&& true === $props['display_nextgen']
+							&& 'picture' === $props['display_nextgen_method']
+							&& true === $props['cdn_enabled'];
 					}
 				)
 			);
@@ -135,33 +144,9 @@ class Test_TrackSettingsSaved extends TestCase {
 	}
 
 	/**
-	 * Tests that optimization_level is cast to int.
+	 * Tests that optimization_format is null when missing.
 	 */
-	public function testOptimizationLevelCastToInt(): void {
-		$mocks    = $this->create_tracking();
-		$tracking = $mocks['tracking'];
-		$mixpanel = $mocks['mixpanel'];
-
-		$new_value = [ 'optimization_level' => '0' ];
-
-		$mixpanel->shouldReceive( 'track_direct' )
-			->once()
-			->with(
-				'Settings Saved',
-				Mockery::on(
-					function ( array $props ) {
-						return 0 === $props['optimization_level'] && is_int( $props['optimization_level'] );
-					}
-				)
-			);
-
-		$tracking->track_settings_saved( [], $new_value );
-	}
-
-	/**
-	 * Tests that missing optimization_level results in null.
-	 */
-	public function testOptimizationLevelNullWhenMissing(): void {
+	public function testOptimizationFormatNullWhenMissing(): void {
 		$mocks    = $this->create_tracking();
 		$tracking = $mocks['tracking'];
 		$mixpanel = $mocks['mixpanel'];
@@ -172,12 +157,56 @@ class Test_TrackSettingsSaved extends TestCase {
 				'Settings Saved',
 				Mockery::on(
 					function ( array $props ) {
-						return null === $props['optimization_level'];
+						return null === $props['optimization_format'];
 					}
 				)
 			);
 
 		$tracking->track_settings_saved( [], [] );
+	}
+
+	/**
+	 * Tests that resize_larger_width is cast to int.
+	 */
+	public function testResizeLargerWidthCastToInt(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return 2560 === $props['resize_larger_width'] && is_int( $props['resize_larger_width'] );
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], [ 'resize_larger_w' => '2560' ] );
+	}
+
+	/**
+	 * Tests that cdn_enabled is false when cdn_url is empty.
+	 */
+	public function testCdnEnabledFalseWhenCdnUrlEmpty(): void {
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->with(
+				'Settings Saved',
+				Mockery::on(
+					function ( array $props ) {
+						return false === $props['cdn_enabled'];
+					}
+				)
+			);
+
+		$tracking->track_settings_saved( [], [ 'cdn_url' => '' ] );
 	}
 
 	/**
@@ -190,10 +219,10 @@ class Test_TrackSettingsSaved extends TestCase {
 
 		$new_value = [
 			'auto_optimize'   => '0',
-			'resize_larger'   => '0',
-			'convert_to_webp' => '0',
-			'convert_to_avif' => '0',
 			'backup'          => '0',
+			'lossless'        => '0',
+			'display_nextgen' => '0',
+			'resize_larger'   => '0',
 		];
 
 		$mixpanel->shouldReceive( 'track_direct' )
@@ -203,10 +232,10 @@ class Test_TrackSettingsSaved extends TestCase {
 				Mockery::on(
 					function ( array $props ) {
 						return false === $props['auto_optimize_on_upload']
-							&& false === $props['resize_larger_images']
-							&& false === $props['next_gen_images_webp']
-							&& false === $props['next_gen_images_avif']
-							&& false === $props['backup_original'];
+							&& false === $props['backup_original']
+							&& false === $props['lossless']
+							&& false === $props['display_nextgen']
+							&& false === $props['resize_larger_images'];
 					}
 				)
 			);
@@ -224,10 +253,10 @@ class Test_TrackSettingsSaved extends TestCase {
 
 		$new_value = [
 			'auto_optimize'   => '1',
-			'resize_larger'   => '1',
-			'convert_to_webp' => '1',
-			'convert_to_avif' => '1',
 			'backup'          => '1',
+			'lossless'        => '1',
+			'display_nextgen' => '1',
+			'resize_larger'   => '1',
 		];
 
 		$mixpanel->shouldReceive( 'track_direct' )
@@ -237,10 +266,10 @@ class Test_TrackSettingsSaved extends TestCase {
 				Mockery::on(
 					function ( array $props ) {
 						return true === $props['auto_optimize_on_upload']
-							&& true === $props['resize_larger_images']
-							&& true === $props['next_gen_images_webp']
-							&& true === $props['next_gen_images_avif']
-							&& true === $props['backup_original'];
+							&& true === $props['backup_original']
+							&& true === $props['lossless']
+							&& true === $props['display_nextgen']
+							&& true === $props['resize_larger_images'];
 					}
 				)
 			);
@@ -285,8 +314,11 @@ class Test_TrackSettingsSaved extends TestCase {
 		$tracking = $mocks['tracking'];
 		$mixpanel = $mocks['mixpanel'];
 
-		$new_value  = $this->valid_new_value();
-		$garbage_old = [ 'completely' => 'irrelevant', 'data' => 12345 ];
+		$new_value   = $this->valid_new_value();
+		$garbage_old = [
+			'completely' => 'irrelevant',
+			'data'       => 12345,
+		];
 
 		$mixpanel->shouldReceive( 'track_direct' )
 			->once()
@@ -294,7 +326,7 @@ class Test_TrackSettingsSaved extends TestCase {
 				'Settings Saved',
 				Mockery::on(
 					function ( array $props ) {
-						return isset( $props['optimization_level'] );
+						return isset( $props['auto_optimize_on_upload'] );
 					}
 				)
 			);

--- a/classes/Tools/ResetInternalState.php
+++ b/classes/Tools/ResetInternalState.php
@@ -60,5 +60,7 @@ class ResetInternalState {
 				as_unschedule_all_actions( $hook );
 			}
 		}
+
+		do_action( 'imagify_after_reset_internal_state' );
 	}
 }

--- a/classes/Tracking/Subscriber.php
+++ b/classes/Tracking/Subscriber.php
@@ -37,7 +37,9 @@ class Subscriber implements SubscriberInterface {
 	public static function get_subscribed_events(): array {
 		return [
 			// @action imagify_after_optimize
-			'imagify_after_optimize' => [ 'track_media_optimized', 10, 2 ],
+			'imagify_after_optimize'             => [ 'track_media_optimized', 10, 2 ],
+			// @action imagify_after_reset_internal_state
+			'imagify_after_reset_internal_state' => [ 'track_internal_state_reset', 10, 0 ],
 		];
 	}
 
@@ -51,5 +53,14 @@ class Subscriber implements SubscriberInterface {
 	 */
 	public function track_media_optimized( $process, $item ): void {
 		$this->tracking->track_media_optimized( $process, $item );
+	}
+
+	/**
+	 * Track an "Internal State Reset" event after the internal state is reset.
+	 *
+	 * @return void
+	 */
+	public function track_internal_state_reset(): void {
+		$this->tracking->track_internal_state_reset();
 	}
 }

--- a/classes/Tracking/Subscriber.php
+++ b/classes/Tracking/Subscriber.php
@@ -37,7 +37,9 @@ class Subscriber implements SubscriberInterface {
 	public static function get_subscribed_events(): array {
 		return [
 			// @action imagify_after_optimize
-			'imagify_after_optimize' => [ 'track_media_optimized', 10, 2 ],
+			'imagify_after_optimize'      => [ 'track_media_optimized', 10, 2 ],
+			// @action imagify_after_restore_media
+			'imagify_after_restore_media' => [ 'track_media_restored', 10, 4 ],
 		];
 	}
 
@@ -51,5 +53,19 @@ class Subscriber implements SubscriberInterface {
 	 */
 	public function track_media_optimized( $process, $item ): void {
 		$this->tracking->track_media_optimized( $process, $item );
+	}
+
+	/**
+	 * Track a "Media Restored" event after a media file is restored.
+	 *
+	 * @param ProcessInterface $process  The optimization process instance.
+	 * @param bool|\WP_Error   $response True on success, WP_Error on failure.
+	 * @param array            $files    The list of files before restoring.
+	 * @param array            $data     The optimization data captured before deletion.
+	 *
+	 * @return void
+	 */
+	public function track_media_restored( $process, $response, array $files, array $data ): void {
+		$this->tracking->track_media_restored( $process, $response, $files, $data );
 	}
 }

--- a/classes/Tracking/Subscriber.php
+++ b/classes/Tracking/Subscriber.php
@@ -37,7 +37,11 @@ class Subscriber implements SubscriberInterface {
 	public static function get_subscribed_events(): array {
 		return [
 			// @action imagify_after_optimize
-			'imagify_after_optimize' => [ 'track_media_optimized', 10, 2 ],
+			'imagify_after_optimize'              => [ 'track_media_optimized', 10, 2 ],
+			// @action update_option_imagify_settings fires on single-site saves.
+			'update_option_imagify_settings'      => [ 'track_settings_saved', 10, 2 ],
+			// @action update_site_option_imagify_settings fires on multisite saves.
+			'update_site_option_imagify_settings' => [ 'track_settings_saved', 10, 2 ],
 		];
 	}
 
@@ -51,5 +55,22 @@ class Subscriber implements SubscriberInterface {
 	 */
 	public function track_media_optimized( $process, $item ): void {
 		$this->tracking->track_media_optimized( $process, $item );
+	}
+
+	/**
+	 * Delegate to Tracking::track_settings_saved().
+	 *
+	 * Both update_option_imagify_settings and update_site_option_imagify_settings fire
+	 * with different arg ordering (on multisite the first arg is the option name string,
+	 * not the old value). Both args are cast to array so the strict-typed downstream
+	 * signature is always satisfied. $old_value is unused downstream.
+	 *
+	 * @param mixed $old_value Old option value, or option name string on multisite.
+	 * @param mixed $new_value New option value.
+	 *
+	 * @return void
+	 */
+	public function track_settings_saved( $old_value, $new_value ): void {
+		$this->tracking->track_settings_saved( (array) $old_value, (array) $new_value );
 	}
 }

--- a/classes/Tracking/Tracking.php
+++ b/classes/Tracking/Tracking.php
@@ -13,6 +13,51 @@ use Imagify\Optimization\Process\ProcessInterface;
 class Tracking extends BaseTracking {
 
 	/**
+	 * Track a "Media Restored" event in Mixpanel.
+	 *
+	 * Fires on `imagify_after_restore_media`. Guards on opt-in and on a
+	 * successful restore — no event is emitted when `$response` is a WP_Error.
+	 *
+	 * NOTE: `$files` is intentionally unused; it is kept in the signature to
+	 * match the four-argument hook and allow WordPress to pass it cleanly.
+	 *
+	 * @param ProcessInterface $process  The optimization process instance.
+	 * @param bool|\WP_Error   $response True on success, WP_Error on failure.
+	 * @param array            $files    The list of files before restoring (unused).
+	 * @param array            $data     The optimization data captured before deletion.
+	 *
+	 * @return void
+	 */
+	public function track_media_restored( ProcessInterface $process, $response, array $files, array $data ): void {
+		if ( ! $this->can_track() ) {
+			return;
+		}
+
+		if ( is_wp_error( $response ) ) {
+			return;
+		}
+
+		$media         = $process->get_media();
+		$media_context = $media ? $media->get_context() : '';
+
+		$raw_level          = $data['level'] ?? null;
+		$optimization_level = is_int( $raw_level ) ? $raw_level : null;
+
+		$next_gen_format = $this->resolve_next_gen_format_from_data( $data );
+
+		$event_data = array_merge(
+			$this->get_default_event_properties(),
+			[
+				'media_context'      => $media_context,
+				'optimization_level' => $optimization_level,
+				'next_gen_format'    => $next_gen_format,
+			]
+		);
+
+		$this->mixpanel->track_direct( 'Media Restored', $event_data );
+	}
+
+	/**
 	 * Track a "Media Optimized" event in Mixpanel.
 	 *
 	 * @param ProcessInterface $process The optimization process instance.
@@ -91,6 +136,33 @@ class Tracking extends BaseTracking {
 		$webp_data = $data->get_size_data( $webp_size );
 
 		if ( ! empty( $webp_data['success'] ) ) {
+			return 'webp';
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolve the next-gen format from the raw optimization data array.
+	 *
+	 * Used by `track_media_restored()` because `DataInterface::get_optimization_data()`
+	 * is deleted before the `imagify_after_restore_media` hook fires; the raw
+	 * array captured beforehand is passed as the `$data` hook argument instead.
+	 *
+	 * @param array $data The optimization data returned by DataInterface::get_optimization_data().
+	 *
+	 * @return string|null 'avif', 'webp', or null.
+	 */
+	private function resolve_next_gen_format_from_data( array $data ): ?string {
+		$sizes = $data['sizes'] ?? [];
+
+		$avif_size = 'full' . ProcessInterface::AVIF_SUFFIX;
+		if ( ! empty( $sizes[ $avif_size ]['success'] ) ) {
+			return 'avif';
+		}
+
+		$webp_size = 'full' . ProcessInterface::WEBP_SUFFIX;
+		if ( ! empty( $sizes[ $webp_size ]['success'] ) ) {
 			return 'webp';
 		}
 

--- a/classes/Tracking/Tracking.php
+++ b/classes/Tracking/Tracking.php
@@ -67,6 +67,37 @@ class Tracking extends BaseTracking {
 	}
 
 	/**
+	 * Track a "Settings Saved" event in Mixpanel.
+	 *
+	 * @param array $old_value The previous option value. Intentionally unused — kept for
+	 *                         hook-signature symmetry. On multisite the first hook arg is the
+	 *                         option name (string), not the old value, so this parameter is
+	 *                         unreliable and must not be used for business logic.
+	 * @param array $new_value The new option value.
+	 *
+	 * @return void
+	 */
+	public function track_settings_saved( array $old_value, array $new_value ): void {
+		if ( ! $this->can_track() ) {
+			return;
+		}
+
+		$event_data = array_merge(
+			$this->get_default_event_properties(),
+			[
+				'optimization_level'      => isset( $new_value['optimization_level'] ) ? (int) $new_value['optimization_level'] : null,
+				'auto_optimize_on_upload' => ! empty( $new_value['auto_optimize'] ),
+				'resize_larger_images'    => ! empty( $new_value['resize_larger'] ),
+				'next_gen_images_webp'    => ! empty( $new_value['convert_to_webp'] ),
+				'next_gen_images_avif'    => ! empty( $new_value['convert_to_avif'] ),
+				'backup_original'         => ! empty( $new_value['backup'] ),
+			]
+		);
+
+		$this->mixpanel->track_direct( 'Settings Saved', $event_data );
+	}
+
+	/**
 	 * Resolve the next-gen format generated for the full size.
 	 *
 	 * @param ProcessInterface $process The optimization process instance.

--- a/classes/Tracking/Tracking.php
+++ b/classes/Tracking/Tracking.php
@@ -85,12 +85,15 @@ class Tracking extends BaseTracking {
 		$event_data = array_merge(
 			$this->get_default_event_properties(),
 			[
-				'optimization_level'      => isset( $new_value['optimization_level'] ) ? (int) $new_value['optimization_level'] : null,
+				'optimization_format'     => isset( $new_value['optimization_format'] ) ? (string) $new_value['optimization_format'] : null,
+				'lossless'                => ! empty( $new_value['lossless'] ),
 				'auto_optimize_on_upload' => ! empty( $new_value['auto_optimize'] ),
-				'resize_larger_images'    => ! empty( $new_value['resize_larger'] ),
-				'next_gen_images_webp'    => ! empty( $new_value['convert_to_webp'] ),
-				'next_gen_images_avif'    => ! empty( $new_value['convert_to_avif'] ),
 				'backup_original'         => ! empty( $new_value['backup'] ),
+				'resize_larger_images'    => ! empty( $new_value['resize_larger'] ),
+				'resize_larger_width'     => isset( $new_value['resize_larger_w'] ) ? (int) $new_value['resize_larger_w'] : null,
+				'display_nextgen'         => ! empty( $new_value['display_nextgen'] ),
+				'display_nextgen_method'  => isset( $new_value['display_nextgen_method'] ) ? (string) $new_value['display_nextgen_method'] : null,
+				'cdn_enabled'             => ! empty( $new_value['cdn_url'] ),
 			]
 		);
 

--- a/classes/Tracking/Tracking.php
+++ b/classes/Tracking/Tracking.php
@@ -67,6 +67,26 @@ class Tracking extends BaseTracking {
 	}
 
 	/**
+	 * Track an "Internal State Reset" event in Mixpanel.
+	 *
+	 * @return void
+	 */
+	public function track_internal_state_reset(): void {
+		if ( ! $this->can_track() ) {
+			return;
+		}
+
+		$event_data = array_merge(
+			$this->get_default_event_properties(),
+			[
+				'is_multisite' => is_multisite(),
+			]
+		);
+
+		$this->mixpanel->track_direct( 'Internal State Reset', $event_data );
+	}
+
+	/**
 	 * Resolve the next-gen format generated for the full size.
 	 *
 	 * @param ProcessInterface $process The optimization process instance.

--- a/docs/api/tracking.md
+++ b/docs/api/tracking.md
@@ -9,8 +9,8 @@ The `Imagify\Tracking` module wires the `wp-media/wp-mixpanel` Composer package 
 | Class | Role |
 |---|---|
 | `Imagify\Tracking\BaseTracking` | Abstract base: `can_track()`, `get_default_event_properties()` |
-| `Imagify\Tracking\Tracking` | Concrete: `track_media_optimized()` |
-| `Imagify\Tracking\Subscriber` | Subscribes to `imagify_after_optimize` and delegates to `Tracking` |
+| `Imagify\Tracking\Tracking` | Concrete: `track_media_optimized()`, `track_settings_saved()` |
+| `Imagify\Tracking\Subscriber` | Subscribes to WordPress hooks and delegates to `Tracking` |
 | `Imagify\Tracking\ServiceProvider` | Registers all module services into the DI container |
 
 The module depends on two Strauss-prefixed vendor classes:
@@ -28,13 +28,17 @@ The module depends on two Strauss-prefixed vendor classes:
 
 ---
 
-## Hook subscribed
+## Hooks subscribed
 
 | Hook | Method | Priority | Args |
 |---|---|---|---|
 | `imagify_after_optimize` | `Subscriber::track_media_optimized` | 10 | 2 (`$process`, `$item`) |
+| `update_option_imagify_settings` | `Subscriber::track_settings_saved` | 10 | 2 (`$old_value`, `$new_value`) |
+| `update_site_option_imagify_settings` | `Subscriber::track_settings_saved` | 10 | 2 (`$option`, `$new_value`) |
 
-The hook fires inside ActionScheduler (see `classes/Job/MediaOptimization.php`). Because bulk/cron runs execute without a logged-in user, the module uses `Optin::can_track()` (option-only check) and `TrackingPlugin::track_direct()` (bypasses `current_user_can`).
+`imagify_after_optimize` fires inside ActionScheduler (see `classes/Job/MediaOptimization.php`). Because bulk/cron runs execute without a logged-in user, the module uses `Optin::can_track()` (option-only check) and `TrackingPlugin::track_direct()` (bypasses `current_user_can`).
+
+`update_option_imagify_settings` fires on single-site when the option value changes. `update_site_option_imagify_settings` fires on multisite. Note the argument ordering differs between them: on multisite the first argument is the option name string, not the old value — the delegating method casts both args to array to satisfy the strict-typed `Tracking` signature, and the old value is unused downstream.
 
 ---
 
@@ -70,6 +74,30 @@ Fired after a successful full-size optimization. Guards (all must pass):
 3. `manual` — fallback.
 
 When `auto` and bulk transients are both true, `auto` wins.
+
+---
+
+## Event: Settings Saved
+
+Fired each time the Imagify settings option is actually updated (WordPress only fires `update_option_*` when the value changes). Guards:
+
+1. `can_track()` returns `true` (opt-in enabled).
+
+### Event properties
+
+| Property | Source option key | Notes |
+|---|---|---|
+| `context` | — | Always `'wp_plugin'` (from `get_default_event_properties()`) |
+| `license_owner` | — | SHA-256 hash of `get_imagify_user()->email`; empty string if not connected |
+| `user_id` | — | `get_current_user_id()` |
+| `optimization_level` | `optimization_level` | Cast to `int`; `null` if key absent |
+| `auto_optimize_on_upload` | `auto_optimize` | `bool` via `! empty()` |
+| `resize_larger_images` | `resize_larger` | `bool` via `! empty()` |
+| `next_gen_images_webp` | `convert_to_webp` | `bool` via `! empty()` |
+| `next_gen_images_avif` | `convert_to_avif` | `bool` via `! empty()` |
+| `backup_original` | `backup` | `bool` via `! empty()` |
+
+`TrackingPlugin::track_direct()` automatically merges `domain`, `wp_version`, `php_version`, `plugin`, `brand`, and `application` — these are not set manually.
 
 ---
 


### PR DESCRIPTION
# Description

Closes #1166

Each time a media file is successfully restored to its original version, a `Media Restored` event is now fired to Mixpanel. This gives the team visibility into restore rates and helps correlate rollbacks with specific optimization levels or next-gen formats.

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] Sub-task of #1122

## Detailed scenario

### What was tested

All scenarios are covered by automated tests:

- **`Test_TrackMediaRestored`** (7 tests): no event when opt-in disabled; no event when response is `WP_Error`; happy path calls `track_direct('Media Restored', ...)` once with correct `media_context` and `optimization_level`; auto-injected properties (`domain`, `wp_version`, etc.) are not set inline; `optimization_level` is `null` when `$data['level']` is `false` or missing; `next_gen_format` resolves to `'avif'`, `'webp'`, or `null` from the pre-deletion data array.
- **`Test_GetSubscribedEvents`** (3 new tests): `imagify_after_restore_media` key is present; mapping is `['track_media_restored', 10, 4]`; `Subscriber::track_media_restored()` delegates to `Tracking::track_media_restored()`.
- **`Test_GetSubscribers` (integration)** (5 tests): `ServiceProvider` provides `Subscriber::class` and `Tracking::class`; `imagify_after_restore_media` is hooked at priority 10; regression guard for `imagify_after_optimize`.

### How to test

1. Run the targeted test suites:
```bash
composer test-unit -- --filter="Test_TrackMediaRestored|Test_GetSubscribedEvents"
```
All tests should pass.

2. Verify PHPCS passes:
```bash
composer phpcs
```

3. Manual smoke test: with opt-in enabled, restore a previously optimised media from the WordPress media library and confirm a `Media Restored` event appears in the Mixpanel event stream with the correct properties. With opt-in disabled, confirm no event fires.

### Affected Features & Quality Assurance Scope

- `classes/Tracking/` module (`Tracking.php`, `Subscriber.php`)
- `imagify_after_restore_media` hook — new listener added, no changes to existing restore logic
- Mixpanel tracking pipeline — new event `Media Restored`

## Technical description

### Documentation

No public API changes. The `imagify_after_restore_media` hook already existed; this PR only attaches a listener to it.

**Key implementation note:** `DataInterface::get_optimization_data()` is deleted before the hook fires, so `next_gen_format` and `optimization_level` are derived from the raw `$data` array passed as the fourth hook argument — not from `$process->get_data()`. A dedicated private helper `resolve_next_gen_format_from_data()` handles this safely.

### New dependencies

None.

### Risks

Low. The change is purely additive — no existing restore logic is modified. If opt-in is disabled or the restore fails, the guard returns early and no tracking call is made. If the Mixpanel service is unavailable, `track_direct()` fails silently with no impact on the restore flow.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.) — Observability is provided by the Mixpanel event stream itself; no additional logging added.
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)