### PR TITLE
add filter to the return of mimes in imagify_get_mime_types.

### DIFF
--- a/inc/functions/attachments.php
+++ b/inc/functions/attachments.php
@@ -26,7 +26,7 @@ function imagify_get_mime_types( $type = null ) {
 		$mimes['pdf'] = 'application/pdf';
 	}
 
-	return $mimes;
+	return apply_filters( 'imagify_get_mime_types', $mimes );
 }
 
 /**


### PR DESCRIPTION
# Description

## Type of change
-Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario
This allows developers to hook in on the MIME types of Imagify. With this hook you can add and remove MIME types so the will not be processed by upload or bulk optimization.

### What was tested
We tested the hook in in a php 8.4 wordpress setup. We hooked in to the hook and added and removed MIME like pdf and gif. After removing them they where no longer proccesed by the optimization and the bulk optimization.

### How to test
Create a hook in your current on imagify_get_mime_types and remove a MIME type like pdf. Then upload a pdf to the media library.

### Affected Features & Quality Assurance Scope
As far as we can see none real thing will changes except the possibility of removing a mime type and give people more freedom to to say which mime types the want to optimization.

## Technical description

### Documentation
With this change, we enable developers to add and remove MIME types, allowing them to specify more precisely what they want to optimize.

### New dependencies
None

### Risks
- People adding MIME types that are not working in the optimzions self.
