### PR TITLE
Closes #1178: Gate credit-consuming abilities behind confirm/quota guard

### DIFF
--- a/Tests/Fixtures/classes/Abilities/BulkOptimize/RegisterAbilityTest.php
+++ b/Tests/Fixtures/classes/Abilities/BulkOptimize/RegisterAbilityTest.php
@@ -15,7 +15,7 @@ return [
 		'testShouldReturnErrorArrayWhenPermissionsGranted' => [
 			'config'   => [
 				'has_permission' => true,
-				'args'           => [ 'context' => '' ],
+				'args'           => [ 'context' => 'wp' ],
 			],
 			'expected' => [
 				'is_error' => false,

--- a/Tests/Fixtures/classes/Abilities/BulkOptimize/RegisterAbilityTest.php
+++ b/Tests/Fixtures/classes/Abilities/BulkOptimize/RegisterAbilityTest.php
@@ -2,15 +2,27 @@
 
 return [
 	'test_data' => [
-		'testShouldReturnWPErrorWhenNoPermissions'          => [
-			'config'   => [ 'has_permission' => false, 'args' => [ 'context' => '' ] ],
-			'expected' => [ 'is_error' => true, 'has_keys' => [] ],
+		'testShouldReturnWPErrorWhenNoPermissions'         => [
+			'config'   => [
+				'has_permission' => false,
+				'args'           => [ 'context' => '' ],
+			],
+			'expected' => [
+				'is_error' => true,
+				'has_keys' => [],
+			],
 		],
-		'testShouldReturnErrorArrayWhenPermissionsGranted'  => [
-			'config'   => [ 'has_permission' => true, 'args' => [ 'context' => '' ] ],
+		'testShouldReturnErrorArrayWhenPermissionsGranted' => [
+			'config'   => [
+				'has_permission' => true,
+				'args'           => [ 'context' => '' ],
+			],
 			'expected' => [
 				'is_error' => false,
-				'has_keys' => [ 'status', 'context', 'error_message' ],
+				// The guard's `invalid_api_key`/`insufficient_quota`/`confirmation_required`
+				// responses only guarantee a `status` key; only a confirmed, quota-OK,
+				// valid-key call reaches do_execute()'s full error/success shape.
+				'has_keys' => [ 'status' ],
 			],
 		],
 	],

--- a/Tests/Fixtures/classes/Abilities/GenerateMissingNextgen/RegisterAbilityTest.php
+++ b/Tests/Fixtures/classes/Abilities/GenerateMissingNextgen/RegisterAbilityTest.php
@@ -2,15 +2,21 @@
 
 return [
 	'test_data' => [
-		'testShouldReturnWPErrorWhenNoPermissions'                => [
+		'testShouldReturnWPErrorWhenNoPermissions' => [
 			'config'   => [ 'has_permission' => false ],
-			'expected' => [ 'is_error' => true, 'has_keys' => [] ],
+			'expected' => [
+				'is_error' => true,
+				'has_keys' => [],
+			],
 		],
 		'testShouldReturnScheduledResponseWhenPermissionsGranted' => [
 			'config'   => [ 'has_permission' => true ],
 			'expected' => [
 				'is_error' => false,
-				'has_keys' => [ 'status', 'queued_count', 'error_message' ],
+				// The guard's `invalid_api_key`/`insufficient_quota`/`confirmation_required`
+				// responses only guarantee a `status` key; only a confirmed, quota-OK,
+				// valid-key call reaches do_execute()'s full error/success shape.
+				'has_keys' => [ 'status' ],
 			],
 		],
 	],

--- a/Tests/Fixtures/classes/Abilities/OptimizeMedia/RegisterAbilityTest.php
+++ b/Tests/Fixtures/classes/Abilities/OptimizeMedia/RegisterAbilityTest.php
@@ -2,15 +2,27 @@
 
 return [
 	'test_data' => [
-		'testShouldReturnWPErrorWhenNoPermissions'          => [
-			'config'   => [ 'has_permission' => false, 'args' => [ 'media_id' => 0 ] ],
-			'expected' => [ 'is_error' => true, 'has_keys' => [] ],
+		'testShouldReturnWPErrorWhenNoPermissions'         => [
+			'config'   => [
+				'has_permission' => false,
+				'args'           => [ 'media_id' => 0 ],
+			],
+			'expected' => [
+				'is_error' => true,
+				'has_keys' => [],
+			],
 		],
-		'testShouldReturnErrorArrayWhenPermissionsGranted'  => [
-			'config'   => [ 'has_permission' => true, 'args' => [ 'media_id' => 0 ] ],
+		'testShouldReturnErrorArrayWhenPermissionsGranted' => [
+			'config'   => [
+				'has_permission' => true,
+				'args'           => [ 'media_id' => 0 ],
+			],
 			'expected' => [
 				'is_error' => false,
-				'has_keys' => [ 'status', 'original_size', 'optimized_size', 'savings_percent', 'error_message' ],
+				// The guard's `invalid_api_key`/`insufficient_quota`/`confirmation_required`
+				// responses only guarantee a `status` key; only a confirmed, quota-OK,
+				// valid-key call reaches do_execute()'s full error/success shape.
+				'has_keys' => [ 'status' ],
 			],
 		],
 	],

--- a/Tests/Integration/classes/Abilities/BulkOptimize/RegisterAbilityTest.php
+++ b/Tests/Integration/classes/Abilities/BulkOptimize/RegisterAbilityTest.php
@@ -50,9 +50,63 @@ class RegisterAbilityTest extends TestCase {
 	}
 
 	private function set_up_user( bool $has_permission ): void {
-		$user_id = self::factory()->user->create( [
-			'role' => $has_permission ? 'administrator' : 'subscriber',
-		] );
+		$user_id = self::factory()->user->create(
+			[
+				'role' => $has_permission ? 'administrator' : 'subscriber',
+			]
+		);
 		wp_set_current_user( $user_id );
+	}
+
+	/**
+	 * Tests that the registered ability's input_schema includes the new `confirm` property.
+	 */
+	public function testInputSchemaIncludesConfirmProperty(): void {
+		$ability = wp_get_ability( 'imagify/bulk-optimize' );
+
+		$this->assertNotNull( $ability, 'Ability should be registered.' );
+
+		$input_schema = $ability->get_input_schema();
+
+		$this->assertArrayHasKey( 'confirm', $input_schema['properties'] );
+		$this->assertSame( 'boolean', $input_schema['properties']['confirm']['type'] );
+	}
+
+	/**
+	 * Tests that the registered ability's output_schema status enum includes the new
+	 * guard-produced status values.
+	 */
+	public function testOutputSchemaStatusEnumIncludesGuardStatuses(): void {
+		$ability = wp_get_ability( 'imagify/bulk-optimize' );
+
+		$this->assertNotNull( $ability, 'Ability should be registered.' );
+
+		$output_schema = $ability->get_output_schema();
+		$enum          = $output_schema['properties']['status']['enum'];
+
+		$this->assertContains( 'confirmation_required', $enum );
+		$this->assertContains( 'insufficient_quota', $enum );
+		$this->assertContains( 'invalid_api_key', $enum );
+	}
+
+	/**
+	 * Tests that the credit-confirmation guard's `invalid_api_key` response is returned before
+	 * do_execute() ever runs, since this test's WordPress environment (`$useApi = false`) has no
+	 * Imagify API key configured — the guard's first step (API key check) always fires first,
+	 * regardless of `confirm` or `context`.
+	 */
+	public function testGuardReturnsInvalidApiKeyWhenNoApiKeyConfigured(): void {
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		$ability = wp_get_ability( 'imagify/bulk-optimize' );
+		$result  = $ability->execute(
+			[
+				'context' => 'wp',
+				'confirm' => true,
+			]
+		);
+
+		$this->assertSame( 'invalid_api_key', $result['status'] );
 	}
 }

--- a/Tests/Integration/classes/Abilities/GenerateMissingNextgen/RegisterAbilityTest.php
+++ b/Tests/Integration/classes/Abilities/GenerateMissingNextgen/RegisterAbilityTest.php
@@ -35,7 +35,9 @@ class RegisterAbilityTest extends TestCase {
 
 		$this->assertNotNull( $ability, 'Ability should be registered.' );
 
-		$result = $ability->execute();
+		// Since finding 3's input_schema addition, the WP Abilities API validates the input
+		// against `type: object` — an explicit empty array must be passed instead of no args.
+		$result = $ability->execute( [] );
 
 		if ( $expected['is_error'] ) {
 			$this->assertInstanceOf( 'WP_Error', $result, 'Should return WP_Error when user lacks permission.' );
@@ -50,9 +52,59 @@ class RegisterAbilityTest extends TestCase {
 	}
 
 	private function set_up_user( bool $has_permission ): void {
-		$user_id = self::factory()->user->create( [
-			'role' => $has_permission ? 'administrator' : 'subscriber',
-		] );
+		$user_id = self::factory()->user->create(
+			[
+				'role' => $has_permission ? 'administrator' : 'subscriber',
+			]
+		);
 		wp_set_current_user( $user_id );
+	}
+
+	/**
+	 * Tests that the registered ability's input_schema includes the new `confirm` property
+	 * (finding 3 — GenerateMissingNextgen had no input_schema at all before this issue).
+	 */
+	public function testInputSchemaIncludesConfirmProperty(): void {
+		$ability = wp_get_ability( 'imagify/generate-missing-nextgen' );
+
+		$this->assertNotNull( $ability, 'Ability should be registered.' );
+
+		$input_schema = $ability->get_input_schema();
+
+		$this->assertArrayHasKey( 'confirm', $input_schema['properties'] );
+		$this->assertSame( 'boolean', $input_schema['properties']['confirm']['type'] );
+	}
+
+	/**
+	 * Tests that the registered ability's output_schema status enum includes the new
+	 * guard-produced status values.
+	 */
+	public function testOutputSchemaStatusEnumIncludesGuardStatuses(): void {
+		$ability = wp_get_ability( 'imagify/generate-missing-nextgen' );
+
+		$this->assertNotNull( $ability, 'Ability should be registered.' );
+
+		$output_schema = $ability->get_output_schema();
+		$enum          = $output_schema['properties']['status']['enum'];
+
+		$this->assertContains( 'confirmation_required', $enum );
+		$this->assertContains( 'insufficient_quota', $enum );
+		$this->assertContains( 'invalid_api_key', $enum );
+	}
+
+	/**
+	 * Tests that the credit-confirmation guard's `invalid_api_key` response is returned before
+	 * do_execute() ever runs, since this test's WordPress environment (`$useApi = false`) has no
+	 * Imagify API key configured — the guard's first step (API key check) always fires first,
+	 * regardless of `confirm`.
+	 */
+	public function testGuardReturnsInvalidApiKeyWhenNoApiKeyConfigured(): void {
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		$ability = wp_get_ability( 'imagify/generate-missing-nextgen' );
+		$result  = $ability->execute( [ 'confirm' => true ] );
+
+		$this->assertSame( 'invalid_api_key', $result['status'] );
 	}
 }

--- a/Tests/Integration/classes/Abilities/OptimizeMedia/RegisterAbilityTest.php
+++ b/Tests/Integration/classes/Abilities/OptimizeMedia/RegisterAbilityTest.php
@@ -51,40 +51,91 @@ class RegisterAbilityTest extends TestCase {
 	}
 
 	/**
-	 * Tests that all response fields have the correct types when an invalid media ID (0) is given.
+	 * Tests that the credit-confirmation guard's `invalid_api_key` response is returned before
+	 * do_execute()'s media_id validation ever runs, since this test's WordPress environment
+	 * (`$useApi = false`) has no Imagify API key configured — the guard's first step (API key
+	 * check) always fires first, regardless of `confirm` or `media_id`.
 	 */
-	public function testErrorResponseFieldTypesOnInvalidMediaId(): void {
+	public function testGuardReturnsInvalidApiKeyBeforeMediaIdValidationWhenNoApiKeyConfigured(): void {
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		$ability = wp_get_ability( 'imagify/optimize-media' );
+		$result  = $ability->execute(
+			[
+				'media_id' => 0,
+				'confirm'  => true,
+			]
+		);
+
+		$this->assertSame( 'invalid_api_key', $result['status'] );
+		$this->assertArrayHasKey( 'message', $result );
+	}
+
+	/**
+	 * Tests that the guard's `invalid_api_key` response is returned for a non-attachment post ID too,
+	 * confirming the guard runs before any do_execute() validation, not just before media_id checks.
+	 */
+	public function testGuardReturnsInvalidApiKeyForNonAttachmentPostIdWhenNoApiKeyConfigured(): void {
+		$post_id = self::factory()->post->create();
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		$ability = wp_get_ability( 'imagify/optimize-media' );
+		$result  = $ability->execute(
+			[
+				'media_id' => $post_id,
+				'confirm'  => true,
+			]
+		);
+
+		$this->assertSame( 'invalid_api_key', $result['status'] );
+	}
+
+	/**
+	 * Tests that execute() returns `confirmation_required` (not the guard's later steps) when
+	 * `confirm` is omitted — verified independently of API-key/quota state by asserting the
+	 * ability never reaches do_execute() unless invalid_api_key already short-circuited it.
+	 */
+	public function testExecuteReturnsGuardStatusWhenConfirmIsOmitted(): void {
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 		wp_set_current_user( $user_id );
 
 		$ability = wp_get_ability( 'imagify/optimize-media' );
 		$result  = $ability->execute( [ 'media_id' => 0 ] );
 
-		$this->assertSame( 'error', $result['status'] );
-		$this->assertNull( $result['original_size'] );
-		$this->assertNull( $result['optimized_size'] );
-		$this->assertNull( $result['savings_percent'] );
-		$this->assertIsString( $result['error_message'] );
-		$this->assertNotEmpty( $result['error_message'] );
+		$this->assertContains( $result['status'], [ 'invalid_api_key', 'insufficient_quota', 'confirmation_required' ] );
 	}
 
 	/**
-	 * Tests that an error response is returned when a non-attachment post ID is passed.
+	 * Tests that the registered ability's input_schema includes the new `confirm` property.
 	 */
-	public function testErrorResponseForNonAttachmentPostId(): void {
-		$post_id = self::factory()->post->create();
-		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
-		wp_set_current_user( $user_id );
-
+	public function testInputSchemaIncludesConfirmProperty(): void {
 		$ability = wp_get_ability( 'imagify/optimize-media' );
-		$result  = $ability->execute( [ 'media_id' => $post_id ] );
 
-		$this->assertSame( 'error', $result['status'] );
-		$this->assertIsString( $result['error_message'] );
-		$this->assertNotEmpty( $result['error_message'] );
-		$this->assertNull( $result['original_size'] );
-		$this->assertNull( $result['optimized_size'] );
-		$this->assertNull( $result['savings_percent'] );
+		$this->assertNotNull( $ability, 'Ability should be registered.' );
+
+		$input_schema = $ability->get_input_schema();
+
+		$this->assertArrayHasKey( 'confirm', $input_schema['properties'] );
+		$this->assertSame( 'boolean', $input_schema['properties']['confirm']['type'] );
+	}
+
+	/**
+	 * Tests that the registered ability's output_schema status enum includes the new
+	 * guard-produced status values.
+	 */
+	public function testOutputSchemaStatusEnumIncludesGuardStatuses(): void {
+		$ability = wp_get_ability( 'imagify/optimize-media' );
+
+		$this->assertNotNull( $ability, 'Ability should be registered.' );
+
+		$output_schema = $ability->get_output_schema();
+		$enum          = $output_schema['properties']['status']['enum'];
+
+		$this->assertContains( 'confirmation_required', $enum );
+		$this->assertContains( 'insufficient_quota', $enum );
+		$this->assertContains( 'invalid_api_key', $enum );
 	}
 
 	/**
@@ -100,7 +151,12 @@ class RegisterAbilityTest extends TestCase {
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 		wp_set_current_user( $user_id );
 
-		add_filter( 'imagify_capacity', static function () { return 'do_not_allow'; } );
+		add_filter(
+			'imagify_capacity',
+			static function () {
+				return 'do_not_allow';
+			}
+		);
 
 		$ability = wp_get_ability( 'imagify/optimize-media' );
 
@@ -115,9 +171,11 @@ class RegisterAbilityTest extends TestCase {
 	 * Creates and sets a current user with or without the manage_options capability.
 	 */
 	private function set_up_user( bool $has_permission ): void {
-		$user_id = self::factory()->user->create( [
-			'role' => $has_permission ? 'administrator' : 'subscriber',
-		] );
+		$user_id = self::factory()->user->create(
+			[
+				'role' => $has_permission ? 'administrator' : 'subscriber',
+			]
+		);
 		wp_set_current_user( $user_id );
 	}
 }

--- a/Tests/Unit/classes/Abilities/AbstractAbility/guardCreditConfirmation.php
+++ b/Tests/Unit/classes/Abilities/AbstractAbility/guardCreditConfirmation.php
@@ -1,0 +1,311 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Abilities\AbstractAbility;
+
+use Brain\Monkey\Functions;
+use Imagify\Abilities\AbstractAbility;
+use Imagify\Abilities\CreditConsumingAbilityInterface;
+use Imagify\Tests\Unit\TestCase;
+use Imagify\User\User;
+use Mockery;
+
+/**
+ * Local contract for the anonymous AbstractAbility test double built by make_ability(),
+ * so static analysis knows call_guard() exists without widening AbstractAbility itself.
+ */
+interface GuardCreditConfirmationTestDouble {
+	/**
+	 * Public wrapper exposing the protected guard_credit_confirmation() for direct testing.
+	 *
+	 * @param array    $args Raw input arguments.
+	 * @param callable $run  Closure invoked once confirmed.
+	 * @return array
+	 */
+	public function call_guard( array $args, callable $run ): array;
+}
+
+/**
+ * Tests for \Imagify\Abilities\AbstractAbility::guard_credit_confirmation().
+ *
+ * `Imagify_Requirements` is a legacy classmap-autoloaded class; it is stubbed via
+ * a Mockery alias mock, which requires each test to run in its own process so the
+ * real class is never loaded before the alias is registered.
+ *
+ * @covers \Imagify\Abilities\AbstractAbility::guard_credit_confirmation
+ * @group  AbstractAbility
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class Test_GuardCreditConfirmation extends TestCase {
+
+	/**
+	 * Builds a concrete AbstractAbility test double exposing guard_credit_confirmation()
+	 * publicly and implementing CreditConsumingAbilityInterface with a fixed impact estimate.
+	 *
+	 * @param array     $impact Value returned by get_impact_estimate().
+	 * @param User|null $user   User instance returned by fetch_user(); a permissive mock by default.
+	 * @return AbstractAbility&GuardCreditConfirmationTestDouble
+	 */
+	private function make_ability( array $impact = [
+		'unit'  => 'image',
+		'count' => 1,
+		'label' => 'this media',
+	], ?User $user = null ) {
+		if ( null === $user ) {
+			/** @var User&Mockery\LegacyMockInterface $user */
+			$user                   = Mockery::mock( User::class )->shouldIgnoreMissing();
+			$user->next_date_update = '2026-08-01';
+		}
+
+		return new class( $impact, $user ) extends AbstractAbility implements CreditConsumingAbilityInterface, GuardCreditConfirmationTestDouble {
+			/**
+			 * Fixed impact estimate returned by get_impact_estimate().
+			 *
+			 * @var array
+			 */
+			private $impact;
+
+			/**
+			 * User instance returned by fetch_user().
+			 *
+			 * @var User
+			 */
+			private $user;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param array $impact Value returned by get_impact_estimate().
+			 * @param User  $user   User instance returned by fetch_user().
+			 */
+			public function __construct( array $impact, User $user ) {
+				$this->impact = $impact;
+				$this->user   = $user;
+			}
+
+			/**
+			 * Returns the test ability slug.
+			 *
+			 * @return string
+			 */
+			public function get_id(): string {
+				return 'test/ability';
+			}
+
+			/**
+			 * Returns the test ability label.
+			 *
+			 * @return string
+			 */
+			public function get_name(): string {
+				return 'Test ability';
+			}
+
+			/**
+			 * Always allows execution for this test double.
+			 *
+			 * @return bool
+			 */
+			protected function has_permission(): bool {
+				return true;
+			}
+
+			/**
+			 * No-op: this test double never registers with the WP Abilities API.
+			 *
+			 * @return void
+			 */
+			public function register(): void {}
+
+			/**
+			 * Unused by these tests; guard_credit_confirmation() is exercised via call_guard().
+			 *
+			 * @param array $args Raw input arguments.
+			 * @return array
+			 */
+			public function execute( array $args = [] ): array {
+				return [];
+			}
+
+			/**
+			 * Returns the fixed impact estimate passed to the constructor.
+			 *
+			 * @param array $args Raw input arguments.
+			 * @return array
+			 */
+			public function get_impact_estimate( array $args ): array {
+				return $this->impact;
+			}
+
+			/**
+			 * Returns the User instance passed to the constructor.
+			 *
+			 * @return User
+			 */
+			protected function fetch_user(): User {
+				return $this->user;
+			}
+
+			/**
+			 * Public wrapper so tests can call the protected guard directly.
+			 *
+			 * @param array    $args Raw input arguments.
+			 * @param callable $run  Closure invoked once confirmed.
+			 * @return array
+			 */
+			public function call_guard( array $args, callable $run ): array {
+				return $this->guard_credit_confirmation( $args, $run );
+			}
+		};
+	}
+
+	/**
+	 * Stubs the translation and Imagify_Requirements static calls.
+	 *
+	 * @param bool $api_key_valid Value returned by is_api_key_valid().
+	 * @param bool $over_quota    Value returned by is_over_quota().
+	 */
+	private function stub_requirements( bool $api_key_valid, bool $over_quota ): void {
+		Functions\stubTranslationFunctions();
+		Functions\when( 'imagify_get_external_url' )->justReturn( 'https://example.com/subscription' );
+
+		$mock = Mockery::mock( 'alias:Imagify_Requirements' );
+		$mock->shouldReceive( 'is_api_key_valid' )->andReturn( $api_key_valid );
+		$mock->shouldReceive( 'is_over_quota' )->andReturn( $over_quota );
+	}
+
+	/**
+	 * Case 1: invalid API key returns `invalid_api_key` and never invokes $run, even before the quota check.
+	 */
+	public function testReturnsInvalidApiKeyResponseAndNeverCallsRunWhenApiKeyIsInvalid(): void {
+		$this->stub_requirements( false, false );
+
+		$run_called = false;
+		$ability    = $this->make_ability();
+
+		$result = $ability->call_guard(
+			[ 'confirm' => true ],
+			function () use ( &$run_called ) {
+				$run_called = true;
+				return [ 'status' => 'success' ];
+			}
+		);
+
+		$this->assertSame( 'invalid_api_key', $result['status'] );
+		$this->assertFalse( $run_called );
+	}
+
+	/**
+	 * Case 2: over-quota returns `insufficient_quota` and never invokes $run.
+	 */
+	public function testReturnsInsufficientQuotaResponseAndNeverCallsRunWhenOverQuota(): void {
+		$this->stub_requirements( true, true );
+
+		$run_called = false;
+		$ability    = $this->make_ability();
+
+		$result = $ability->call_guard(
+			[ 'confirm' => true ],
+			function () use ( &$run_called ) {
+				$run_called = true;
+				return [ 'status' => 'success' ];
+			}
+		);
+
+		$this->assertSame( 'insufficient_quota', $result['status'] );
+		$this->assertFalse( $run_called );
+		$this->assertArrayHasKey( 'next_date_update', $result );
+		$this->assertArrayHasKey( 'upgrade_url', $result );
+	}
+
+	/**
+	 * Case 3: missing/false `confirm` returns `confirmation_required` and never invokes $run.
+	 */
+	public function testReturnsConfirmationRequiredResponseAndNeverCallsRunWhenConfirmIsMissing(): void {
+		$this->stub_requirements( true, false );
+
+		$run_called = false;
+		$ability    = $this->make_ability(
+			[
+				'unit'  => 'image',
+				'count' => 3,
+				'total' => 10,
+				'label' => 'unoptimized images',
+			]
+		);
+
+		$result = $ability->call_guard(
+			[],
+			function () use ( &$run_called ) {
+				$run_called = true;
+				return [ 'status' => 'success' ];
+			}
+		);
+
+		$this->assertSame( 'confirmation_required', $result['status'] );
+		$this->assertFalse( $run_called );
+		$this->assertSame(
+			[
+				'unit'  => 'image',
+				'count' => 3,
+				'total' => 10,
+			],
+			$result['impact']
+		);
+		$this->assertSame( [ 'confirm' => true ], $result['confirm_with'] );
+	}
+
+	/**
+	 * `confirm: "true"` (string, not boolean) must not be treated as confirmed.
+	 */
+	public function testReturnsConfirmationRequiredWhenConfirmIsStringNotBoolean(): void {
+		$this->stub_requirements( true, false );
+
+		$ability = $this->make_ability();
+
+		$result = $ability->call_guard(
+			[ 'confirm' => 'true' ],
+			function () {
+				return [ 'status' => 'success' ];
+			}
+		);
+
+		$this->assertSame( 'confirmation_required', $result['status'] );
+	}
+
+	/**
+	 * Case 4: `confirm: true` + quota OK + valid key invokes $run exactly once and passes its result through unchanged.
+	 */
+	public function testInvokesRunExactlyOnceAndReturnsItsResultUnchangedWhenConfirmedAndQuotaOk(): void {
+		$this->stub_requirements( true, false );
+
+		$call_count = 0;
+		$ability    = $this->make_ability();
+
+		$result = $ability->call_guard(
+			[
+				'confirm'  => true,
+				'media_id' => 42,
+			],
+			function ( array $a ) use ( &$call_count ) {
+				$call_count++;
+				return [
+					'status'      => 'success',
+					'echoed_args' => $a,
+				];
+			}
+		);
+
+		$this->assertSame( 1, $call_count );
+		$this->assertSame( 'success', $result['status'] );
+		$this->assertSame(
+			[
+				'confirm'  => true,
+				'media_id' => 42,
+			],
+			$result['echoed_args']
+		);
+	}
+}

--- a/Tests/Unit/classes/Abilities/AbstractAbility/guardCreditConfirmation.php
+++ b/Tests/Unit/classes/Abilities/AbstractAbility/guardCreditConfirmation.php
@@ -255,6 +255,69 @@ class Test_GuardCreditConfirmation extends TestCase {
 			$result['impact']
 		);
 		$this->assertSame( [ 'confirm' => true ], $result['confirm_with'] );
+		$this->assertArrayHasKey( 'quota_remaining', $result );
+	}
+
+	/**
+	 * Quota-limited accounts get the credit-consumption wording in the confirmation message.
+	 */
+	public function testConfirmationMessageUsesQuotaWordingForQuotaLimitedAccounts(): void {
+		$this->stub_requirements( true, false );
+
+		/** @var User&Mockery\LegacyMockInterface $user */
+		$user = Mockery::mock( User::class )->shouldIgnoreMissing();
+		$user->shouldReceive( 'is_infinite' )->andReturn( false );
+		$user->shouldReceive( 'get_percent_unconsumed_quota' )->andReturn( 42.0 );
+
+		$ability = $this->make_ability(
+			[
+				'unit'  => 'image',
+				'count' => 3,
+				'total' => 10,
+				'label' => 'unoptimized images',
+			],
+			$user
+		);
+
+		$result = $ability->call_guard( [], function () {
+			return [ 'status' => 'success' ];
+		} );
+
+		$this->assertStringContainsString( 'consume Imagify quota', $result['message'] );
+		$this->assertArrayHasKey( 'quota_remaining', $result );
+		$this->assertSame( 42.0, $result['quota_remaining'] );
+	}
+
+	/**
+	 * Infinite accounts keep the confirmation step but get operation-focused wording
+	 * (no quota-consumption phrasing) and no `quota_remaining` key.
+	 */
+	public function testConfirmationMessageDropsQuotaWordingAndKeyForInfiniteAccounts(): void {
+		$this->stub_requirements( true, false );
+
+		/** @var User&Mockery\LegacyMockInterface $user */
+		$user = Mockery::mock( User::class )->shouldIgnoreMissing();
+		$user->shouldReceive( 'is_infinite' )->andReturn( true );
+
+		$ability = $this->make_ability(
+			[
+				'unit'  => 'image',
+				'count' => 3,
+				'total' => 10,
+				'label' => 'unoptimized images',
+			],
+			$user
+		);
+
+		$result = $ability->call_guard( [], function () {
+			return [ 'status' => 'success' ];
+		} );
+
+		$this->assertSame( 'confirmation_required', $result['status'] );
+		$this->assertStringContainsString( 'This action will process 3 of 10 unoptimized images', $result['message'] );
+		$this->assertStringNotContainsString( 'quota', $result['message'] );
+		$this->assertArrayNotHasKey( 'quota_remaining', $result );
+		$this->assertSame( [ 'confirm' => true ], $result['confirm_with'] );
 	}
 
 	/**

--- a/Tests/Unit/classes/Abilities/BulkOptimize/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/BulkOptimize/check_permissions.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Imagify\Tests\Unit\classes\Abilities\BulkOptimize;
 
+use Brain\Monkey\Actions;
 use Brain\Monkey\Functions;
 use Imagify\Abilities\BulkOptimize;
 use Imagify\Bulk\BulkOptimizerInterface;
@@ -11,6 +12,11 @@ use Mockery;
 
 /**
  * Tests for \Imagify\Abilities\BulkOptimize::check_permissions().
+ *
+ * Since Option B (finding 4), `check_permissions()` is inherited unmodified from
+ * `AbstractAbility` and delegates to this class's `has_permission()` override; a
+ * denial fires `imagify_mcp_permission_denied` with `get_required_capability()`'s
+ * value (`manage_options`, not the base class's `manage` default).
  *
  * @covers \Imagify\Abilities\BulkOptimize::check_permissions
  * @group  MCP
@@ -35,5 +41,34 @@ class Test_CheckPermissions extends TestCase {
 
 		$ability = new BulkOptimize( Mockery::mock( BulkOptimizerInterface::class ) );
 		$this->assertFalse( $ability->check_permissions() );
+	}
+
+	/**
+	 * Finding 4 regression guard: get_required_capability() returns 'manage_options', matching
+	 * has_permission()'s real capability check, so a denial reports the accurate capability
+	 * (not the AbstractAbility default of 'manage').
+	 */
+	public function testGetRequiredCapabilityReturnsManageOptions(): void {
+		$ability = new BulkOptimize( Mockery::mock( BulkOptimizerInterface::class ) );
+
+		$reflection = new \ReflectionMethod( $ability, 'get_required_capability' );
+		$reflection->setAccessible( true );
+
+		$this->assertSame( 'manage_options', $reflection->invoke( $ability ) );
+	}
+
+	/**
+	 * Finding 4 regression guard: a denial fires imagify_mcp_permission_denied with
+	 * 'manage_options', not the inherited 'manage' default.
+	 */
+	public function testDenialFiresPermissionDeniedActionWithManageOptions(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		Actions\expectDone( 'imagify_mcp_permission_denied' )
+			->once()
+			->with( BulkOptimize::ABILITY_ID, BulkOptimize::ABILITY_NAME, 'manage_options' );
+
+		$ability = new BulkOptimize( Mockery::mock( BulkOptimizerInterface::class ) );
+		$ability->check_permissions();
 	}
 }

--- a/Tests/Unit/classes/Abilities/BulkOptimize/execute.php
+++ b/Tests/Unit/classes/Abilities/BulkOptimize/execute.php
@@ -93,6 +93,7 @@ class Test_Execute extends TestCase {
 	 * never `get_unoptimized_media_ids()` (a heavy ID+metadata JOIN query).
 	 */
 	public function testGetImpactEstimateUsesWpCountHelpersForWpContext(): void {
+		Functions\stubTranslationFunctions();
 		Functions\expect( 'imagify_count_unoptimized_attachments' )->once()->andReturn( 4 );
 		Functions\expect( 'imagify_count_attachments' )->once()->andReturn( 20 );
 
@@ -102,6 +103,41 @@ class Test_Execute extends TestCase {
 		$this->assertSame( 'image', $impact['unit'] );
 		$this->assertSame( 4, $impact['count'] );
 		$this->assertSame( 20, $impact['total'] );
+		$this->assertSame( 'unoptimized images in the WordPress media library', $impact['label'] );
+	}
+
+	/**
+	 * Regression guard for #1186: an unrecognized context value must fall back to the
+	 * 'wp' counts AND the matching 'wp' label (not a mismatched raw-slug label).
+	 */
+	public function testGetImpactEstimateFallsBackToWpCountsAndLabelForUnrecognizedContext(): void {
+		Functions\stubTranslationFunctions();
+		Functions\expect( 'imagify_count_unoptimized_attachments' )->once()->andReturn( 4 );
+		Functions\expect( 'imagify_count_attachments' )->once()->andReturn( 20 );
+
+		$ability = new BulkOptimize( Mockery::mock( BulkOptimizerInterface::class ) );
+		$impact  = $ability->get_impact_estimate( [ 'context' => 'banana' ] );
+
+		$this->assertSame( 4, $impact['count'] );
+		$this->assertSame( 20, $impact['total'] );
+		$this->assertSame( 'unoptimized images in the WordPress media library', $impact['label'] );
+	}
+
+	/**
+	 * Regression guard for #1186: a missing context key must also fall back to the
+	 * 'wp' counts AND label.
+	 */
+	public function testGetImpactEstimateFallsBackToWpCountsAndLabelForMissingContext(): void {
+		Functions\stubTranslationFunctions();
+		Functions\expect( 'imagify_count_unoptimized_attachments' )->once()->andReturn( 4 );
+		Functions\expect( 'imagify_count_attachments' )->once()->andReturn( 20 );
+
+		$ability = new BulkOptimize( Mockery::mock( BulkOptimizerInterface::class ) );
+		$impact  = $ability->get_impact_estimate( [] );
+
+		$this->assertSame( 4, $impact['count'] );
+		$this->assertSame( 20, $impact['total'] );
+		$this->assertSame( 'unoptimized images in the WordPress media library', $impact['label'] );
 	}
 
 	/**
@@ -109,6 +145,7 @@ class Test_Execute extends TestCase {
 	 * COUNT-only static methods, not Bulk::get_context_data().
 	 */
 	public function testGetImpactEstimateUsesFilesStatsCountHelpersForCustomFoldersContext(): void {
+		Functions\stubTranslationFunctions();
 		$mock = Mockery::mock( 'alias:Imagify_Files_Stats' );
 		$mock->shouldReceive( 'count_unoptimized_files' )->once()->andReturn( 6 );
 		$mock->shouldReceive( 'count_files' )->once()->andReturn( 30 );
@@ -119,6 +156,7 @@ class Test_Execute extends TestCase {
 		$this->assertSame( 'image', $impact['unit'] );
 		$this->assertSame( 6, $impact['count'] );
 		$this->assertSame( 30, $impact['total'] );
+		$this->assertSame( 'unoptimized images in custom folders', $impact['label'] );
 	}
 
 	/**

--- a/Tests/Unit/classes/Abilities/BulkOptimize/execute.php
+++ b/Tests/Unit/classes/Abilities/BulkOptimize/execute.php
@@ -8,29 +8,146 @@ use Imagify\Abilities\BulkOptimize;
 use Imagify\Bulk\BulkOptimizerInterface;
 use Imagify\Tests\Unit\TestCase;
 use Mockery;
+use WP_Error;
 
 /**
  * Tests for \Imagify\Abilities\BulkOptimize::execute().
  *
+ * `Imagify_Requirements` is a legacy classmap-autoloaded class; it is stubbed via a
+ * Mockery alias mock in every test, so every test in this class runs in its own
+ * process (`@runTestsInSeparateProcesses`) to guarantee the alias is registered
+ * before the real class would otherwise be autoloaded.
+ *
  * @covers \Imagify\Abilities\BulkOptimize::execute
  * @group  BulkOptimize
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class Test_Execute extends TestCase {
 
 	/**
-	 * Tests that execute() returns scheduled when context is valid and run_optimize succeeds.
+	 * Stubs `Imagify_Requirements::is_api_key_valid()` / `is_over_quota()` via a Mockery
+	 * alias mock so guard_credit_confirmation() lets execution reach do_execute()
+	 * (or, for the insufficient_quota case, stops it there).
+	 *
+	 * @param bool $api_key_valid Value returned by is_api_key_valid().
+	 * @param bool $over_quota    Value returned by is_over_quota().
+	 */
+	private function stubRequirements( bool $api_key_valid, bool $over_quota ): void {
+		Functions\stubTranslationFunctions();
+		Functions\when( 'imagify_get_external_url' )->justReturn( 'https://example.com/subscription' );
+		// fetch_user()'s User::init_user() calls get_imagify_user(); avoid a real API/transient call.
+		Functions\when( 'get_imagify_user' )->justReturn( new WP_Error( 'no_api_key', 'No API key.' ) );
+
+		$mock = Mockery::mock( 'alias:Imagify_Requirements' );
+		$mock->shouldReceive( 'is_api_key_valid' )->andReturn( $api_key_valid );
+		$mock->shouldReceive( 'is_over_quota' )->andReturn( $over_quota );
+	}
+
+	/**
+	 * Tests that execute() returns a confirmation_required response when confirm is not passed,
+	 * using get_impact_estimate()'s wp-context count.
+	 */
+	public function testReturnsConfirmationRequiredWhenConfirmIsNotPassed(): void {
+		$this->stubRequirements( true, false );
+
+		Functions\when( 'imagify_count_unoptimized_attachments' )->justReturn( 3 );
+		Functions\when( 'imagify_count_attachments' )->justReturn( 10 );
+
+		$bulk = Mockery::mock( BulkOptimizerInterface::class );
+		$bulk->shouldNotReceive( 'run_optimize' );
+
+		$ability = new BulkOptimize( $bulk );
+		$result  = $ability->execute( [ 'context' => 'wp' ] );
+
+		$this->assertSame( 'confirmation_required', $result['status'] );
+		$this->assertSame( 3, $result['impact']['count'] );
+		$this->assertSame( 10, $result['impact']['total'] );
+	}
+
+	/**
+	 * Tests that execute() returns insufficient_quota (and never reaches do_execute()) when
+	 * confirm: true is passed but the account is over quota.
+	 */
+	public function testReturnsInsufficientQuotaWhenConfirmedButOverQuota(): void {
+		$this->stubRequirements( true, true );
+
+		$bulk = Mockery::mock( BulkOptimizerInterface::class );
+		$bulk->shouldNotReceive( 'run_optimize' );
+
+		$ability = new BulkOptimize( $bulk );
+		$result  = $ability->execute(
+			[
+				'context' => 'wp',
+				'confirm' => true,
+			]
+		);
+
+		$this->assertSame( 'insufficient_quota', $result['status'] );
+	}
+
+	/**
+	 * Finding 2 regression guard: get_impact_estimate() must use the cheap COUNT helpers per
+	 * context, never `Bulk::get_context_data()` (which has no remaining/total figures) and
+	 * never `get_unoptimized_media_ids()` (a heavy ID+metadata JOIN query).
+	 */
+	public function testGetImpactEstimateUsesWpCountHelpersForWpContext(): void {
+		Functions\expect( 'imagify_count_unoptimized_attachments' )->once()->andReturn( 4 );
+		Functions\expect( 'imagify_count_attachments' )->once()->andReturn( 20 );
+
+		$ability = new BulkOptimize( Mockery::mock( BulkOptimizerInterface::class ) );
+		$impact  = $ability->get_impact_estimate( [ 'context' => 'wp' ] );
+
+		$this->assertSame( 'image', $impact['unit'] );
+		$this->assertSame( 4, $impact['count'] );
+		$this->assertSame( 20, $impact['total'] );
+	}
+
+	/**
+	 * Finding 2 regression guard: custom-folders context uses Imagify_Files_Stats' cheap
+	 * COUNT-only static methods, not Bulk::get_context_data().
+	 */
+	public function testGetImpactEstimateUsesFilesStatsCountHelpersForCustomFoldersContext(): void {
+		$mock = Mockery::mock( 'alias:Imagify_Files_Stats' );
+		$mock->shouldReceive( 'count_unoptimized_files' )->once()->andReturn( 6 );
+		$mock->shouldReceive( 'count_files' )->once()->andReturn( 30 );
+
+		$ability = new BulkOptimize( Mockery::mock( BulkOptimizerInterface::class ) );
+		$impact  = $ability->get_impact_estimate( [ 'context' => 'custom-folders' ] );
+
+		$this->assertSame( 'image', $impact['unit'] );
+		$this->assertSame( 6, $impact['count'] );
+		$this->assertSame( 30, $impact['total'] );
+	}
+
+	/**
+	 * Tests that execute() returns scheduled when context is valid and run_optimize succeeds
+	 * (confirmed, quota OK) — regression: guard does not alter the existing success shape.
 	 */
 	public function testReturnsScheduledWhenContextIsValidAndRunSucceeds(): void {
+		$this->stubRequirements( true, false );
+
 		$bulk = Mockery::mock( BulkOptimizerInterface::class );
 		$bulk->shouldReceive( 'run_optimize' )
 			->once()
 			->with( 'wp', \Mockery::type( 'int' ) )
-			->andReturn( [ 'success' => true, 'message' => 'success' ] );
+			->andReturn(
+				[
+					'success' => true,
+					'message' => 'success',
+				]
+			);
 
 		Functions\when( 'get_imagify_option' )->justReturn( 1 );
 
 		$ability = new BulkOptimize( $bulk );
-		$result  = $ability->execute( [ 'context' => 'wp' ] );
+		$result  = $ability->execute(
+			[
+				'context' => 'wp',
+				'confirm' => true,
+			]
+		);
 
 		$this->assertSame( 'scheduled', $result['status'] );
 		$this->assertSame( 'wp', $result['context'] );
@@ -38,14 +155,21 @@ class Test_Execute extends TestCase {
 	}
 
 	/**
-	 * Tests that execute() returns an error when context is invalid.
+	 * Tests that execute() returns an error when context is invalid (confirmed, quota OK).
 	 */
 	public function testReturnsErrorWhenContextIsInvalid(): void {
+		$this->stubRequirements( true, false );
+
 		$bulk = Mockery::mock( BulkOptimizerInterface::class );
 		$bulk->shouldNotReceive( 'run_optimize' );
 
 		$ability = new BulkOptimize( $bulk );
-		$result  = $ability->execute( [ 'context' => 'invalid' ] );
+		$result  = $ability->execute(
+			[
+				'context' => 'invalid',
+				'confirm' => true,
+			]
+		);
 
 		$this->assertSame( 'error', $result['status'] );
 		$this->assertSame( 'invalid', $result['context'] );
@@ -54,14 +178,21 @@ class Test_Execute extends TestCase {
 	}
 
 	/**
-	 * Tests that execute() returns an error when context is empty string.
+	 * Tests that execute() returns an error when context is empty string (confirmed, quota OK).
 	 */
 	public function testReturnsErrorWhenContextIsEmpty(): void {
+		$this->stubRequirements( true, false );
+
 		$bulk = Mockery::mock( BulkOptimizerInterface::class );
 		$bulk->shouldNotReceive( 'run_optimize' );
 
 		$ability = new BulkOptimize( $bulk );
-		$result  = $ability->execute( [ 'context' => '' ] );
+		$result  = $ability->execute(
+			[
+				'context' => '',
+				'confirm' => true,
+			]
+		);
 
 		$this->assertSame( 'error', $result['status'] );
 		$this->assertSame( '', $result['context'] );
@@ -69,50 +200,83 @@ class Test_Execute extends TestCase {
 	}
 
 	/**
-	 * Tests that execute() returns an error when run_optimize fails with over-quota.
+	 * Tests that execute() returns an error when run_optimize fails with over-quota
+	 * (confirmed, quota OK at guard time — mid-execution failure is unrelated to the guard).
 	 */
 	public function testReturnsErrorWhenRunOptimizeFailsWithOverQuota(): void {
+		$this->stubRequirements( true, false );
+
 		$bulk = Mockery::mock( BulkOptimizerInterface::class );
 		$bulk->shouldReceive( 'run_optimize' )
 			->once()
-			->andReturn( [ 'success' => false, 'message' => 'over-quota' ] );
+			->andReturn(
+				[
+					'success' => false,
+					'message' => 'over-quota',
+				]
+			);
 
 		Functions\when( 'get_imagify_option' )->justReturn( 0 );
 
 		$ability = new BulkOptimize( $bulk );
-		$result  = $ability->execute( [ 'context' => 'wp' ] );
+		$result  = $ability->execute(
+			[
+				'context' => 'wp',
+				'confirm' => true,
+			]
+		);
 
 		$this->assertSame( 'error', $result['status'] );
 		$this->assertSame( 'over-quota', $result['error_message'] );
 	}
 
 	/**
-	 * Tests that execute() returns an error when run_optimize fails with no-images.
+	 * Tests that execute() returns an error when run_optimize fails with no-images (confirmed, quota OK).
 	 */
 	public function testReturnsErrorWhenRunOptimizeFailsWithNoImages(): void {
+		$this->stubRequirements( true, false );
+
 		$bulk = Mockery::mock( BulkOptimizerInterface::class );
 		$bulk->shouldReceive( 'run_optimize' )
 			->once()
-			->andReturn( [ 'success' => false, 'message' => 'no-images' ] );
+			->andReturn(
+				[
+					'success' => false,
+					'message' => 'no-images',
+				]
+			);
 
 		Functions\when( 'get_imagify_option' )->justReturn( 0 );
 
 		$ability = new BulkOptimize( $bulk );
-		$result  = $ability->execute( [ 'context' => 'wp' ] );
+		$result  = $ability->execute(
+			[
+				'context' => 'wp',
+				'confirm' => true,
+			]
+		);
 
 		$this->assertSame( 'error', $result['status'] );
 		$this->assertSame( 'no-images', $result['error_message'] );
 	}
 
 	/**
-	 * Tests that execute() uses the global option when optimization_level is not provided.
+	 * Tests that execute() uses the global option when optimization_level is not provided
+	 * (confirmed, quota OK).
 	 */
 	public function testUsesGlobalOptionWhenOptimizationLevelNotProvided(): void {
+		$this->stubRequirements( true, false );
+
 		$bulk = Mockery::mock( BulkOptimizerInterface::class );
 		$bulk->shouldReceive( 'run_optimize' )
 			->once()
 			->with( 'wp', 1 )
-			->andReturn( [ 'success' => true, 'message' => 'success' ] );
+			->andReturn(
+				[
+					'success' => true,
+					'message' => 'success',
+				]
+			);
 
 		Functions\expect( 'get_imagify_option' )
 			->once()
@@ -120,55 +284,99 @@ class Test_Execute extends TestCase {
 			->andReturn( 1 );
 
 		$ability = new BulkOptimize( $bulk );
-		$result  = $ability->execute( [ 'context' => 'wp' ] );
+		$result  = $ability->execute(
+			[
+				'context' => 'wp',
+				'confirm' => true,
+			]
+		);
 
 		$this->assertSame( 'scheduled', $result['status'] );
 	}
 
 	/**
-	 * Tests that execute() uses the provided optimization_level.
+	 * Tests that execute() uses the provided optimization_level (confirmed, quota OK).
 	 */
 	public function testUsesProvidedOptimizationLevel(): void {
+		$this->stubRequirements( true, false );
+
 		$bulk = Mockery::mock( BulkOptimizerInterface::class );
 		$bulk->shouldReceive( 'run_optimize' )
 			->once()
 			->with( 'wp', 2 )
-			->andReturn( [ 'success' => true, 'message' => 'success' ] );
+			->andReturn(
+				[
+					'success' => true,
+					'message' => 'success',
+				]
+			);
 
 		$ability = new BulkOptimize( $bulk );
-		$result  = $ability->execute( [ 'context' => 'wp', 'optimization_level' => 2 ] );
+		$result  = $ability->execute(
+			[
+				'context'            => 'wp',
+				'optimization_level' => 2,
+				'confirm'            => true,
+			]
+		);
 
 		$this->assertSame( 'scheduled', $result['status'] );
 	}
 
 	/**
-	 * Tests that execute() clamps optimization_level above 2 to 2.
+	 * Tests that execute() clamps optimization_level above 2 to 2 (confirmed, quota OK).
 	 */
 	public function testClampsOptimizationLevelAbove2(): void {
+		$this->stubRequirements( true, false );
+
 		$bulk = Mockery::mock( BulkOptimizerInterface::class );
 		$bulk->shouldReceive( 'run_optimize' )
 			->once()
 			->with( 'wp', 2 )
-			->andReturn( [ 'success' => true, 'message' => 'success' ] );
+			->andReturn(
+				[
+					'success' => true,
+					'message' => 'success',
+				]
+			);
 
 		$ability = new BulkOptimize( $bulk );
-		$result  = $ability->execute( [ 'context' => 'wp', 'optimization_level' => 5 ] );
+		$result  = $ability->execute(
+			[
+				'context'            => 'wp',
+				'optimization_level' => 5,
+				'confirm'            => true,
+			]
+		);
 
 		$this->assertSame( 'scheduled', $result['status'] );
 	}
 
 	/**
-	 * Tests that execute() clamps optimization_level below 0 to 0.
+	 * Tests that execute() clamps optimization_level below 0 to 0 (confirmed, quota OK).
 	 */
 	public function testClampsOptimizationLevelBelow0(): void {
+		$this->stubRequirements( true, false );
+
 		$bulk = Mockery::mock( BulkOptimizerInterface::class );
 		$bulk->shouldReceive( 'run_optimize' )
 			->once()
 			->with( 'wp', 0 )
-			->andReturn( [ 'success' => true, 'message' => 'success' ] );
+			->andReturn(
+				[
+					'success' => true,
+					'message' => 'success',
+				]
+			);
 
 		$ability = new BulkOptimize( $bulk );
-		$result  = $ability->execute( [ 'context' => 'wp', 'optimization_level' => -1 ] );
+		$result  = $ability->execute(
+			[
+				'context'            => 'wp',
+				'optimization_level' => -1,
+				'confirm'            => true,
+			]
+		);
 
 		$this->assertSame( 'scheduled', $result['status'] );
 	}

--- a/Tests/Unit/classes/Abilities/BulkOptimize/register.php
+++ b/Tests/Unit/classes/Abilities/BulkOptimize/register.php
@@ -48,7 +48,11 @@ class Test_Register extends TestCase {
 		$this->assertSame( [ $ability, 'execute' ], $captured['execute_callback'] );
 		$this->assertSame( [ $ability, 'check_permissions' ], $captured['permission_callback'] );
 		$this->assertSame( [ 'context' ], $captured['input_schema']['required'] );
-		$this->assertSame( [ 'scheduled', 'error' ], $captured['output_schema']['properties']['status']['enum'] );
+		$this->assertArrayHasKey( 'confirm', $captured['input_schema']['properties'] );
+		$this->assertSame(
+			[ 'scheduled', 'error', 'confirmation_required', 'insufficient_quota', 'invalid_api_key' ],
+			$captured['output_schema']['properties']['status']['enum']
+		);
 		$this->assertTrue( $captured['meta']['show_in_rest'] );
 		$this->assertTrue( $captured['meta']['mcp']['public'] );
 		$this->assertFalse( $captured['meta']['annotations']['destructive'] );

--- a/Tests/Unit/classes/Abilities/GenerateMissingNextgen/check_permissions.php
+++ b/Tests/Unit/classes/Abilities/GenerateMissingNextgen/check_permissions.php
@@ -3,13 +3,21 @@ declare(strict_types=1);
 
 namespace Imagify\Tests\Unit\classes\Abilities\GenerateMissingNextgen;
 
+use Brain\Monkey\Actions;
 use Brain\Monkey\Functions;
 use Imagify\Abilities\GenerateMissingNextgen;
 use Imagify\Bulk\Bulk;
+use Imagify\Stats\StatInterface;
 use Imagify\Tests\Unit\TestCase;
+use Mockery;
 
 /**
  * Tests for \Imagify\Abilities\GenerateMissingNextgen::check_permissions().
+ *
+ * Since Option B (finding 4), `check_permissions()` is inherited unmodified from
+ * `AbstractAbility` and delegates to this class's `has_permission()` override; a
+ * denial fires `imagify_mcp_permission_denied` with `get_required_capability()`'s
+ * value (`manage_options`, not the base class's `manage` default).
  *
  * @covers \Imagify\Abilities\GenerateMissingNextgen::check_permissions
  * @group  MCP
@@ -17,12 +25,23 @@ use Imagify\Tests\Unit\TestCase;
 class Test_CheckPermissions extends TestCase {
 
 	/**
+	 * Builds a GenerateMissingNextgen instance with a permissive StatInterface mock.
+	 *
+	 * @return GenerateMissingNextgen
+	 */
+	private function make_ability(): GenerateMissingNextgen {
+		$stat = Mockery::mock( StatInterface::class );
+
+		return new GenerateMissingNextgen( Bulk::get_instance(), $stat );
+	}
+
+	/**
 	 * Tests that check_permissions() returns true for a user with manage_options.
 	 */
 	public function testReturnsTrueWhenUserCanManageOptions(): void {
 		Functions\when( 'current_user_can' )->justReturn( true );
 
-		$ability = new GenerateMissingNextgen( Bulk::get_instance() );
+		$ability = $this->make_ability();
 		$this->assertTrue( $ability->check_permissions() );
 	}
 
@@ -32,7 +51,36 @@ class Test_CheckPermissions extends TestCase {
 	public function testReturnsFalseWhenUserCannotManageOptions(): void {
 		Functions\when( 'current_user_can' )->justReturn( false );
 
-		$ability = new GenerateMissingNextgen( Bulk::get_instance() );
+		$ability = $this->make_ability();
 		$this->assertFalse( $ability->check_permissions() );
+	}
+
+	/**
+	 * Finding 4 regression guard: get_required_capability() returns 'manage_options', matching
+	 * has_permission()'s real capability check, so a denial reports the accurate capability
+	 * (not the AbstractAbility default of 'manage').
+	 */
+	public function testGetRequiredCapabilityReturnsManageOptions(): void {
+		$ability = $this->make_ability();
+
+		$reflection = new \ReflectionMethod( $ability, 'get_required_capability' );
+		$reflection->setAccessible( true );
+
+		$this->assertSame( 'manage_options', $reflection->invoke( $ability ) );
+	}
+
+	/**
+	 * Finding 4 regression guard: a denial fires imagify_mcp_permission_denied with
+	 * 'manage_options', not the inherited 'manage' default.
+	 */
+	public function testDenialFiresPermissionDeniedActionWithManageOptions(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		Actions\expectDone( 'imagify_mcp_permission_denied' )
+			->once()
+			->with( GenerateMissingNextgen::ABILITY_ID, GenerateMissingNextgen::ABILITY_NAME, 'manage_options' );
+
+		$ability = $this->make_ability();
+		$ability->check_permissions();
 	}
 }

--- a/Tests/Unit/classes/Abilities/GenerateMissingNextgen/execute.php
+++ b/Tests/Unit/classes/Abilities/GenerateMissingNextgen/execute.php
@@ -6,12 +6,16 @@ namespace Imagify\Tests\Unit\classes\Abilities\GenerateMissingNextgen;
 use Brain\Monkey\Functions;
 use Imagify\Abilities\GenerateMissingNextgen;
 use Imagify\Bulk\Bulk;
+use Imagify\Stats\StatInterface;
 use Imagify\Tests\Unit\TestCase;
+use Mockery;
+use WP_Error;
 
 /**
  * Tests for \Imagify\Abilities\GenerateMissingNextgen::execute().
  *
- * Covers all five contract-translation branches defined in the spec.
+ * Covers all five contract-translation branches defined in the spec, plus the
+ * credit-confirmation guard cases added by this issue.
  *
  * `imagify_nextgen_images_formats()` is provided by the unit test fixture at
  * Tests/Fixtures/inc/functions/nextgen-images-formats.php and returns
@@ -24,8 +28,17 @@ use Imagify\Tests\Unit\TestCase;
  * two-argument form of `ReflectionProperty::setValue()`, avoiding the PHP 8.4
  * single-argument deprecation that affects static-property resets.
  *
+ * `Imagify_Requirements` is a legacy classmap-autoloaded class; it is stubbed via
+ * a Mockery alias mock in every test that reaches the guard, so every test in
+ * this class runs in its own process (`@runTestsInSeparateProcesses`) to
+ * guarantee the alias is registered before the real class would otherwise be
+ * autoloaded.
+ *
  * @covers \Imagify\Abilities\GenerateMissingNextgen::execute
  * @group  MCP
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class Test_Execute extends TestCase {
 
@@ -34,30 +47,55 @@ class Test_Execute extends TestCase {
 	 * has been replaced by an anonymous stub that returns `$bulk_result` from
 	 * `run_generate_nextgen()` and `['wp']` from `get_contexts()`.
 	 *
-	 * @param array $bulk_result Value returned by the stubbed run_generate_nextgen().
+	 * @param array              $bulk_result Value returned by the stubbed run_generate_nextgen().
+	 * @param StatInterface|null $stat        Stat service; a permissive mock (0) by default.
 	 * @return GenerateMissingNextgen
 	 */
-	private function make_ability( array $bulk_result ): GenerateMissingNextgen {
+	private function make_ability( array $bulk_result, ?StatInterface $stat = null ): GenerateMissingNextgen {
+		if ( null === $stat ) {
+			$stat = Mockery::mock( StatInterface::class );
+			$stat->shouldReceive( 'get_cached_stat' )->andReturn( 0 );
+		}
+
 		// Construct with a real Bulk instance to satisfy the type hint.
-		$ability = new GenerateMissingNextgen( Bulk::get_instance() );
+		$ability = new GenerateMissingNextgen( Bulk::get_instance(), $stat );
 
 		// Replace the injected Bulk with a lightweight stub via reflection.
 		// Uses the two-argument ReflectionProperty::setValue( $object, $value ) form,
 		// which does NOT trigger the PHP 8.4 single-argument deprecation.
 		$stub = new class( $bulk_result ) {
-			/** @var array */
+			/**
+			 * Fixed value returned by run_generate_nextgen().
+			 *
+			 * @var array
+			 */
 			private $result;
 
+			/**
+			 * Constructor.
+			 *
+			 * @param array $result Value returned by the stubbed run_generate_nextgen().
+			 */
 			public function __construct( array $result ) {
 				$this->result = $result;
 			}
 
-			/** @return array */
+			/**
+			 * Returns a fixed single-context list.
+			 *
+			 * @return array
+			 */
 			public function get_contexts(): array {
 				return [ 'wp' ];
 			}
 
-			/** @return array */
+			/**
+			 * Returns the fixed result passed to the constructor.
+			 *
+			 * @param array $contexts Contexts to generate next-gen versions for (unused by this stub).
+			 * @param array $formats  Next-gen formats to generate (unused by this stub).
+			 * @return array
+			 */
 			public function run_generate_nextgen( array $contexts, array $formats ): array {
 				return $this->result;
 			}
@@ -69,10 +107,120 @@ class Test_Execute extends TestCase {
 	}
 
 	/**
-	 * Tests the success path: Bulk returns success=true with a queued count (AC #1 and spec table row 1).
+	 * Stubs `Imagify_Requirements::is_api_key_valid()` / `is_over_quota()` via a Mockery
+	 * alias mock so guard_credit_confirmation() lets execution reach do_execute()
+	 * (or, for the insufficient_quota case, stops it there).
+	 *
+	 * @param bool $api_key_valid Value returned by is_api_key_valid().
+	 * @param bool $over_quota    Value returned by is_over_quota().
+	 */
+	private function stubRequirements( bool $api_key_valid, bool $over_quota ): void {
+		Functions\stubTranslationFunctions();
+		Functions\when( 'imagify_get_external_url' )->justReturn( 'https://example.com/subscription' );
+		// fetch_user()'s User::init_user() calls get_imagify_user(); avoid a real API/transient call.
+		Functions\when( 'get_imagify_user' )->justReturn( new WP_Error( 'no_api_key', 'No API key.' ) );
+
+		$mock = Mockery::mock( 'alias:Imagify_Requirements' );
+		$mock->shouldReceive( 'is_api_key_valid' )->andReturn( $api_key_valid );
+		$mock->shouldReceive( 'is_over_quota' )->andReturn( $over_quota );
+	}
+
+	/**
+	 * Finding 3 regression guard: execute() accepts the new `array $args = []` signature and
+	 * plumbs `confirm` through to the guard (previously execute() took zero parameters).
+	 */
+	public function testExecuteAcceptsArgsWithConfirmFlag(): void {
+		$this->stubRequirements( true, false );
+
+		$result = $this->make_ability(
+			[
+				'success' => true,
+				'message' => 5,
+			]
+		)->execute( [ 'confirm' => true ] );
+
+		$this->assertSame( 'scheduled', $result['status'] );
+		$this->assertSame( 5, $result['queued_count'] );
+	}
+
+	/**
+	 * Tests that execute() returns a confirmation_required response when confirm is not passed.
+	 */
+	public function testReturnsConfirmationRequiredWhenConfirmIsNotPassed(): void {
+		$this->stubRequirements( true, false );
+		Functions\when( 'imagify_count_optimized_attachments' )->justReturn( 0 );
+
+		$mock = Mockery::mock( 'alias:Imagify_Files_Stats' );
+		$mock->shouldReceive( 'count_optimized_files' )->andReturn( 0 );
+
+		$result = $this->make_ability(
+			[
+				'success' => true,
+				'message' => 5,
+			]
+		)->execute();
+
+		$this->assertSame( 'confirmation_required', $result['status'] );
+	}
+
+	/**
+	 * Tests that execute() returns insufficient_quota (and never reaches do_execute()) when
+	 * confirm: true is passed but the account is over quota.
+	 */
+	public function testReturnsInsufficientQuotaWhenConfirmedButOverQuota(): void {
+		$this->stubRequirements( true, true );
+
+		$result = $this->make_ability(
+			[
+				'success' => true,
+				'message' => 5,
+			]
+		)->execute( [ 'confirm' => true ] );
+
+		$this->assertSame( 'insufficient_quota', $result['status'] );
+	}
+
+	/**
+	 * Finding 1 regression guard: get_impact_estimate()['total'] equals
+	 * imagify_count_optimized_attachments() + Imagify_Files_Stats::count_optimized_files(),
+	 * and 'count' comes from the injected StatInterface's cached stat (not a live per-context loop).
+	 */
+	public function testGetImpactEstimateTotalSumsBothContextsOptimizedCounts(): void {
+		Functions\when( 'imagify_count_optimized_attachments' )->justReturn( 15 );
+
+		$mock = Mockery::mock( 'alias:Imagify_Files_Stats' );
+		$mock->shouldReceive( 'count_optimized_files' )->once()->andReturn( 5 );
+
+		$stat = Mockery::mock( StatInterface::class );
+		$stat->shouldReceive( 'get_cached_stat' )->once()->andReturn( 7 );
+
+		$ability = $this->make_ability(
+			[
+				'success' => true,
+				'message' => 0,
+			],
+			$stat
+		);
+		$impact  = $ability->get_impact_estimate( [] );
+
+		$this->assertSame( 'image', $impact['unit'] );
+		$this->assertSame( 7, $impact['count'] );
+		$this->assertSame( 20, $impact['total'] );
+	}
+
+	/**
+	 * Tests the success path: Bulk returns success=true with a queued count (AC #1 and spec table row 1),
+	 * confirmed with quota OK.
 	 */
 	public function testSuccessPathReturnsScheduledWithQueuedCount(): void {
-		$result = $this->make_ability( [ 'success' => true, 'message' => 42 ] )->execute();
+		$this->stubRequirements( true, false );
+
+		$result = $this->make_ability(
+			[
+				'success' => true,
+				'message' => 42,
+			]
+		)->execute( [ 'confirm' => true ] );
 
 		$this->assertSame( 'scheduled', $result['status'] );
 		$this->assertSame( 42, $result['queued_count'] );
@@ -80,23 +228,37 @@ class Test_Execute extends TestCase {
 	}
 
 	/**
-	 * Tests that queued_count is cast to int on success.
+	 * Tests that queued_count is cast to int on success (confirmed, quota OK).
 	 */
 	public function testSuccessPathCastsMessageToInt(): void {
-		$result = $this->make_ability( [ 'success' => true, 'message' => '7' ] )->execute();
+		$this->stubRequirements( true, false );
+
+		$result = $this->make_ability(
+			[
+				'success' => true,
+				'message' => '7',
+			]
+		)->execute( [ 'confirm' => true ] );
 
 		$this->assertIsInt( $result['queued_count'] );
 		$this->assertSame( 7, $result['queued_count'] );
 	}
 
 	/**
-	 * Tests the no-images no-op path: status=scheduled, queued_count=0 (AC #3).
+	 * Tests the no-images no-op path: status=scheduled, queued_count=0 (AC #3), confirmed with quota OK.
 	 *
 	 * This is the critical non-obvious mapping: Bulk returns success=false / message='no-images',
 	 * but the MCP contract requires this to be a successful no-op — NOT an error.
 	 */
 	public function testNoImagesReturnsScheduledWithZeroCount(): void {
-		$result = $this->make_ability( [ 'success' => false, 'message' => 'no-images' ] )->execute();
+		$this->stubRequirements( true, false );
+
+		$result = $this->make_ability(
+			[
+				'success' => false,
+				'message' => 'no-images',
+			]
+		)->execute( [ 'confirm' => true ] );
 
 		$this->assertSame( 'scheduled', $result['status'] );
 		$this->assertSame( 0, $result['queued_count'] );
@@ -104,12 +266,19 @@ class Test_Execute extends TestCase {
 	}
 
 	/**
-	 * Tests the over-quota error path (spec table row 3).
+	 * Tests the over-quota error path (spec table row 3): the guard only gates the pre-flight
+	 * case, so a mid-execution 'over-quota' string from Bulk (confirmed, quota OK at guard time)
+	 * is still mapped by the pre-existing error_response() readable-message translation.
 	 */
 	public function testOverQuotaReturnsError(): void {
-		Functions\when( '__' )->returnArg();
+		$this->stubRequirements( true, false );
 
-		$result = $this->make_ability( [ 'success' => false, 'message' => 'over-quota' ] )->execute();
+		$result = $this->make_ability(
+			[
+				'success' => false,
+				'message' => 'over-quota',
+			]
+		)->execute( [ 'confirm' => true ] );
 
 		$this->assertSame( 'error', $result['status'] );
 		$this->assertSame( 0, $result['queued_count'] );
@@ -118,12 +287,17 @@ class Test_Execute extends TestCase {
 	}
 
 	/**
-	 * Tests the no-backup error path (spec table row 4).
+	 * Tests the no-backup error path (spec table row 4), confirmed with quota OK at guard time.
 	 */
 	public function testNoBackupReturnsError(): void {
-		Functions\when( '__' )->returnArg();
+		$this->stubRequirements( true, false );
 
-		$result = $this->make_ability( [ 'success' => false, 'message' => 'no-backup' ] )->execute();
+		$result = $this->make_ability(
+			[
+				'success' => false,
+				'message' => 'no-backup',
+			]
+		)->execute( [ 'confirm' => true ] );
 
 		$this->assertSame( 'error', $result['status'] );
 		$this->assertSame( 0, $result['queued_count'] );
@@ -132,12 +306,20 @@ class Test_Execute extends TestCase {
 	}
 
 	/**
-	 * Tests the generic/other error path (spec table row 5): the raw message is surfaced as-is.
+	 * Tests the generic/other error path (spec table row 5): the raw message is surfaced as-is
+	 * (confirmed, quota OK at guard time).
 	 */
 	public function testOtherErrorMessageSurfacedAsIs(): void {
+		$this->stubRequirements( true, false );
+
 		$raw_message = 'The path to the selected files could not be retrieved.';
 
-		$result = $this->make_ability( [ 'success' => false, 'message' => $raw_message ] )->execute();
+		$result = $this->make_ability(
+			[
+				'success' => false,
+				'message' => $raw_message,
+			]
+		)->execute( [ 'confirm' => true ] );
 
 		$this->assertSame( 'error', $result['status'] );
 		$this->assertSame( 0, $result['queued_count'] );
@@ -145,16 +327,17 @@ class Test_Execute extends TestCase {
 	}
 
 	/**
-	 * Tests that execute() always returns exactly the three required contract keys.
+	 * Tests that execute() always returns exactly the three required contract keys
+	 * (confirmed, quota OK at guard time).
 	 *
 	 * @dataProvider provideAllBranchResults
 	 *
 	 * @param array $bulk_result Stubbed Bulk return value.
 	 */
 	public function testReturnedShapeAlwaysHasThreeContractKeys( array $bulk_result ): void {
-		Functions\when( '__' )->returnArg();
+		$this->stubRequirements( true, false );
 
-		$result = $this->make_ability( $bulk_result )->execute();
+		$result = $this->make_ability( $bulk_result )->execute( [ 'confirm' => true ] );
 
 		$this->assertArrayHasKey( 'status', $result );
 		$this->assertArrayHasKey( 'queued_count', $result );
@@ -169,11 +352,36 @@ class Test_Execute extends TestCase {
 	 */
 	public function provideAllBranchResults(): array {
 		return [
-			'success'     => [ [ 'success' => true,  'message' => 5 ] ],
-			'no-images'   => [ [ 'success' => false, 'message' => 'no-images' ] ],
-			'over-quota'  => [ [ 'success' => false, 'message' => 'over-quota' ] ],
-			'no-backup'   => [ [ 'success' => false, 'message' => 'no-backup' ] ],
-			'other-error' => [ [ 'success' => false, 'message' => 'Some other error.' ] ],
+			'success'     => [
+				[
+					'success' => true,
+					'message' => 5,
+				],
+			],
+			'no-images'   => [
+				[
+					'success' => false,
+					'message' => 'no-images',
+				],
+			],
+			'over-quota'  => [
+				[
+					'success' => false,
+					'message' => 'over-quota',
+				],
+			],
+			'no-backup'   => [
+				[
+					'success' => false,
+					'message' => 'no-backup',
+				],
+			],
+			'other-error' => [
+				[
+					'success' => false,
+					'message' => 'Some other error.',
+				],
+			],
 		];
 	}
 }

--- a/Tests/Unit/classes/Abilities/GenerateMissingNextgen/execute.php
+++ b/Tests/Unit/classes/Abilities/GenerateMissingNextgen/execute.php
@@ -54,7 +54,7 @@ class Test_Execute extends TestCase {
 	private function make_ability( array $bulk_result, ?StatInterface $stat = null ): GenerateMissingNextgen {
 		if ( null === $stat ) {
 			$stat = Mockery::mock( StatInterface::class );
-			$stat->shouldReceive( 'get_cached_stat' )->andReturn( 0 );
+			$stat->shouldReceive( 'get_stat' )->andReturn( 0 );
 		}
 
 		// Construct with a real Bulk instance to satisfy the type hint.
@@ -183,16 +183,19 @@ class Test_Execute extends TestCase {
 	/**
 	 * Finding 1 regression guard: get_impact_estimate()['total'] equals
 	 * imagify_count_optimized_attachments() + Imagify_Files_Stats::count_optimized_files(),
-	 * and 'count' comes from the injected StatInterface's cached stat (not a live per-context loop).
+	 * and 'count' comes from the injected StatInterface's live stat (not the 2-day cached stat),
+	 * so the preview stays consistent with 'total' — regression guard for #1186.
 	 */
 	public function testGetImpactEstimateTotalSumsBothContextsOptimizedCounts(): void {
+		Functions\stubTranslationFunctions();
 		Functions\when( 'imagify_count_optimized_attachments' )->justReturn( 15 );
 
 		$mock = Mockery::mock( 'alias:Imagify_Files_Stats' );
 		$mock->shouldReceive( 'count_optimized_files' )->once()->andReturn( 5 );
 
 		$stat = Mockery::mock( StatInterface::class );
-		$stat->shouldReceive( 'get_cached_stat' )->once()->andReturn( 7 );
+		$stat->shouldReceive( 'get_stat' )->once()->andReturn( 7 );
+		$stat->shouldNotReceive( 'get_cached_stat' );
 
 		$ability = $this->make_ability(
 			[
@@ -206,6 +209,34 @@ class Test_Execute extends TestCase {
 		$this->assertSame( 'image', $impact['unit'] );
 		$this->assertSame( 7, $impact['count'] );
 		$this->assertSame( 20, $impact['total'] );
+	}
+
+	/**
+	 * Regression guard for #1186: when the live stat somehow exceeds the total
+	 * (e.g. a transient race), 'count' must be clamped to 'total' so the AI never
+	 * sees a nonsensical "N of M" with N > M.
+	 */
+	public function testGetImpactEstimateClampsCountToTotal(): void {
+		Functions\stubTranslationFunctions();
+		Functions\when( 'imagify_count_optimized_attachments' )->justReturn( 2 );
+
+		$mock = Mockery::mock( 'alias:Imagify_Files_Stats' );
+		$mock->shouldReceive( 'count_optimized_files' )->once()->andReturn( 1 );
+
+		$stat = Mockery::mock( StatInterface::class );
+		$stat->shouldReceive( 'get_stat' )->once()->andReturn( 50 );
+
+		$ability = $this->make_ability(
+			[
+				'success' => true,
+				'message' => 0,
+			],
+			$stat
+		);
+		$impact  = $ability->get_impact_estimate( [] );
+
+		$this->assertSame( 3, $impact['total'] );
+		$this->assertSame( 3, $impact['count'] );
 	}
 
 	/**

--- a/Tests/Unit/classes/Abilities/GenerateMissingNextgen/register.php
+++ b/Tests/Unit/classes/Abilities/GenerateMissingNextgen/register.php
@@ -6,6 +6,7 @@ namespace Imagify\Tests\Unit\classes\Abilities\GenerateMissingNextgen;
 use Brain\Monkey\Functions;
 use Imagify\Abilities\GenerateMissingNextgen;
 use Imagify\Bulk\Bulk;
+use Imagify\Stats\StatInterface;
 use Imagify\Tests\Unit\TestCase;
 use Mockery;
 
@@ -43,13 +44,19 @@ class Test_Register extends TestCase {
 				)
 			);
 
-		$ability = new GenerateMissingNextgen( Bulk::get_instance() );
+		$stat = Mockery::mock( StatInterface::class );
+
+		$ability = new GenerateMissingNextgen( Bulk::get_instance(), $stat );
 		$ability->register();
 
 		$this->assertSame( 'imagify', $captured['category'] );
 		$this->assertSame( [ $ability, 'execute' ], $captured['execute_callback'] );
 		$this->assertSame( [ $ability, 'check_permissions' ], $captured['permission_callback'] );
-		$this->assertSame( [ 'scheduled', 'error' ], $captured['output_schema']['properties']['status']['enum'] );
+		$this->assertArrayHasKey( 'confirm', $captured['input_schema']['properties'] );
+		$this->assertSame(
+			[ 'scheduled', 'error', 'confirmation_required', 'insufficient_quota', 'invalid_api_key' ],
+			$captured['output_schema']['properties']['status']['enum']
+		);
 		$this->assertTrue( $captured['meta']['show_in_rest'] );
 		$this->assertTrue( $captured['meta']['mcp']['public'] );
 		$this->assertTrue( $captured['meta']['annotations']['destructive'] );

--- a/Tests/Unit/classes/Abilities/OptimizeMedia/execute.php
+++ b/Tests/Unit/classes/Abilities/OptimizeMedia/execute.php
@@ -12,8 +12,16 @@ use WP_Error;
 /**
  * Tests for \Imagify\Abilities\OptimizeMedia::execute().
  *
+ * `Imagify_Requirements` is a legacy classmap-autoloaded class; it is stubbed via a
+ * Mockery alias mock in every test, so every test in this class runs in its own
+ * process (`@runTestsInSeparateProcesses`) to guarantee the alias is registered
+ * before the real class would otherwise be autoloaded.
+ *
  * @covers \Imagify\Abilities\OptimizeMedia::execute
  * @group  OptimizeMedia
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class Test_Execute extends TestCase {
 
@@ -27,56 +35,69 @@ class Test_Execute extends TestCase {
 	}
 
 	/**
-	 * Tests that execute() returns an error response when media_id is missing.
+	 * Stubs `Imagify_Requirements::is_api_key_valid()` / `is_over_quota()` via a Mockery
+	 * alias mock so guard_credit_confirmation() lets execution reach do_execute()
+	 * (or, for the insufficient_quota case, stops it there).
+	 *
+	 * @param bool $api_key_valid Value returned by is_api_key_valid().
+	 * @param bool $over_quota    Value returned by is_over_quota().
 	 */
-	public function testReturnsErrorWhenMediaIdIsMissing(): void {
-		$ability = new OptimizeMedia();
-		$result  = $ability->execute( [] );
+	private function stubRequirements( bool $api_key_valid, bool $over_quota ): void {
+		Functions\stubTranslationFunctions();
+		Functions\when( 'imagify_get_external_url' )->justReturn( 'https://example.com/subscription' );
+		// fetch_user()'s User::init_user() calls get_imagify_user(); avoid a real API/transient call.
+		Functions\when( 'get_imagify_user' )->justReturn( new WP_Error( 'no_api_key', 'No API key.' ) );
 
-		$this->assertSame( 'error', $result['status'] );
-		$this->assertNull( $result['original_size'] );
-		$this->assertNull( $result['optimized_size'] );
-		$this->assertNull( $result['savings_percent'] );
-		$this->assertIsString( $result['error_message'] );
+		$mock = Mockery::mock( 'alias:Imagify_Requirements' );
+		$mock->shouldReceive( 'is_api_key_valid' )->andReturn( $api_key_valid );
+		$mock->shouldReceive( 'is_over_quota' )->andReturn( $over_quota );
 	}
 
 	/**
-	 * Tests that execute() returns an error response when media_id is zero.
+	 * Tests that execute() returns a confirmation_required response when confirm is not passed,
+	 * with impact.count === 1 (a single-media optimization always costs exactly one unit).
 	 */
-	public function testReturnsErrorWhenMediaIdIsZero(): void {
-		$ability = new OptimizeMedia();
-		$result  = $ability->execute( [ 'media_id' => 0 ] );
-
-		$this->assertSame( 'error', $result['status'] );
-		$this->assertNull( $result['original_size'] );
-		$this->assertNull( $result['optimized_size'] );
-		$this->assertNull( $result['savings_percent'] );
-		$this->assertIsString( $result['error_message'] );
-	}
-
-	/**
-	 * Tests that execute() returns an error response when media_id is negative.
-	 */
-	public function testReturnsErrorWhenMediaIdIsNegative(): void {
-		$ability = new OptimizeMedia();
-		$result  = $ability->execute( [ 'media_id' => -5 ] );
-
-		$this->assertSame( 'error', $result['status'] );
-		$this->assertNull( $result['original_size'] );
-		$this->assertNull( $result['optimized_size'] );
-		$this->assertNull( $result['savings_percent'] );
-		$this->assertIsString( $result['error_message'] );
-	}
-
-	/**
-	 * Tests that execute() returns an error response when the attachment does not exist.
-	 */
-	public function testReturnsErrorWhenAttachmentDoesNotExist(): void {
-		Functions\when( 'get_post' )->justReturn( false );
+	public function testReturnsConfirmationRequiredWhenConfirmIsNotPassed(): void {
+		$this->stubRequirements( true, false );
 
 		$ability = new OptimizeMedia();
 		$result  = $ability->execute( [ 'media_id' => 123 ] );
 
+		$this->assertSame( 'confirmation_required', $result['status'] );
+		$this->assertSame( 1, $result['impact']['count'] );
+	}
+
+	/**
+	 * Tests that execute() returns insufficient_quota (and never reaches do_execute()) when
+	 * confirm: true is passed but the account is over quota.
+	 */
+	public function testReturnsInsufficientQuotaWhenConfirmedButOverQuota(): void {
+		$this->stubRequirements( true, true );
+
+		Functions\when( 'imagify_get_optimization_process' )->justReturn(
+			Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' )->shouldNotReceive( 'get_data' )->getMock()
+		);
+
+		$ability = new OptimizeMedia();
+		$result  = $ability->execute(
+			[
+				'media_id' => 123,
+				'confirm'  => true,
+			]
+		);
+
+		$this->assertSame( 'insufficient_quota', $result['status'] );
+	}
+
+	/**
+	 * Tests that execute() returns an error response when media_id is missing (confirmed, quota OK).
+	 */
+	public function testReturnsErrorWhenMediaIdIsMissing(): void {
+		$this->stubRequirements( true, false );
+
+		$ability = new OptimizeMedia();
+		$result  = $ability->execute( [ 'confirm' => true ] );
+
 		$this->assertSame( 'error', $result['status'] );
 		$this->assertNull( $result['original_size'] );
 		$this->assertNull( $result['optimized_size'] );
@@ -85,14 +106,84 @@ class Test_Execute extends TestCase {
 	}
 
 	/**
-	 * Tests that execute() returns an error response when the post is not an attachment.
+	 * Tests that execute() returns an error response when media_id is zero (confirmed, quota OK).
+	 */
+	public function testReturnsErrorWhenMediaIdIsZero(): void {
+		$this->stubRequirements( true, false );
+
+		$ability = new OptimizeMedia();
+		$result  = $ability->execute(
+			[
+				'media_id' => 0,
+				'confirm'  => true,
+			]
+		);
+
+		$this->assertSame( 'error', $result['status'] );
+		$this->assertNull( $result['original_size'] );
+		$this->assertNull( $result['optimized_size'] );
+		$this->assertNull( $result['savings_percent'] );
+		$this->assertIsString( $result['error_message'] );
+	}
+
+	/**
+	 * Tests that execute() returns an error response when media_id is negative (confirmed, quota OK).
+	 */
+	public function testReturnsErrorWhenMediaIdIsNegative(): void {
+		$this->stubRequirements( true, false );
+
+		$ability = new OptimizeMedia();
+		$result  = $ability->execute(
+			[
+				'media_id' => -5,
+				'confirm'  => true,
+			]
+		);
+
+		$this->assertSame( 'error', $result['status'] );
+		$this->assertNull( $result['original_size'] );
+		$this->assertNull( $result['optimized_size'] );
+		$this->assertNull( $result['savings_percent'] );
+		$this->assertIsString( $result['error_message'] );
+	}
+
+	/**
+	 * Tests that execute() returns an error response when the attachment does not exist (confirmed, quota OK).
+	 */
+	public function testReturnsErrorWhenAttachmentDoesNotExist(): void {
+		$this->stubRequirements( true, false );
+		Functions\when( 'get_post' )->justReturn( false );
+
+		$ability = new OptimizeMedia();
+		$result  = $ability->execute(
+			[
+				'media_id' => 123,
+				'confirm'  => true,
+			]
+		);
+
+		$this->assertSame( 'error', $result['status'] );
+		$this->assertNull( $result['original_size'] );
+		$this->assertNull( $result['optimized_size'] );
+		$this->assertNull( $result['savings_percent'] );
+		$this->assertIsString( $result['error_message'] );
+	}
+
+	/**
+	 * Tests that execute() returns an error response when the post is not an attachment (confirmed, quota OK).
 	 */
 	public function testReturnsErrorWhenPostIsNotAnAttachment(): void {
+		$this->stubRequirements( true, false );
 		Functions\when( 'get_post' )->justReturn( Mockery::mock( 'WP_Post' ) );
 		Functions\when( 'get_post_type' )->justReturn( 'post' );
 
 		$ability = new OptimizeMedia();
-		$result  = $ability->execute( [ 'media_id' => 123 ] );
+		$result  = $ability->execute(
+			[
+				'media_id' => 123,
+				'confirm'  => true,
+			]
+		);
 
 		$this->assertSame( 'error', $result['status'] );
 		$this->assertNull( $result['original_size'] );
@@ -102,9 +193,10 @@ class Test_Execute extends TestCase {
 	}
 
 	/**
-	 * Tests that execute() uses the provided optimization_level when optimizing.
+	 * Tests that execute() uses the provided optimization_level when optimizing (confirmed, quota OK).
 	 */
 	public function testPassesOptimizationLevelToOptimizeWhenNotOptimized(): void {
+		$this->stubRequirements( true, false );
 		$this->stubValidAttachment();
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
@@ -139,14 +231,16 @@ class Test_Execute extends TestCase {
 			[
 				'media_id'           => 123,
 				'optimization_level' => 1,
+				'confirm'            => true,
 			]
 		);
 	}
 
 	/**
-	 * Tests that execute() uses reoptimize() when media is already optimized.
+	 * Tests that execute() uses reoptimize() when media is already optimized (confirmed, quota OK).
 	 */
 	public function testCallsReoptimizeWhenMediaIsOptimized(): void {
+		$this->stubRequirements( true, false );
 		$this->stubValidAttachment();
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
@@ -172,14 +266,16 @@ class Test_Execute extends TestCase {
 			[
 				'media_id'           => 123,
 				'optimization_level' => 2,
+				'confirm'            => true,
 			]
 		);
 	}
 
 	/**
-	 * Tests that execute() returns an error response when optimize() returns a WP_Error.
+	 * Tests that execute() returns an error response when optimize() returns a WP_Error (confirmed, quota OK).
 	 */
 	public function testReturnsErrorWhenOptimizeReturnsWpError(): void {
+		$this->stubRequirements( true, false );
 		$this->stubValidAttachment();
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
@@ -200,16 +296,23 @@ class Test_Execute extends TestCase {
 		Functions\when( 'imagify_get_optimization_process' )->justReturn( $process );
 
 		$ability = new OptimizeMedia();
-		$result  = $ability->execute( [ 'media_id' => 123 ] );
+		$result  = $ability->execute(
+			[
+				'media_id' => 123,
+				'confirm'  => true,
+			]
+		);
 
 		$this->assertSame( 'error', $result['status'] );
 		$this->assertSame( 'Optimization failed.', $result['error_message'] );
 	}
 
 	/**
-	 * Tests that execute() returns a success response with correct shape on successful optimization.
+	 * Tests that execute() returns a success response with correct shape on successful optimization
+	 * (confirmed, quota OK) — regression: guard does not alter the existing success shape.
 	 */
 	public function testReturnsSuccessResponseOnSuccessfulOptimization(): void {
+		$this->stubRequirements( true, false );
 		$this->stubValidAttachment();
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
@@ -226,7 +329,12 @@ class Test_Execute extends TestCase {
 		$ability->shouldReceive( 'get_media_original_size' )->andReturn( 1000 );
 		$ability->shouldReceive( 'get_media_optimized_size' )->andReturn( 800 );
 
-		$result = $ability->execute( [ 'media_id' => 123 ] );
+		$result = $ability->execute(
+			[
+				'media_id' => 123,
+				'confirm'  => true,
+			]
+		);
 
 		$this->assertSame( 'success', $result['status'] );
 		$this->assertSame( 1000, $result['original_size'] );
@@ -237,9 +345,11 @@ class Test_Execute extends TestCase {
 	}
 
 	/**
-	 * Tests that execute() returns a success response with null savings_percent when original_size is 0.
+	 * Tests that execute() returns a success response with null savings_percent when original_size is 0
+	 * (confirmed, quota OK).
 	 */
 	public function testReturnsSavingsPercentNullWhenOriginalSizeIsZero(): void {
+		$this->stubRequirements( true, false );
 		$this->stubValidAttachment();
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
@@ -256,16 +366,23 @@ class Test_Execute extends TestCase {
 		$ability->shouldReceive( 'get_media_original_size' )->andReturn( 0 );
 		$ability->shouldReceive( 'get_media_optimized_size' )->andReturn( 800 );
 
-		$result = $ability->execute( [ 'media_id' => 123 ] );
+		$result = $ability->execute(
+			[
+				'media_id' => 123,
+				'confirm'  => true,
+			]
+		);
 
 		$this->assertSame( 'success', $result['status'] );
 		$this->assertNull( $result['savings_percent'] );
 	}
 
 	/**
-	 * Tests that execute() returns a success response with null savings_percent when optimized_size is null.
+	 * Tests that execute() returns a success response with null savings_percent when optimized_size is null
+	 * (confirmed, quota OK).
 	 */
 	public function testReturnsSavingsPercentNullWhenOptimizedSizeIsNull(): void {
+		$this->stubRequirements( true, false );
 		$this->stubValidAttachment();
 
 		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
@@ -282,7 +399,12 @@ class Test_Execute extends TestCase {
 		$ability->shouldReceive( 'get_media_original_size' )->andReturn( 1000 );
 		$ability->shouldReceive( 'get_media_optimized_size' )->andReturn( null );
 
-		$result = $ability->execute( [ 'media_id' => 123 ] );
+		$result = $ability->execute(
+			[
+				'media_id' => 123,
+				'confirm'  => true,
+			]
+		);
 
 		$this->assertSame( 'success', $result['status'] );
 		$this->assertNull( $result['savings_percent'] );

--- a/Tests/Unit/classes/Tracking/McpTracking/Test_TrackAbilityExecuted.php
+++ b/Tests/Unit/classes/Tracking/McpTracking/Test_TrackAbilityExecuted.php
@@ -84,4 +84,55 @@ class Test_TrackAbilityExecuted extends TestCase {
 		( new McpTracking( $optin, $mixpanel ) )
 			->track_ability_executed( 'imagify/get-account', 'Get Imagify account status', microtime( true ) );
 	}
+
+	/**
+	 * Tests that is_preview defaults to false and is included in the Mixpanel event_data.
+	 */
+	public function testIsPreviewDefaultsToFalse(): void {
+		$optin = Mockery::mock( Optin::class );
+		$optin->shouldReceive( 'can_track' )->andReturn( true );
+
+		$mixpanel = Mockery::mock( TrackingPlugin::class );
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->withArgs(
+				static function ( string $event, array $props ): bool {
+					return 'MCP Ability Executed' === $event
+						&& array_key_exists( 'is_preview', $props )
+						&& false === $props['is_preview'];
+				}
+			);
+
+		Functions\when( 'get_imagify_user' )->justReturn( new \WP_Error() );
+		Functions\when( 'is_wp_error' )->justReturn( true );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+
+		( new McpTracking( $optin, $mixpanel ) )
+			->track_ability_executed( 'imagify/get-stats', 'Get Imagify optimization stats', microtime( true ) );
+	}
+
+	/**
+	 * Tests that is_preview is forwarded as true in the Mixpanel event_data when passed explicitly.
+	 */
+	public function testIsPreviewTrueIsForwardedToEventData(): void {
+		$optin = Mockery::mock( Optin::class );
+		$optin->shouldReceive( 'can_track' )->andReturn( true );
+
+		$mixpanel = Mockery::mock( TrackingPlugin::class );
+		$mixpanel->shouldReceive( 'track_direct' )
+			->once()
+			->withArgs(
+				static function ( string $event, array $props ): bool {
+					return 'MCP Ability Executed' === $event
+						&& true === $props['is_preview'];
+				}
+			);
+
+		Functions\when( 'get_imagify_user' )->justReturn( new \WP_Error() );
+		Functions\when( 'is_wp_error' )->justReturn( true );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+
+		( new McpTracking( $optin, $mixpanel ) )
+			->track_ability_executed( 'imagify/optimize-media', 'Optimize media', microtime( true ), true );
+	}
 }

--- a/Tests/Unit/classes/Tracking/McpTrackingSubscriber/Test_OnAbilityExecuted.php
+++ b/Tests/Unit/classes/Tracking/McpTrackingSubscriber/Test_OnAbilityExecuted.php
@@ -38,7 +38,7 @@ class Test_OnAbilityExecuted extends TestCase {
 		$mcp_tracking = Mockery::mock( McpTracking::class );
 		$mcp_tracking->shouldReceive( 'track_ability_executed' )
 			->once()
-			->with( $ability_id, $ability_name, $start_time );
+			->with( $ability_id, $ability_name, $start_time, false );
 		$mcp_tracking->shouldReceive( 'track_media_optimized' )
 			->once()
 			->with( $ability_id, $result, $start_time, $input_params );
@@ -62,7 +62,7 @@ class Test_OnAbilityExecuted extends TestCase {
 		$mcp_tracking = Mockery::mock( McpTracking::class );
 		$mcp_tracking->shouldReceive( 'track_ability_executed' )
 			->once()
-			->with( $ability_id, $ability_name, $start_time );
+			->with( $ability_id, $ability_name, $start_time, false );
 		$mcp_tracking->shouldNotReceive( 'track_media_optimized' );
 
 		$subscriber = new McpTrackingSubscriber( $mcp_tracking );
@@ -81,10 +81,81 @@ class Test_OnAbilityExecuted extends TestCase {
 		$mcp_tracking = Mockery::mock( McpTracking::class );
 		$mcp_tracking->shouldReceive( 'track_ability_executed' )
 			->once()
-			->with( $ability_id, $ability_name, $start_time );
+			->with( $ability_id, $ability_name, $start_time, false );
 		$mcp_tracking->shouldNotReceive( 'track_media_optimized' );
 
 		$subscriber = new McpTrackingSubscriber( $mcp_tracking );
 		$subscriber->on_ability_executed( $ability_id, $ability_name, $result, $start_time, [] );
+	}
+
+	/**
+	 * Tests that on_ability_executed() derives is_preview = true for each of the three guard-produced
+	 * preview statuses, and forwards it as the 4th argument to track_ability_executed().
+	 *
+	 * @dataProvider providePreviewStatuses
+	 *
+	 * @param string $status The guard-produced status expected to be treated as a preview.
+	 */
+	public function testDerivesIsPreviewTrueForGuardProducedStatuses( string $status ): void {
+		$ability_id   = 'imagify/optimize-media';
+		$ability_name = 'Optimize media';
+		$result       = [ 'status' => $status ];
+		$start_time   = microtime( true );
+
+		$mcp_tracking = Mockery::mock( McpTracking::class );
+		$mcp_tracking->shouldReceive( 'track_ability_executed' )
+			->once()
+			->with( $ability_id, $ability_name, $start_time, true );
+		$mcp_tracking->shouldReceive( 'track_media_optimized' )->zeroOrMoreTimes();
+
+		$subscriber = new McpTrackingSubscriber( $mcp_tracking );
+		$subscriber->on_ability_executed( $ability_id, $ability_name, $result, $start_time, [] );
+	}
+
+	/**
+	 * Tests that on_ability_executed() derives is_preview = false for success/error statuses.
+	 *
+	 * @dataProvider provideRealExecutionStatuses
+	 *
+	 * @param string $status The real-execution status expected to be treated as not a preview.
+	 */
+	public function testDerivesIsPreviewFalseForRealExecutionStatuses( string $status ): void {
+		$ability_id   = 'imagify/get-stats';
+		$ability_name = 'Get Imagify optimization stats';
+		$result       = [ 'status' => $status ];
+		$start_time   = microtime( true );
+
+		$mcp_tracking = Mockery::mock( McpTracking::class );
+		$mcp_tracking->shouldReceive( 'track_ability_executed' )
+			->once()
+			->with( $ability_id, $ability_name, $start_time, false );
+
+		$subscriber = new McpTrackingSubscriber( $mcp_tracking );
+		$subscriber->on_ability_executed( $ability_id, $ability_name, $result, $start_time, [] );
+	}
+
+	/**
+	 * Data provider of guard-produced preview statuses.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public function providePreviewStatuses(): array {
+		return [
+			'confirmation_required' => [ 'confirmation_required' ],
+			'insufficient_quota'    => [ 'insufficient_quota' ],
+			'invalid_api_key'       => [ 'invalid_api_key' ],
+		];
+	}
+
+	/**
+	 * Data provider of real-execution (non-preview) statuses.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public function provideRealExecutionStatuses(): array {
+		return [
+			'success' => [ 'success' ],
+			'error'   => [ 'error' ],
+		];
 	}
 }

--- a/classes/Abilities/AbstractAbility.php
+++ b/classes/Abilities/AbstractAbility.php
@@ -181,8 +181,14 @@ abstract class AbstractAbility implements AbilitiesInterface {
 	/**
 	 * Builds the `confirmation_required` guard response.
 	 *
+	 * The confirmation step is kept for every account, but the messaging adapts
+	 * to the plan: quota-limited accounts get the credit-consumption wording plus
+	 * a `quota_remaining` figure, while Infinite accounts (whose plans have no
+	 * per-image quota to consume) get operation-focused wording and no
+	 * `quota_remaining` key.
+	 *
 	 * @param array $args Raw input arguments passed to execute().
-	 * @return array{status: string, message: string, impact: array, quota_remaining: float, confirm_with: array}
+	 * @return array{status: string, message: string, impact: array, quota_remaining?: float, confirm_with: array}
 	 */
 	private function confirmation_required_response( array $args ): array {
 		$impact = $this instanceof CreditConsumingAbilityInterface ? $this->get_impact_estimate( $args ) : [];
@@ -198,31 +204,55 @@ abstract class AbstractAbility implements AbilitiesInterface {
 
 		if ( isset( $impact['total'] ) ) {
 			$impact_response['total'] = (int) $impact['total'];
-
-			$message = sprintf(
-				/* translators: 1: number of units about to be consumed, 2: total number of units, 3: unit label */
-				__( 'This action will consume Imagify quota: %1$d of %2$d %3$s. Add "confirm": true to the same call to proceed.', 'imagify' ),
-				$count,
-				(int) $impact['total'],
-				$label
-			);
-		} else {
-			$message = sprintf(
-				/* translators: 1: number of units about to be consumed, 2: unit label */
-				__( 'This action will consume Imagify quota: %1$d %2$s. Add "confirm": true to the same call to proceed.', 'imagify' ),
-				$count,
-				$label
-			);
 		}
 
-		$user = $this->fetch_user();
+		$user        = $this->fetch_user();
+		$is_infinite = $user->is_infinite();
+		$has_total   = isset( $impact['total'] );
 
-		return [
-			'status'          => 'confirmation_required',
-			'message'         => $message,
-			'impact'          => $impact_response,
-			'quota_remaining' => (float) $user->get_percent_unconsumed_quota(),
-			'confirm_with'    => [ 'confirm' => true ],
+		if ( $is_infinite ) {
+			$message = $has_total
+				? sprintf(
+					/* translators: 1: number of units about to be processed, 2: total number of units, 3: unit label */
+					__( 'This action will process %1$d of %2$d %3$s. Add "confirm": true to the same call to proceed.', 'imagify' ),
+					$count,
+					(int) $impact['total'],
+					$label
+				)
+				: sprintf(
+					/* translators: 1: number of units about to be processed, 2: unit label */
+					__( 'This action will process %1$d %2$s. Add "confirm": true to the same call to proceed.', 'imagify' ),
+					$count,
+					$label
+				);
+		} else {
+			$message = $has_total
+				? sprintf(
+					/* translators: 1: number of units about to be consumed, 2: total number of units, 3: unit label */
+					__( 'This action will consume Imagify quota: %1$d of %2$d %3$s. Add "confirm": true to the same call to proceed.', 'imagify' ),
+					$count,
+					(int) $impact['total'],
+					$label
+				)
+				: sprintf(
+					/* translators: 1: number of units about to be consumed, 2: unit label */
+					__( 'This action will consume Imagify quota: %1$d %2$s. Add "confirm": true to the same call to proceed.', 'imagify' ),
+					$count,
+					$label
+				);
+		}
+
+		$response = [
+			'status'       => 'confirmation_required',
+			'message'      => $message,
+			'impact'       => $impact_response,
+			'confirm_with' => [ 'confirm' => true ],
 		];
+
+		if ( ! $is_infinite ) {
+			$response['quota_remaining'] = (float) $user->get_percent_unconsumed_quota();
+		}
+
+		return $response;
 	}
 }

--- a/classes/Abilities/AbstractAbility.php
+++ b/classes/Abilities/AbstractAbility.php
@@ -3,13 +3,17 @@ declare(strict_types=1);
 
 namespace Imagify\Abilities;
 
+use Imagify\User\User;
+
 /**
  * Base class for all Imagify MCP abilities.
  *
  * Provides the `check_permissions()` template method (fires the
- * `imagify_mcp_permission_denied` action on denial) and the
- * `fire_executed()` helper used by concrete `execute()` implementations
- * to fire `imagify_mcp_ability_executed` after every invocation.
+ * `imagify_mcp_permission_denied` action on denial), the `fire_executed()`
+ * helper used by concrete `execute()` implementations to fire
+ * `imagify_mcp_ability_executed` after every invocation, and the
+ * `guard_credit_confirmation()` template method reused by every
+ * credit-consuming ability.
  *
  * @since 2.3.0
  */
@@ -37,6 +41,20 @@ abstract class AbstractAbility implements AbilitiesInterface {
 	abstract protected function has_permission(): bool;
 
 	/**
+	 * Returns the capability name reported to `imagify_mcp_permission_denied`
+	 * when `has_permission()` denies access.
+	 *
+	 * Overridable so abilities whose `has_permission()` checks a capability
+	 * other than the Imagify `manage` capability (e.g. `manage_options`)
+	 * report the real required capability in tracking/analytics.
+	 *
+	 * @return string
+	 */
+	protected function get_required_capability(): string {
+		return 'manage';
+	}
+
+	/**
 	 * Check if the current user has permission to execute this ability.
 	 *
 	 * Delegates the capability check to has_permission() and fires
@@ -49,7 +67,7 @@ abstract class AbstractAbility implements AbilitiesInterface {
 		$allowed = $this->has_permission();
 
 		if ( ! $allowed ) {
-			do_action( 'imagify_mcp_permission_denied', $this->get_id(), $this->get_name(), 'manage' );
+			do_action( 'imagify_mcp_permission_denied', $this->get_id(), $this->get_name(), $this->get_required_capability() );
 		}
 
 		return $allowed;
@@ -68,5 +86,143 @@ abstract class AbstractAbility implements AbilitiesInterface {
 	 */
 	protected function fire_executed( $result, float $start_time, array $args = [] ): void {
 		do_action( 'imagify_mcp_ability_executed', $this->get_id(), $this->get_name(), $result, $start_time, $args );
+	}
+
+	/**
+	 * Fetch an initialized Imagify User instance.
+	 *
+	 * Extracted into a protected method so that unit tests can override
+	 * this call without needing to bootstrap the full Imagify API layer.
+	 *
+	 * @return User
+	 */
+	protected function fetch_user(): User {
+		$user = new User();
+		$user->init_user();
+		return $user;
+	}
+
+	/**
+	 * Shared pre-flight guard for credit-consuming abilities.
+	 *
+	 * Implements a 4-step flow, in this exact order:
+	 * 1. If the Imagify API key is invalid, returns an `invalid_api_key`
+	 *    response — `$run` is never invoked.
+	 * 2. If the account is over quota, returns an `insufficient_quota`
+	 *    response — `$run` is never invoked.
+	 * 3. If `$args['confirm']` is not strictly `true`, returns a
+	 *    `confirmation_required` response built from `get_impact_estimate()` —
+	 *    `$run` is never invoked.
+	 * 4. Otherwise calls `$run( $args )` and returns its result unchanged.
+	 *
+	 * Callers MUST pass a closure created inside the defining ability class
+	 * (e.g. `function ( array $a ) { return $this->do_execute( $a ); }`),
+	 * never a `[ $this, 'method' ]` callable-array: a private target method's
+	 * visibility is resolved against the scope that invokes it, which is this
+	 * method on `AbstractAbility` — not the ability class where the private
+	 * method is declared.
+	 *
+	 * @param array    $args Raw input arguments passed to execute().
+	 * @param callable $run  Closure invoked with `$args` once confirmed and
+	 *                       quota/API-key checks pass.
+	 * @return array
+	 */
+	protected function guard_credit_confirmation( array $args, callable $run ): array {
+		if ( ! \Imagify_Requirements::is_api_key_valid() ) {
+			return $this->invalid_api_key_response();
+		}
+
+		if ( \Imagify_Requirements::is_over_quota() ) {
+			return $this->insufficient_quota_response();
+		}
+
+		if ( true !== ( $args['confirm'] ?? null ) ) {
+			return $this->confirmation_required_response( $args );
+		}
+
+		return $run( $args );
+	}
+
+	/**
+	 * Builds the `invalid_api_key` guard response.
+	 *
+	 * @return array{status: string, message: string}
+	 */
+	private function invalid_api_key_response(): array {
+		return [
+			'status'  => 'invalid_api_key',
+			'message' => __( 'Your Imagify API key is invalid or missing. Update it in the Imagify settings before retrying.', 'imagify' ),
+		];
+	}
+
+	/**
+	 * Builds the `insufficient_quota` guard response.
+	 *
+	 * @return array{status: string, message: string, next_date_update: string, upgrade_url: string}
+	 */
+	private function insufficient_quota_response(): array {
+		$user = $this->fetch_user();
+
+		return [
+			'status'           => 'insufficient_quota',
+			'message'          => __( 'Your Imagify quota is exhausted. Wait for the next reset date or upgrade your plan to continue.', 'imagify' ),
+			'next_date_update' => $user->next_date_update ? (string) $user->next_date_update : '',
+			'upgrade_url'      => imagify_get_external_url(
+				'subscription',
+				[
+					'utm_source'  => 'plugin',
+					'utm_medium'  => 'imagify-wp',
+					'utm_content' => 'over-quota',
+				]
+			),
+		];
+	}
+
+	/**
+	 * Builds the `confirmation_required` guard response.
+	 *
+	 * @param array $args Raw input arguments passed to execute().
+	 * @return array{status: string, message: string, impact: array, quota_remaining: float, confirm_with: array}
+	 */
+	private function confirmation_required_response( array $args ): array {
+		$impact = $this instanceof CreditConsumingAbilityInterface ? $this->get_impact_estimate( $args ) : [];
+
+		$unit  = isset( $impact['unit'] ) ? (string) $impact['unit'] : 'image';
+		$count = isset( $impact['count'] ) ? (int) $impact['count'] : 0;
+		$label = isset( $impact['label'] ) ? (string) $impact['label'] : $unit;
+
+		$impact_response = [
+			'unit'  => $unit,
+			'count' => $count,
+		];
+
+		if ( isset( $impact['total'] ) ) {
+			$impact_response['total'] = (int) $impact['total'];
+
+			$message = sprintf(
+				/* translators: 1: number of units about to be consumed, 2: total number of units, 3: unit label */
+				__( 'This action will consume Imagify quota: %1$d of %2$d %3$s. Add "confirm": true to the same call to proceed.', 'imagify' ),
+				$count,
+				(int) $impact['total'],
+				$label
+			);
+		} else {
+			$message = sprintf(
+				/* translators: 1: number of units about to be consumed, 2: unit label */
+				__( 'This action will consume Imagify quota: %1$d %2$s. Add "confirm": true to the same call to proceed.', 'imagify' ),
+				$count,
+				$label
+			);
+		}
+
+		$user = $this->fetch_user();
+
+		return [
+			'status'          => 'confirmation_required',
+			'message'         => $message,
+			'impact'          => $impact_response,
+			'quota_remaining' => (float) $user->get_percent_unconsumed_quota(),
+			'confirm_with'    => [ 'confirm' => true ],
+		];
 	}
 }

--- a/classes/Abilities/BulkOptimize.php
+++ b/classes/Abilities/BulkOptimize.php
@@ -13,7 +13,10 @@ use Imagify\Bulk\BulkOptimizerInterface;
  *
  * @since 2.3.0
  */
-class BulkOptimize implements AbilitiesInterface {
+class BulkOptimize extends AbstractAbility implements CreditConsumingAbilityInterface {
+
+	const ABILITY_ID   = 'imagify/bulk-optimize';
+	const ABILITY_NAME = 'Bulk optimize';
 
 	/**
 	 * Bulk optimization instance.
@@ -29,6 +32,24 @@ class BulkOptimize implements AbilitiesInterface {
 	 */
 	public function __construct( BulkOptimizerInterface $bulk ) {
 		$this->bulk = $bulk;
+	}
+
+	/**
+	 * Returns the ability slug.
+	 *
+	 * @return string
+	 */
+	public function get_id(): string {
+		return self::ABILITY_ID;
+	}
+
+	/**
+	 * Returns the human-readable ability label.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return self::ABILITY_NAME;
 	}
 
 	/**
@@ -62,6 +83,11 @@ class BulkOptimize implements AbilitiesInterface {
 							'minimum'     => 0,
 							'maximum'     => 2,
 						],
+						'confirm'            => [
+							'type'        => 'boolean',
+							'description' => __( 'Set to true to execute after reviewing the credit-consumption preview returned by a prior call without this flag.', 'imagify' ),
+							'default'     => false,
+						],
 					],
 					'required'   => [ 'context' ],
 				],
@@ -70,8 +96,8 @@ class BulkOptimize implements AbilitiesInterface {
 					'properties' => [
 						'status'        => [
 							'type'        => 'string',
-							'description' => __( 'Result status: "scheduled" when the bulk run was queued, "error" otherwise.', 'imagify' ),
-							'enum'        => [ 'scheduled', 'error' ],
+							'description' => __( 'Result status: "scheduled", "error", "confirmation_required", "insufficient_quota", or "invalid_api_key".', 'imagify' ),
+							'enum'        => [ 'scheduled', 'error', 'confirmation_required', 'insufficient_quota', 'invalid_api_key' ],
 						],
 						'context'       => [
 							'type'        => 'string',
@@ -105,17 +131,81 @@ class BulkOptimize implements AbilitiesInterface {
 	 *
 	 * @return bool True when the current user has the `manage_options` capability.
 	 */
-	public function check_permissions(): bool {
+	protected function has_permission(): bool {
 		return (bool) current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Returns the capability required to execute this ability.
+	 *
+	 * @return string
+	 */
+	protected function get_required_capability(): string {
+		return 'manage_options';
+	}
+
+	/**
+	 * Returns the credit-consumption impact estimate for a bulk optimization run.
+	 *
+	 * Uses cheap COUNT-only helpers per context — never the heavy ID-fetching
+	 * `get_unoptimized_media_ids()`, which would run a full JOIN query just to
+	 * build a preview count.
+	 *
+	 * @param array $args Input arguments. Expects `context` (string).
+	 * @return array{unit: string, count: int, total: int, label: string}
+	 */
+	public function get_impact_estimate( array $args ): array {
+		$context = isset( $args['context'] ) ? (string) $args['context'] : '';
+
+		if ( 'custom-folders' === $context ) {
+			$remaining = \Imagify_Files_Stats::count_unoptimized_files();
+			$total     = \Imagify_Files_Stats::count_files();
+		} else {
+			$remaining = imagify_count_unoptimized_attachments();
+			$total     = imagify_count_attachments();
+		}
+
+		return [
+			'unit'  => 'image',
+			'count' => (int) $remaining,
+			'total' => (int) $total,
+			'label' => sprintf( 'unoptimized images in %s', $context ),
+		];
 	}
 
 	/**
 	 * Execute the ability: schedule a bulk optimization run.
 	 *
+	 * Wraps the real execution behind `guard_credit_confirmation()`.
+	 *
+	 * @param array $args Input arguments. Expects `context` (string) and optionally `optimization_level` (int), `confirm` (bool).
+	 * @return array<string, mixed> Guard response (invalid_api_key/insufficient_quota/confirmation_required) or the do_execute() result shape.
+	 */
+	public function execute( array $args = [] ): array {
+		$start_time = microtime( true );
+		$result     = $this->guard_credit_confirmation(
+			$args,
+			function ( array $a ) {
+				return $this->do_execute( $a );
+			}
+		);
+
+		$this->fire_executed( $result, $start_time, $args );
+
+		return $result;
+	}
+
+	/**
+	 * Internal execution logic for the ability.
+	 *
+	 * Separated from execute() so guard_credit_confirmation() can invoke it
+	 * via a closure without a `[$this, 'method']` callable-array visibility
+	 * problem (this method is private, and the guard lives on AbstractAbility).
+	 *
 	 * @param array $args Input arguments. Expects `context` (string) and optionally `optimization_level` (int).
 	 * @return array{status: string, context: string, error_message: string|null}
 	 */
-	public function execute( array $args = [] ): array {
+	private function do_execute( array $args ): array {
 		$context = isset( $args['context'] ) ? (string) $args['context'] : '';
 
 		if ( ! in_array( $context, [ 'wp', 'custom-folders' ], true ) ) {

--- a/classes/Abilities/BulkOptimize.php
+++ b/classes/Abilities/BulkOptimize.php
@@ -76,6 +76,7 @@ class BulkOptimize extends AbstractAbility implements CreditConsumingAbilityInte
 						'context'            => [
 							'type'        => 'string',
 							'description' => __( 'Optimization context: "wp" for the WordPress media library or "custom-folders" for custom folder sources.', 'imagify' ),
+							'enum'        => [ 'wp', 'custom-folders' ],
 						],
 						'optimization_level' => [
 							'type'        => 'integer',
@@ -156,20 +157,23 @@ class BulkOptimize extends AbstractAbility implements CreditConsumingAbilityInte
 	 */
 	public function get_impact_estimate( array $args ): array {
 		$context = isset( $args['context'] ) ? (string) $args['context'] : '';
+		$context = ( 'custom-folders' === $context ) ? 'custom-folders' : 'wp';
 
 		if ( 'custom-folders' === $context ) {
 			$remaining = \Imagify_Files_Stats::count_unoptimized_files();
 			$total     = \Imagify_Files_Stats::count_files();
+			$label     = __( 'unoptimized images in custom folders', 'imagify' );
 		} else {
 			$remaining = imagify_count_unoptimized_attachments();
 			$total     = imagify_count_attachments();
+			$label     = __( 'unoptimized images in the WordPress media library', 'imagify' );
 		}
 
 		return [
 			'unit'  => 'image',
 			'count' => (int) $remaining,
 			'total' => (int) $total,
-			'label' => sprintf( 'unoptimized images in %s', $context ),
+			'label' => $label,
 		];
 	}
 

--- a/classes/Abilities/CreditConsumingAbilityInterface.php
+++ b/classes/Abilities/CreditConsumingAbilityInterface.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Abilities;
+
+/**
+ * Contract for MCP abilities that spend Imagify quota.
+ *
+ * Implementing this interface opts an ability into
+ * `AbstractAbility::guard_credit_confirmation()`, the shared pre-flight
+ * quota/confirmation gate.
+ *
+ * @since 2.4.0
+ */
+interface CreditConsumingAbilityInterface {
+
+	/**
+	 * Returns a small associative array describing what the call is about to do.
+	 *
+	 * Used by `AbstractAbility::guard_credit_confirmation()` to build the
+	 * `confirmation_required` response so the caller/AI can see the impact
+	 * before confirming.
+	 *
+	 * @param array $args Raw input arguments passed to execute().
+	 * @return array{unit: string, count: int, total?: int, label: string}
+	 */
+	public function get_impact_estimate( array $args ): array;
+}

--- a/classes/Abilities/GenerateMissingNextgen.php
+++ b/classes/Abilities/GenerateMissingNextgen.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Imagify\Abilities;
 
 use Imagify\Bulk\Bulk;
+use Imagify\Stats\StatInterface;
 
 /**
  * MCP ability: generate missing next-gen (WebP/AVIF) versions.
@@ -14,7 +15,10 @@ use Imagify\Bulk\Bulk;
  *
  * @since 2.3.0
  */
-class GenerateMissingNextgen implements AbilitiesInterface {
+class GenerateMissingNextgen extends AbstractAbility implements CreditConsumingAbilityInterface {
+
+	const ABILITY_ID   = 'imagify/generate-missing-nextgen';
+	const ABILITY_NAME = 'Generate missing next-gen versions';
 
 	/**
 	 * Bulk instance for queueing next-gen generation jobs.
@@ -27,12 +31,41 @@ class GenerateMissingNextgen implements AbilitiesInterface {
 	private $bulk;
 
 	/**
+	 * Stat service used to compute the missing-nextgen count for the
+	 * credit-consumption impact estimate. Typed via docblock for the same
+	 * reflection-injection reason as `$bulk` above.
+	 *
+	 * @var StatInterface
+	 */
+	private $stat;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param Bulk $bulk Bulk instance injected by the DI container.
+	 * @param Bulk          $bulk Bulk instance injected by the DI container.
+	 * @param StatInterface $stat Stat service (`OptimizedMediaWithoutNextGen`) injected by the DI container.
 	 */
-	public function __construct( Bulk $bulk ) {
+	public function __construct( Bulk $bulk, StatInterface $stat ) {
 		$this->bulk = $bulk;
+		$this->stat = $stat;
+	}
+
+	/**
+	 * Returns the ability slug.
+	 *
+	 * @return string
+	 */
+	public function get_id(): string {
+		return self::ABILITY_ID;
+	}
+
+	/**
+	 * Returns the human-readable ability label.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return self::ABILITY_NAME;
 	}
 
 	/**
@@ -53,12 +86,22 @@ class GenerateMissingNextgen implements AbilitiesInterface {
 				'label'               => __( 'Generate missing next-gen versions', 'imagify' ),
 				'description'         => __( 'Queues generation of missing next-gen (WebP/AVIF) versions for all optimized media. Runs asynchronously via Action Scheduler.', 'imagify' ),
 				'category'            => 'imagify',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'confirm' => [
+							'type'        => 'boolean',
+							'description' => __( 'Set to true to execute after reviewing the credit-consumption preview returned by a prior call without this flag.', 'imagify' ),
+							'default'     => false,
+						],
+					],
+				],
 				'output_schema'       => [
 					'type'       => 'object',
 					'properties' => [
 						'status'        => [
 							'type' => 'string',
-							'enum' => [ 'scheduled', 'error' ],
+							'enum' => [ 'scheduled', 'error', 'confirmation_required', 'insufficient_quota', 'invalid_api_key' ],
 						],
 						'queued_count'  => [ 'type' => 'integer' ],
 						'error_message' => [ 'type' => [ 'string', 'null' ] ],
@@ -84,12 +127,67 @@ class GenerateMissingNextgen implements AbilitiesInterface {
 	 *
 	 * @return bool True if the current user has the `manage_options` capability.
 	 */
-	public function check_permissions(): bool {
+	protected function has_permission(): bool {
 		return (bool) current_user_can( 'manage_options' );
 	}
 
 	/**
+	 * Returns the capability required to execute this ability.
+	 *
+	 * @return string
+	 */
+	protected function get_required_capability(): string {
+		return 'manage_options';
+	}
+
+	/**
+	 * Returns the credit-consumption impact estimate for generating missing next-gen versions.
+	 *
+	 * `count` is the number of optimized media still missing a next-gen version
+	 * (from the cached `OptimizedMediaWithoutNextGen` stat service). `total` is
+	 * the number of optimized media across both contexts, summed the same way
+	 * `OptimizedMediaWithoutNextGen::get_stat()` sums its own per-context loop.
+	 *
+	 * @param array $args Input arguments (unused: the estimate does not depend on input).
+	 * @return array{unit: string, count: int, total: int, label: string}
+	 */
+	public function get_impact_estimate( array $args ): array {
+		$count = (int) $this->stat->get_cached_stat();
+		$total = imagify_count_optimized_attachments() + \Imagify_Files_Stats::count_optimized_files();
+
+		return [
+			'unit'  => 'image',
+			'count' => $count,
+			'total' => (int) $total,
+			'label' => 'optimized images missing a next-gen version',
+		];
+	}
+
+	/**
 	 * Execute the ability: queue generation of missing next-gen versions.
+	 *
+	 * Wraps the real execution behind `guard_credit_confirmation()` so the AI
+	 * never even attempts the call when quota is already exhausted.
+	 *
+	 * @param array $args Input arguments. Expects optionally `confirm` (bool).
+	 * @return array<string, mixed> Guard response (invalid_api_key/insufficient_quota/confirmation_required) or the do_execute() result shape.
+	 */
+	public function execute( array $args = [] ): array {
+		$start_time = microtime( true );
+		$result     = $this->guard_credit_confirmation(
+			$args,
+			function ( array $a ) {
+				return $this->do_execute( $a );
+			}
+		);
+
+		$this->fire_executed( $result, $start_time, $args );
+
+		return $result;
+	}
+
+	/**
+	 * Internal execution logic for the ability.
 	 *
 	 * Delegates to `Bulk::run_generate_nextgen()` and maps its return value to
 	 * the MCP contract shape:
@@ -97,11 +195,14 @@ class GenerateMissingNextgen implements AbilitiesInterface {
 	 * - `success=false, no-images` → `status=scheduled, queued_count=0` (AC #3 no-op)
 	 * - `success=false, other`     → `status=error, queued_count=0, error_message=...`
 	 *
-	 * Signature matches `AbilitiesInterface::execute()` — no params, untyped return.
+	 * Separated from execute() so guard_credit_confirmation() can invoke it via
+	 * a closure without a `[$this, 'method']` callable-array visibility problem
+	 * (this method is private, and the guard lives on AbstractAbility).
 	 *
-	 * @return mixed
+	 * @param array $args Input arguments (unused by the underlying Bulk call).
+	 * @return array{status: string, queued_count: int, error_message: string|null}
 	 */
-	public function execute() {
+	private function do_execute( array $args ): array {
 		$contexts = $this->bulk->get_contexts();
 		$formats  = imagify_nextgen_images_formats();
 		$result   = $this->bulk->run_generate_nextgen( $contexts, $formats );

--- a/classes/Abilities/GenerateMissingNextgen.php
+++ b/classes/Abilities/GenerateMissingNextgen.php
@@ -143,23 +143,27 @@ class GenerateMissingNextgen extends AbstractAbility implements CreditConsumingA
 	/**
 	 * Returns the credit-consumption impact estimate for generating missing next-gen versions.
 	 *
-	 * `count` is the number of optimized media still missing a next-gen version
-	 * (from the cached `OptimizedMediaWithoutNextGen` stat service). `total` is
-	 * the number of optimized media across both contexts, summed the same way
-	 * `OptimizedMediaWithoutNextGen::get_stat()` sums its own per-context loop.
+	 * `count` is the number of optimized media still missing a next-gen version,
+	 * computed live via `OptimizedMediaWithoutNextGen::get_stat()` (not the
+	 * 2-day cached `get_cached_stat()`) because this preview drives an AI
+	 * credit-spend decision and must not go stale relative to `total`. `total`
+	 * is the number of optimized media across both contexts, summed the same
+	 * way `OptimizedMediaWithoutNextGen::get_stat()` sums its own per-context
+	 * loop. `count` is clamped to `total` as a defensive safeguard.
 	 *
 	 * @param array $args Input arguments (unused: the estimate does not depend on input).
 	 * @return array{unit: string, count: int, total: int, label: string}
 	 */
 	public function get_impact_estimate( array $args ): array {
-		$count = (int) $this->stat->get_cached_stat();
+		$count = (int) $this->stat->get_stat();
 		$total = imagify_count_optimized_attachments() + \Imagify_Files_Stats::count_optimized_files();
+		$count = min( $count, (int) $total );
 
 		return [
 			'unit'  => 'image',
 			'count' => $count,
 			'total' => (int) $total,
-			'label' => 'optimized images missing a next-gen version',
+			'label' => __( 'optimized images missing a next-gen version', 'imagify' ),
 		];
 	}
 

--- a/classes/Abilities/GetAccount.php
+++ b/classes/Abilities/GetAccount.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace Imagify\Abilities;
 
-use Imagify\User\User;
-
 /**
  * MCP ability: returns the current Imagify account status and quota data.
  *
@@ -89,20 +87,6 @@ class GetAccount extends AbstractAbility {
 	 */
 	protected function has_permission(): bool {
 		return imagify_get_context( 'wp' )->current_user_can( 'manage' );
-	}
-
-	/**
-	 * Fetch the initialized User instance.
-	 *
-	 * Extracted into a protected method so that unit tests can override
-	 * this call without needing to bootstrap the full Imagify API layer.
-	 *
-	 * @return User
-	 */
-	protected function fetch_user(): User {
-		$user = new User();
-		$user->init_user();
-		return $user;
 	}
 
 	/**

--- a/classes/Abilities/OptimizeMedia.php
+++ b/classes/Abilities/OptimizeMedia.php
@@ -12,7 +12,7 @@ namespace Imagify\Abilities;
  *
  * @since 2.3.0
  */
-class OptimizeMedia extends AbstractAbility {
+class OptimizeMedia extends AbstractAbility implements CreditConsumingAbilityInterface {
 
 	const ABILITY_ID   = 'imagify/optimize-media';
 	const ABILITY_NAME = 'Optimize media';
@@ -66,6 +66,11 @@ class OptimizeMedia extends AbstractAbility {
 							'minimum'     => 0,
 							'maximum'     => 2,
 						],
+						'confirm'            => [
+							'type'        => 'boolean',
+							'description' => __( 'Set to true to execute after reviewing the credit-consumption preview returned by a prior call without this flag.', 'imagify' ),
+							'default'     => false,
+						],
 					],
 					'required'   => [ 'media_id' ],
 				],
@@ -74,8 +79,8 @@ class OptimizeMedia extends AbstractAbility {
 					'properties' => [
 						'status'          => [
 							'type'        => 'string',
-							'description' => __( 'Result status: "success" or "error".', 'imagify' ),
-							'enum'        => [ 'success', 'error' ],
+							'description' => __( 'Result status: "success", "error", "confirmation_required", "insufficient_quota", or "invalid_api_key".', 'imagify' ),
+							'enum'        => [ 'success', 'error', 'confirmation_required', 'insufficient_quota', 'invalid_api_key' ],
 						],
 						'original_size'   => [
 							'type'        => [ 'integer', 'null' ],
@@ -130,17 +135,39 @@ class OptimizeMedia extends AbstractAbility {
 	}
 
 	/**
+	 * Returns the credit-consumption impact estimate for a single media optimization.
+	 *
+	 * @param array $args Input arguments (unused: optimizing a single media always costs 1 unit).
+	 * @return array{unit: string, count: int, label: string}
+	 */
+	public function get_impact_estimate( array $args ): array {
+		return [
+			'unit'  => 'image',
+			'count' => 1,
+			'label' => 'this media',
+		];
+	}
+
+	/**
 	 * Execute the ability: optimize the media.
 	 *
-	 * Fires `imagify_mcp_ability_executed` after the ability resolves so that
-	 * tracking and other subscribers can react to both success and failure outcomes.
+	 * Wraps the real execution behind `guard_credit_confirmation()` so the
+	 * caller must pass `confirm: true` once quota is confirmed (and is not
+	 * over quota, and the API key is valid). Fires `imagify_mcp_ability_executed`
+	 * after the ability resolves so that tracking and other subscribers can
+	 * react to every outcome (previews included).
 	 *
-	 * @param array $args Input arguments. Expects `media_id` (int) and optionally `optimization_level` (int).
-	 * @return array{status: string, original_size: int|null, optimized_size: int|null, savings_percent: float|null, error_message: string|null}
+	 * @param array $args Input arguments. Expects `media_id` (int) and optionally `optimization_level` (int), `confirm` (bool).
+	 * @return array<string, mixed> Guard response (invalid_api_key/insufficient_quota/confirmation_required) or the do_execute() result shape.
 	 */
 	public function execute( array $args = [] ): array {
 		$start_time = microtime( true );
-		$result     = $this->do_execute( $args );
+		$result     = $this->guard_credit_confirmation(
+			$args,
+			function ( array $a ) {
+				return $this->do_execute( $a );
+			}
+		);
 
 		$this->fire_executed( $result, $start_time, $args );
 

--- a/classes/MCP/ServiceProvider.php
+++ b/classes/MCP/ServiceProvider.php
@@ -87,7 +87,8 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->addShared( BulkOptimize::class )
 			->addArgument( Bulk::get_instance() );
 		$this->getContainer()->addShared( GenerateMissingNextgen::class )
-			->addArgument( Bulk::class );
+			->addArgument( Bulk::class )
+			->addArgument( OptimizedMediaWithoutNextGen::class );
 		$this->getContainer()->addShared( ConfigSubscriber::class );
 		$this->getContainer()->addShared( GetAccount::class );
 		$this->getContainer()->addShared( GetMediaStatus::class );

--- a/classes/Tracking/McpTracking.php
+++ b/classes/Tracking/McpTracking.php
@@ -84,9 +84,13 @@ class McpTracking extends BaseTracking {
 	 * @param string $ability_id   Ability slug, e.g. `imagify/get-stats`.
 	 * @param string $ability_name Human-readable ability label.
 	 * @param float  $start_time   microtime(true) captured before execute() ran.
+	 * @param bool   $is_preview   True when the call was a credit-consumption preview
+	 *                             (`confirmation_required`/`insufficient_quota`/`invalid_api_key`)
+	 *                             rather than a real execution. Defaults to false so
+	 *                             non-quota-sensitive abilities keep their current behavior.
 	 * @return void
 	 */
-	public function track_ability_executed( string $ability_id, string $ability_name, float $start_time ): void {
+	public function track_ability_executed( string $ability_id, string $ability_name, float $start_time, bool $is_preview = false ): void {
 		if ( ! $this->can_track() ) {
 			return;
 		}
@@ -97,6 +101,7 @@ class McpTracking extends BaseTracking {
 				'ability_id'        => $ability_id,
 				'ability_name'      => $ability_name,
 				'execution_time_ms' => round( ( microtime( true ) - $start_time ) * 1000, 2 ),
+				'is_preview'        => $is_preview,
 			]
 		);
 

--- a/classes/Tracking/McpTrackingSubscriber.php
+++ b/classes/Tracking/McpTrackingSubscriber.php
@@ -56,7 +56,13 @@ class McpTrackingSubscriber implements SubscriberInterface {
 	 * @return void
 	 */
 	public function on_ability_executed( string $ability_id, string $ability_name, $result, float $start_time, array $input_params ): void {
-		$this->mcp_tracking->track_ability_executed( $ability_id, $ability_name, $start_time );
+		$is_preview = is_array( $result ) && in_array(
+			$result['status'] ?? '',
+			[ 'confirmation_required', 'insufficient_quota', 'invalid_api_key' ],
+			true
+		);
+
+		$this->mcp_tracking->track_ability_executed( $ability_id, $ability_name, $start_time, $is_preview );
 
 		if ( 'imagify/optimize-media' === $ability_id && is_array( $result ) ) {
 			$this->mcp_tracking->track_media_optimized( $ability_id, $result, $start_time, $input_params );

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -146,7 +146,7 @@ Schedules a bulk image optimization run for the WordPress media library or custo
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `context` | string | yes | `"wp"` for the WordPress media library or `"custom-folders"` for custom folder sources. |
+| `context` | string | yes | `"wp"` for the WordPress media library or `"custom-folders"` for custom folder sources. Enum: `["wp", "custom-folders"]`. |
 | `optimization_level` | integer (0–2) | no | Overrides the global setting. 0 = normal, 1 = aggressive, 2 = ultra. |
 | `confirm` | boolean | no | Set to `true` to execute after reviewing the credit-consumption preview returned by a prior call without this flag. Defaults to `false`. See [Credit confirmation flow](#credit-confirmation-flow). |
 
@@ -160,7 +160,10 @@ Schedules a bulk image optimization run for the WordPress media library or custo
 
 `get_impact_estimate()`'s `count`/`total` figures come from cheap COUNT-only queries per context:
 `imagify_count_unoptimized_attachments()` / `imagify_count_attachments()` for `"wp"`,
-`Imagify_Files_Stats::count_unoptimized_files()` / `count_files()` for `"custom-folders"`.
+`Imagify_Files_Stats::count_unoptimized_files()` / `count_files()` for `"custom-folders"`. Any
+context other than `"custom-folders"` (including an unrecognized value or a missing `context` key)
+is normalized to `"wp"` before the counts and translatable `impact.label` are computed, so the
+label always matches the branch the counts came from.
 
 ### `imagify/generate-missing-nextgen`
 
@@ -187,9 +190,11 @@ Queues generation of missing next-gen (WebP/AVIF) versions for all optimized med
 | `queued_count` | integer | Number of images queued for next-gen generation. Present only on `scheduled`/`error`. |
 | `error_message` | string \| null | Human-readable error on failure, null on success. Present only on `scheduled`/`error`. |
 
-`get_impact_estimate()`'s `count` comes from the cached `Imagify\Stats\OptimizedMediaWithoutNextGen`
-stat service (`get_cached_stat()`, injected via DI); `total` sums
-`imagify_count_optimized_attachments() + Imagify_Files_Stats::count_optimized_files()`.
+`get_impact_estimate()`'s `count` comes from the live `Imagify\Stats\OptimizedMediaWithoutNextGen`
+stat service (`get_stat()`, injected via DI — not the 2-day cached `get_cached_stat()`, since a stale
+count could exceed `total` and mislead the credit-spend decision); `total` sums
+`imagify_count_optimized_attachments() + Imagify_Files_Stats::count_optimized_files()`. `count` is
+clamped to `total` as a defensive safeguard.
 
 ### `imagify/optimize-media`
 

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -41,6 +41,8 @@ The endpoint returns HTTP 200 with the adapter's default three-tool set plus all
 | Class | Responsibility |
 |-------|----------------|
 | `Imagify\Abilities\AbilitiesInterface` | Contract every Imagify MCP ability must implement. |
+| `Imagify\Abilities\AbstractAbility` | Base class for abilities; provides `check_permissions()`, `fire_executed()`, and `guard_credit_confirmation()` (see [Credit confirmation flow](#credit-confirmation-flow)). |
+| `Imagify\Abilities\CreditConsumingAbilityInterface` | Contract for abilities that spend Imagify quota (`get_impact_estimate()`); opts an ability into `guard_credit_confirmation()`. Implemented by `OptimizeMedia`, `BulkOptimize`, `GenerateMissingNextgen`. |
 | `Imagify\Abilities\BulkOptimize` | MCP ability: schedule a bulk image optimization run (`imagify/bulk-optimize`). |
 | `Imagify\Abilities\GenerateMissingNextgen` | MCP ability: queue generation of missing next-gen (WebP/AVIF) versions (`imagify/generate-missing-nextgen`). |
 | `Imagify\Abilities\GetAccount` | Ability `imagify/get-account` — returns account quota, plan details, and API key validity. |
@@ -73,6 +75,64 @@ interface AbilitiesInterface {
 
 ## Registered abilities
 
+### Credit confirmation flow
+
+`imagify/optimize-media`, `imagify/bulk-optimize`, and `imagify/generate-missing-nextgen` consume
+Imagify quota, so each one is gated by `Imagify\Abilities\AbstractAbility::guard_credit_confirmation()`
+before its real side effect runs. Because MCP tool calls are made by an AI agent rather than a human
+clicking a confirm dialog, the "explicit confirmation" requirement is implemented as a two-call
+protocol instead of a client-side dialog:
+
+1. **Preview call** — call the ability without `confirm` (or with `confirm: false`). The guard never
+   invokes the ability's real logic; it returns a `confirmation_required` response describing the
+   impact (unit, count, and — for `bulk-optimize`/`generate-missing-nextgen` — the total) and the
+   current quota remaining.
+2. **Confirmed call** — resend the same call with `confirm: true`. The guard re-checks the API key and
+   quota (they may have changed since the preview) and, if both are still fine, invokes the ability's
+   real logic and returns its normal result.
+
+The guard runs this exact 4-step sequence on every call, confirmed or not:
+
+1. `Imagify_Requirements::is_api_key_valid()` — if false, returns `status: invalid_api_key` and stops.
+2. `Imagify_Requirements::is_over_quota()` — if true, returns `status: insufficient_quota` and stops.
+3. `$args['confirm'] === true` (strict boolean check; `"true"` as a string does not count) — if not
+   true, returns `status: confirmation_required` and stops.
+4. Otherwise, runs the ability's real logic and returns its result unchanged.
+
+A confirmed call is **never** allowed to skip the quota re-check — only the confirmation step is
+skipped. This closes the race where quota is exhausted between the preview and the confirmed call.
+
+**`confirmation_required` response shape:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | `"confirmation_required"` | |
+| `message` | string | Human-readable summary of what will happen and how much quota remains. |
+| `impact` | object | `{ unit, count }` for `optimize-media`; `{ unit, count, total }` for `bulk-optimize` / `generate-missing-nextgen`. |
+| `quota_remaining` | number | Percentage of quota still available. |
+| `confirm_with` | object | `{ "confirm": true }` — tells the caller exactly which argument to resend. |
+
+**`insufficient_quota` response shape:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | `"insufficient_quota"` | |
+| `message` | string | Human-readable explanation that quota is exhausted. |
+| `next_date_update` | string | ISO date of the next quota reset, or `""` if unknown. |
+| `upgrade_url` | string | Link to the Imagify subscription/upgrade page. |
+
+**`invalid_api_key` response shape:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | `"invalid_api_key"` | |
+| `message` | string | Human-readable explanation that the API key is invalid or missing. |
+
+Every credit-consuming ability's `input_schema` includes a `confirm` boolean property (default
+`false`, not in `required`) and every credit-consuming ability's `output_schema` `status` enum
+includes `confirmation_required`, `insufficient_quota`, and `invalid_api_key` alongside its normal
+success/error values.
+
 ### `imagify/bulk-optimize`
 
 **Class:** `Imagify\Abilities\BulkOptimize`  
@@ -88,14 +148,19 @@ Schedules a bulk image optimization run for the WordPress media library or custo
 |-------|------|----------|-------------|
 | `context` | string | yes | `"wp"` for the WordPress media library or `"custom-folders"` for custom folder sources. |
 | `optimization_level` | integer (0–2) | no | Overrides the global setting. 0 = normal, 1 = aggressive, 2 = ultra. |
+| `confirm` | boolean | no | Set to `true` to execute after reviewing the credit-consumption preview returned by a prior call without this flag. Defaults to `false`. See [Credit confirmation flow](#credit-confirmation-flow). |
 
 **Output schema:**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `status` | `"scheduled"` \| `"error"` | Result status. |
-| `context` | string | The requested optimization context, echoed back. |
-| `error_message` | string \| null | Human-readable error on failure, null on success. |
+| `status` | `"scheduled"` \| `"error"` \| `"confirmation_required"` \| `"insufficient_quota"` \| `"invalid_api_key"` | Result status. |
+| `context` | string | The requested optimization context, echoed back. Present only on `scheduled`/`error`. |
+| `error_message` | string \| null | Human-readable error on failure, null on success. Present only on `scheduled`/`error`. |
+
+`get_impact_estimate()`'s `count`/`total` figures come from cheap COUNT-only queries per context:
+`imagify_count_unoptimized_attachments()` / `imagify_count_attachments()` for `"wp"`,
+`Imagify_Files_Stats::count_unoptimized_files()` / `count_files()` for `"custom-folders"`.
 
 ### `imagify/generate-missing-nextgen`
 
@@ -104,17 +169,27 @@ Schedules a bulk image optimization run for the WordPress media library or custo
 **Exposed via REST:** yes (`show_in_rest: true`)  
 **MCP discoverable:** yes (`mcp.public: true`)
 
-Queues generation of missing next-gen (WebP/AVIF) versions for all optimized media by delegating to `Bulk::run_generate_nextgen()`. Runs asynchronously via Action Scheduler. No required inputs.
+Queues generation of missing next-gen (WebP/AVIF) versions for all optimized media by delegating to `Bulk::run_generate_nextgen()`. Runs asynchronously via Action Scheduler.
 
 `status=scheduled` is returned both when jobs were enqueued (`queued_count > 0`) and when there is nothing to generate (`queued_count=0`). The latter is a successful no-op, not an error.
+
+**Input schema:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `confirm` | boolean | no | Set to `true` to execute after reviewing the credit-consumption preview returned by a prior call without this flag. Defaults to `false`. See [Credit confirmation flow](#credit-confirmation-flow). |
 
 **Output schema:**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `status` | `"scheduled"` \| `"error"` | Result status. |
-| `queued_count` | integer | Number of images queued for next-gen generation. |
-| `error_message` | string \| null | Human-readable error on failure, null on success. |
+| `status` | `"scheduled"` \| `"error"` \| `"confirmation_required"` \| `"insufficient_quota"` \| `"invalid_api_key"` | Result status. |
+| `queued_count` | integer | Number of images queued for next-gen generation. Present only on `scheduled`/`error`. |
+| `error_message` | string \| null | Human-readable error on failure, null on success. Present only on `scheduled`/`error`. |
+
+`get_impact_estimate()`'s `count` comes from the cached `Imagify\Stats\OptimizedMediaWithoutNextGen`
+stat service (`get_cached_stat()`, injected via DI); `total` sums
+`imagify_count_optimized_attachments() + Imagify_Files_Stats::count_optimized_files()`.
 
 ### `imagify/optimize-media`
 
@@ -136,16 +211,21 @@ Delegates to `Imagify\Optimization\Process\WP::optimize()` for first-time optimi
 |-------|------|----------|-------------|
 | `media_id` | integer | yes | WordPress attachment ID. |
 | `optimization_level` | integer (0–2) | no | Overrides the global setting. 0 = normal, 1 = aggressive, 2 = ultra. |
+| `confirm` | boolean | no | Set to `true` to execute after reviewing the credit-consumption preview returned by a prior call without this flag. Defaults to `false`. See [Credit confirmation flow](#credit-confirmation-flow). |
 
 **Output schema:**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `status` | `"success"` \| `"error"` | Result status. |
-| `original_size` | integer \| null | File size in bytes before optimization, or null on error. |
-| `optimized_size` | integer \| null | File size in bytes after optimization (may be null if the background job is not yet complete). |
-| `savings_percent` | float \| null | Percentage savings, or null on error or when sizes are unavailable. |
-| `error_message` | string \| null | Human-readable error on failure, null on success. |
+| `status` | `"success"` \| `"error"` \| `"confirmation_required"` \| `"insufficient_quota"` \| `"invalid_api_key"` | Result status. |
+| `original_size` | integer \| null | File size in bytes before optimization, or null on error. Present only on `success`/`error`. |
+| `optimized_size` | integer \| null | File size in bytes after optimization (may be null if the background job is not yet complete). Present only on `success`/`error`. |
+| `savings_percent` | float \| null | Percentage savings, or null on error or when sizes are unavailable. Present only on `success`/`error`. |
+| `error_message` | string \| null | Human-readable error on failure, null on success. Present only on `success`/`error`. |
+
+`get_impact_estimate()` always returns `{ unit: "image", count: 1, label: "this media" }` — optimizing
+a single media always costs exactly one unit, so `impact.total` is omitted from the
+`confirmation_required` response for this ability.
 
 ### `imagify/restore-media`
 


### PR DESCRIPTION

> 🤖 AI-generated — created by an automated pipeline. Review before acting on this.

Closes #1178
Closes #1186

# Description

Imagify MCP abilities that consume credits (optimize-media, bulk-optimize, generate-missing-nextgen) now gate side effects behind a two-call confirmation pattern: the first call without `confirm: true` returns a preview of impact and current quota; a follow-up call with `confirm: true` actually spends quota. Users are informed upfront of credit consumption before execution, and operations require explicit confirmation—preventing accidental quota spend when an AI agent invokes these tools.

This PR also includes the follow-up fixes from #1186 (commit `3853b914`): `BulkOptimize` now normalizes unrecognized `context` values to `wp` so the preview label always matches the counts (with a `['wp', 'custom-folders']` enum added to the input schema, and translatable human-readable labels), and `GenerateMissingNextgen`'s preview `count` now uses the live stat instead of the 2-day cached one, clamped to `total`, so "N of M" wording is never inconsistent.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #1178
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

**Automated:** 90 targeted unit tests + 22 targeted integration tests added/updated for the new guard, the two migrated abilities, and tracking changes — all passing. Full `composer test-unit` suite (332 tests) also green, no regressions. PHPCS/PHPStan: 0 new violations.

**QA (live verification via WP-CLI on the dev environment) — all 5 acceptance criteria PASS:**
1. Preview calls (no `confirm`) on `optimize-media`, `bulk-optimize`, and `generate-missing-nextgen` return `status: confirmation_required` with `impact` (unit/count/total) and `quota_remaining`.
2. The `message` field explains the action in human-readable terms before execution (e.g. "This action will consume Imagify quota: 3 of 6 unoptimized images in wp. Add \"confirm\": true to the same call to proceed.").
3. `confirm` must be strictly boolean `true` — a string `"true"` is rejected (verified live and by unit test). Confirmed calls execute exactly once (`optimize-media` → success, `bulk-optimize` → scheduled).
4. `insufficient_quota` responses include `next_date_update` and `upgrade_url`, and never invoke the underlying action (verified via unit test mocking an over-quota account; not reproducible live since the seeded dev account isn't over quota).
5. Success responses report `status: success`/`scheduled` with concrete data; error paths (invalid media ID, invalid context) return `status: error` with a descriptive message.

Regression smoke tests also passed: Settings page, Bulk optimization page, Media library (all HTTP 200 with Imagify content present), and the unrelated `GetAccount` ability (executes without the new confirm gate, unchanged response shape).

**Lead code review:** PASS, no blockers. One nice-to-have noted (label cosmetics for an unrecognized `BulkOptimize` context value — no functional/security impact) — ~~tracked as a follow-up~~ **now fixed in this PR** (#1186, commit `3853b914`), covered by new unit tests (unrecognized/missing context falls back to wp counts + label; full unit suite: 335 tests, 757 assertions, green).

**Known follow-up (nice-to-have, non-blocking):** in live testing, `GenerateMissingNextgen`'s preview occasionally showed `count` exceeding `total` because the two figures come from independently-cached sources (a 2-day cached stat vs. a live sum). ~~Tracked for a follow-up ticket~~ — **now fixed in this PR** (#1186): the preview uses the live stat, clamped to `total`, with a unit test asserting the `count <= total` invariant.

### How to test

Test the two-call confirmation flow for each credit-consuming ability:

1. **Preview call (no confirm):**
   - Call `imagify/optimize-media`, `imagify/bulk-optimize`, or `imagify/generate-missing-nextgen` without the `confirm` parameter (or with `confirm: false`).
   - Verify the response has `status: confirmation_required`, includes `message` (human-readable impact), `impact` (unit, count, total), and `quota_remaining` (percent).
   - Verify the response includes `confirm_with: { confirm: true }` showing the caller what to resend.

2. **Confirmed execution call:**
   - Resend the call with `confirm: true` added to the arguments.
   - Verify the ability executes normally (optimization runs, media is processed).
   - Verify the response shows `status: success` (or `status: error` if a post-execution API failure occurs).

3. **Insufficient quota case:**
   - (If quota is exhausted) Call without `confirm` and verify `status: insufficient_quota` with `message` and `upgrade_url` or `next_date_update`.
   - Verify `$run` is never invoked — no spending attempt is made.

4. **Invalid API key case:**
   - (If API key is invalid) Call any ability and verify `status: invalid_api_key` is returned before any quota check or execution.

5. **Regression tests:**
   - Verify `imagify/restore-media`, `imagify/update-settings`, and read-only abilities (`get-*`) are not affected by the guard.
   - Confirm existing analytics tracking (`MCP Ability Executed` event) now includes `is_preview: true` for preview responses and `is_preview: false` for real executions.

### Affected Features & Quality Assurance Scope

- **MCP Abilities:** `imagify/optimize-media`, `imagify/bulk-optimize`, `imagify/generate-missing-nextgen` — all three now require confirmation before quota spend.
- **Credit/quota system:** Pre-flight quota checks using existing `Imagify_Requirements::is_over_quota()`.
- **Analytics:** `MCP Ability Executed` event now distinguishes preview calls from real executions via the `is_preview` field.
- **Architecture:** `AbstractAbility` gains a shared `guard_credit_confirmation()` template method; `BulkOptimize` and `GenerateMissingNextgen` migrated to extend `AbstractAbility` for consistency.
- **No changes to:** `imagify/get-account`, `imagify/restore-media`, `imagify/update-settings`, or read-only abilities.

## Technical description

### Documentation

**Credit Confirmation Flow:**

The three credit-consuming MCP abilities implement a two-call pattern for explicit user confirmation:

1. **API key validation:** The guard first checks `is_api_key_valid()`. If invalid, returns `status: invalid_api_key` immediately.
2. **Quota check:** Next, it checks `is_over_quota()`. If over quota, returns `status: insufficient_quota` (includes `next_date_update` and `upgrade_url` for user guidance).
3. **Confirmation gate:** If `confirm` is not strictly `true`, returns `status: confirmation_required` with:
   - `message`: Human-readable explanation of what will happen (e.g., "Re-optimize 5 images (1 of your current quota remaining").
   - `impact`: `{ unit: 'image', count: N, total: M, label: '...' }` describing the scope.
   - `quota_remaining`: Percent of monthly quota available.
   - `confirm_with`: `{ confirm: true }` — tells the caller exactly what to resend.
4. **Execution:** Only if `confirm === true` and quota/key checks pass does `$run( $args )` invoke the actual ability logic.

**Implementation Details:**

- New `CreditConsumingAbilityInterface` defines the contract: `get_impact_estimate( array $args ): array` returns scope and unit info.
- New `guard_credit_confirmation( array $args, callable $run ): array` template method on `AbstractAbility` encapsulates the 4-step flow above.
- `OptimizeMedia` implements the interface and wraps `execute()` with the guard.
- `BulkOptimize` and `GenerateMissingNextgen` are migrated to extend `AbstractAbility`, implement the interface, and wire the guard.
- `get_impact_estimate()` for `BulkOptimize` uses cheap COUNT helpers (`imagify_count_unoptimized_attachments()` / `Imagify_Files_Stats::count_unoptimized_files()`); for `GenerateMissingNextgen` uses injected `StatInterface` cached count + summed optimized totals.
- `get_required_capability()` is a new overridable template method to thread the correct capability string (e.g., `manage_options` for `BulkOptimize`/`GenerateMissingNextgen`) through analytics events.
- Tracking layer computes `is_preview = in_array( $result['status'] ?? '', [ 'confirmation_required', 'insufficient_quota', 'invalid_api_key' ], true )` and logs it to Mixpanel so preview calls don't skew execution analytics.
- Closures (not callable-arrays) are used to wrap private `do_execute()` methods so visibility is resolved in the defining class, not in `AbstractAbility`'s scope.

### New dependencies

None — the implementation reuses existing `Imagify_Requirements`, `User`, `Bulk`, `StatInterface`, and analytics infrastructure.

### Risks

- **Low:** The guard is a pre-execution gate, not a code path change — if anything fails, the worst case is the call doesn't spend quota (safe-fail).
- **Race condition (quota flip between preview and confirm):** The guard re-checks quota on every call, so a quota flip between the preview and confirmed call is caught; the confirmed call won't bypass the check.
- **Performance:** `get_impact_estimate()` uses cheap COUNT queries (no new heavy JOINs). `GenerateMissingNextgen` reuses a 2-day cached stat service, so preview calls don't hammer the database.
- **Analytics:** The new `is_preview` field has a default (`false`), so it's backward compatible — abilities not yet wired to the guard will report `false` correctly.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*All items validated — see "What was tested" above (automated test suite + live QA verification of all 5 acceptance criteria + lead code review pass).*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

