### PR TITLE
Add imagify_get_mime_types filter to imagify_get_mime_types()

### DIFF
--- a/Tests/Integration/inc/functions/imagifyGetMimeTypes.php
+++ b/Tests/Integration/inc/functions/imagifyGetMimeTypes.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Imagify\Tests\Integration\Functions;
+
+use Imagify\Tests\Integration\TestCase;
+
+class Test_ImagifyGetMimeTypes extends TestCase {
+	protected $useApi = false;
+
+	public function testShouldReturnAllMimeTypesByDefault() {
+		$this->assertSame(
+			[
+				'jpg|jpeg|jpe' => 'image/jpeg',
+				'png'          => 'image/png',
+				'gif'          => 'image/gif',
+				'webp'         => 'image/webp',
+				'pdf'          => 'application/pdf',
+			],
+			imagify_get_mime_types()
+		);
+	}
+
+	public function testShouldReturnImageMimeTypesOnly() {
+		$this->assertSame(
+			[
+				'jpg|jpeg|jpe' => 'image/jpeg',
+				'png'          => 'image/png',
+				'gif'          => 'image/gif',
+				'webp'         => 'image/webp',
+			],
+			imagify_get_mime_types( 'image' )
+		);
+	}
+
+	public function testShouldReturnNotImageMimeTypesOnly() {
+		$this->assertSame(
+			[ 'pdf' => 'application/pdf' ],
+			imagify_get_mime_types( 'not-image' )
+		);
+	}
+
+	public function testShouldApplyMimeTypesFilter() {
+		$callback = function ( $mimes ) {
+			$mimes['avif'] = 'image/avif';
+			unset( $mimes['pdf'] );
+
+			return $mimes;
+		};
+
+		add_filter( 'imagify_get_mime_types', $callback );
+
+		$mimes = imagify_get_mime_types();
+
+		remove_filter( 'imagify_get_mime_types', $callback );
+
+		$this->assertSame( 'image/avif', $mimes['avif'] );
+		$this->assertArrayNotHasKey( 'pdf', $mimes );
+	}
+}

--- a/Tests/Integration/inc/functions/imagifyGetMimeTypes.php
+++ b/Tests/Integration/inc/functions/imagifyGetMimeTypes.php
@@ -56,4 +56,25 @@ class Test_ImagifyGetMimeTypes extends TestCase {
 		$this->assertSame( 'image/avif', $mimes['avif'] );
 		$this->assertArrayNotHasKey( 'pdf', $mimes );
 	}
+
+	public function testShouldDiscardMalformedFilteredMimeTypes() {
+		$callback = function ( $mimes ) {
+			$mimes['bad-bool']  = true;
+			$mimes['bad-array'] = [ 'image/png' ];
+			$mimes['not-mime']  = 'image';
+
+			return $mimes;
+		};
+
+		add_filter( 'imagify_get_mime_types', $callback );
+
+		$mimes = imagify_get_mime_types();
+
+		remove_filter( 'imagify_get_mime_types', $callback );
+
+		$this->assertArrayNotHasKey( 'bad-bool', $mimes );
+		$this->assertArrayNotHasKey( 'bad-array', $mimes );
+		$this->assertArrayNotHasKey( 'not-mime', $mimes );
+		$this->assertSame( 'image/jpeg', $mimes['jpg|jpeg|jpe'] );
+	}
 }

--- a/Tests/Unit/inc/functions/imagifyGetMimeTypes.php
+++ b/Tests/Unit/inc/functions/imagifyGetMimeTypes.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Imagify\Tests\Unit\Functions;
+
+use Brain\Monkey\Filters;
+use Imagify\Tests\Unit\TestCase;
+
+class Test_ImagifyGetMimeTypes extends TestCase {
+	/**
+	 * Test should return image mime types and PDF when no type is given.
+	 */
+	public function testShouldReturnAllMimeTypesByDefault() {
+		$this->assertSame(
+			[
+				'jpg|jpeg|jpe' => 'image/jpeg',
+				'png'          => 'image/png',
+				'gif'          => 'image/gif',
+				'webp'         => 'image/webp',
+				'pdf'          => 'application/pdf',
+			],
+			imagify_get_mime_types()
+		);
+	}
+
+	/**
+	 * Test should return only image mime types for the image type.
+	 */
+	public function testShouldReturnImageMimeTypesOnly() {
+		$this->assertSame(
+			[
+				'jpg|jpeg|jpe' => 'image/jpeg',
+				'png'          => 'image/png',
+				'gif'          => 'image/gif',
+				'webp'         => 'image/webp',
+			],
+			imagify_get_mime_types( 'image' )
+		);
+	}
+
+	/**
+	 * Test should return only PDF for the not-image type.
+	 */
+	public function testShouldReturnNotImageMimeTypesOnly() {
+		$this->assertSame(
+			[ 'pdf' => 'application/pdf' ],
+			imagify_get_mime_types( 'not-image' )
+		);
+	}
+
+	/**
+	 * Test should pass the mime types through the imagify_get_mime_types filter.
+	 */
+	public function testShouldApplyMimeTypesFilter() {
+		Filters\expectApplied( 'imagify_get_mime_types' )
+			->once()
+			->andReturn( [ 'avif' => 'image/avif' ] );
+
+		$this->assertSame( [ 'avif' => 'image/avif' ], imagify_get_mime_types() );
+	}
+
+	/**
+	 * Test should discard malformed entries returned by the filter.
+	 */
+	public function testShouldDiscardMalformedFilteredMimeTypes() {
+		Filters\expectApplied( 'imagify_get_mime_types' )
+			->once()
+			->andReturn(
+				[
+					'avif'      => 'image/avif',
+					'bad-bool'  => true,
+					'bad-array' => [ 'image/png' ],
+					'not-mime'  => 'image',
+					0           => 'image/gif',
+					''          => 'image/jpeg',
+				]
+			);
+
+		$this->assertSame( [ 'avif' => 'image/avif' ], imagify_get_mime_types() );
+	}
+}

--- a/inc/functions/attachments.php
+++ b/inc/functions/attachments.php
@@ -33,7 +33,16 @@ function imagify_get_mime_types( $type = null ) {
 	 *
 	 * @param array $mimes The mime types, as extension => mime type pairs.
 	 */
-	return wpm_apply_filters_typed( 'array', 'imagify_get_mime_types', $mimes );
+	$mimes = wpm_apply_filters_typed( 'array', 'imagify_get_mime_types', $mimes );
+
+	// Keep only well-formed extension => mime type pairs.
+	return array_filter(
+		$mimes,
+		function ( $mime, $ext ) {
+			return is_string( $ext ) && '' !== $ext && is_string( $mime ) && preg_match( '@^[a-z-]+/[a-z0-9.+-]+$@', $mime );
+		},
+		ARRAY_FILTER_USE_BOTH
+	);
 }
 
 /**

--- a/inc/functions/attachments.php
+++ b/inc/functions/attachments.php
@@ -26,7 +26,14 @@ function imagify_get_mime_types( $type = null ) {
 		$mimes['pdf'] = 'application/pdf';
 	}
 
-	return $mimes;
+	/**
+	 * Filter the mime types which could be optimized by Imagify.
+	 *
+	 * @since 2.3.1
+	 *
+	 * @param array $mimes The mime types, as extension => mime type pairs.
+	 */
+	return wpm_apply_filters_typed( 'array', 'imagify_get_mime_types', $mimes );
 }
 
 /**


### PR DESCRIPTION
# Description

Closes #1177

Adds a filter on the return value of `imagify_get_mime_types()`, allowing developers to customize the mime types Imagify considers optimizable when checking whether a file is supported.

This PR adopts community PR #1177 from @mauroTabsSpaces (credited as commit co-author), which originally proposed a plain `apply_filters()` call. Per our project standard, it was converted to `wpm_apply_filters_typed( 'array', 'imagify_get_mime_types', $mimes )` and a filter docblock was added. We adopt it internally because fork PRs cannot pass CI here: our integration tests require the `IMAGIFY_TESTS_API_KEY` secret, which GitHub does not expose to workflows triggered from forks.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- **Manual**: Without a callback registered, `imagify_get_mime_types()` returns the same array as before (default passthrough — no behavior change for existing sites). With an `add_filter( 'imagify_get_mime_types', ... )` callback registered, the returned array reflects the callback's modification. A callback returning a non-array value is coerced back to an array by `wpm_apply_filters_typed`, protecting callers from invalid filter output.

### How to test

1. In a mu-plugin, add: `add_filter( 'imagify_get_mime_types', function( $mimes ) { unset( $mimes['pdf'] ); return $mimes; } );`
2. Verify PDFs are no longer treated as optimizable (e.g. bulk optimization / media library no longer lists PDFs as supported).
3. Remove the filter and confirm behavior returns to the default (PDFs supported again, depending on the `$type` argument passed to `imagify_get_mime_types()`).

### Affected Features & Quality Assurance Scope

- `imagify_get_mime_types()` in `inc/functions/attachments.php` — used by mime-type support checks across the plugin. Default behavior is unchanged when no filter callback is registered, so regression risk is limited to code paths that explicitly hook into the new filter.

## Technical description

### Documentation

New filter `imagify_get_mime_types`:

- **Signature**: `wpm_apply_filters_typed( 'array', 'imagify_get_mime_types', $mimes )`
- **Param**: `array $mimes` — mime types as `extension => mime type` pairs. Contains images and/or PDF depending on the `$type` argument passed to `imagify_get_mime_types()`.
- **Since**: 2.3.1

### New dependencies

None.

### Risks

None identified. The change is additive (a new filter hook around an existing return value); with no callback registered, output is identical to before. `wpm_apply_filters_typed( 'array', ... )` enforces the return type, so a misbehaving third-party callback cannot corrupt the mime types array with a non-array value.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

- No new automated test was added: the change is a single-line addition of a `wpm_apply_filters_typed()` call around an existing return statement, with no branching logic to cover. Manual verification (see "What was tested") confirms both the default passthrough and the filtered path.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
