### PR TITLE
Integrate wp-media/mcp-oauth library for MCP OAuth (#1182)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
 		"woocommerce/action-scheduler": "^3.4",
 		"wordpress/mcp-adapter": "^0.5.0",
 		"wp-media/apply-filters-typed": "^1.0",
+		"wp-media/mcp-oauth": "^1.0.1",
 		"wp-media/plugin-family": "^1.0",
 		"wp-media/wp-mixpanel": "^1.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
 		"woocommerce/action-scheduler": "^3.4",
 		"wordpress/mcp-adapter": "^0.5.0",
 		"wp-media/apply-filters-typed": "^1.0",
-		"wp-media/mcp-oauth": "^1.0.1",
+		"wp-media/mcp-oauth": "^1.0.2",
 		"wp-media/plugin-family": "^1.0",
 		"wp-media/wp-mixpanel": "^1.0"
 	},

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -36,6 +36,31 @@ class_exists( \WP\MCP\Core\McpAdapter::class )
 
 The endpoint returns HTTP 200 with the adapter's default three-tool set plus all registered Imagify abilities.
 
+## OAuth (Claude Desktop / MCP clients)
+
+Imagify bundles the shared `wp-media/mcp-oauth` library (`^1.0.1`) to expose an OAuth 2.1 + PKCE authenticated MCP server for clients such as Claude Desktop. Imagify contains **no custom OAuth code** — the library owns the entire flow (authorize / consent / token / revoke endpoints, `.well-known` discovery documents, and the isolated server registration).
+
+The library is booted in `imagify_init()` in `inc/main.php`, guarded by `class_exists( \WPMedia\MCP\OAuth\Bootstrap::class )`, right after the `wordpress/mcp-adapter` boot:
+
+```php
+if ( class_exists( \WPMedia\MCP\OAuth\Bootstrap::class ) ) {
+    add_filter( 'wpmedia_mcp_oauth_server_enabled', '__return_true' );
+
+    \WPMedia\MCP\OAuth\Bootstrap::instance();
+}
+```
+
+Imagify enables the server unconditionally via the library's `wpmedia_mcp_oauth_server_enabled` filter (default `false` upstream).
+
+| Key | Value |
+|-----|-------|
+| OAuth server path | `/wp-json/mcp/mcp-oauth-server` |
+| Discovery | `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource` |
+| Tools exposed | `mcp-adapter/discover-abilities`, `mcp-adapter/get-ability-info`, `mcp-adapter/execute-ability` |
+| Auth | OAuth 2.1 + PKCE, JWT bearer tokens |
+
+The OAuth server's fixed tool list is only the three generic mcp-adapter tools, but `discover-abilities` and `execute-ability` read from the **global** WordPress Abilities registry (`wp_get_abilities()` / `wp_get_ability()`), not a fixed category — so all `imagify/*` abilities registered by `AbilitiesSubscriber` are fully discoverable and callable through the OAuth server, with no extra wiring needed. `ConfigSubscriber`'s `mcp_adapter_default_server_config` filter is unaffected — it only customizes the unauthenticated default server, not the OAuth server created by the library.
+
 ## Classes
 
 | Class | Responsibility |

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -38,19 +38,21 @@ The endpoint returns HTTP 200 with the adapter's default three-tool set plus all
 
 ## OAuth (Claude Desktop / MCP clients)
 
-Imagify bundles the shared `wp-media/mcp-oauth` library (`^1.0.1`) to expose an OAuth 2.1 + PKCE authenticated MCP server for clients such as Claude Desktop. Imagify contains **no custom OAuth code** — the library owns the entire flow (authorize / consent / token / revoke endpoints, `.well-known` discovery documents, and the isolated server registration).
+Imagify bundles the shared `wp-media/mcp-oauth` library (`^1.0.2`) to expose an OAuth 2.1 + PKCE authenticated MCP server for clients such as Claude Desktop. Imagify contains **no custom OAuth code** — the library owns the entire flow (authorize / consent / token / revoke endpoints, `.well-known` discovery documents, and the isolated server registration).
 
-The library is booted in `imagify_init()` in `inc/main.php`, guarded by `class_exists( \WPMedia\MCP\OAuth\Bootstrap::class )`, right after the `wordpress/mcp-adapter` boot:
+The library is booted in `imagify_init()` in `inc/main.php`, guarded by `class_exists( \WPMedia\MCP\OAuth\Bootstrap::class )`, inside the same `$can_boot_mcp_adapter` guard as the `wordpress/mcp-adapter` boot it depends on:
 
 ```php
-if ( class_exists( \WPMedia\MCP\OAuth\Bootstrap::class ) ) {
-    add_filter( 'wpmedia_mcp_oauth_server_enabled', '__return_true' );
+if ( $can_boot_mcp_adapter ) {
+    \WP\MCP\Core\McpAdapter::instance();
 
-    \WPMedia\MCP\OAuth\Bootstrap::instance();
+    if ( class_exists( \WPMedia\MCP\OAuth\Bootstrap::class ) ) {
+        \WPMedia\MCP\OAuth\Bootstrap::instance();
+    }
 }
 ```
 
-Imagify enables the server unconditionally via the library's `wpmedia_mcp_oauth_server_enabled` filter (default `false` upstream).
+The server is enabled by default from `wp-media/mcp-oauth` v1.0.2 onward, so no `wpmedia_mcp_oauth_server_enabled` filter is needed. It can still be disabled by filtering that value to `false`.
 
 | Key | Value |
 |-----|-------|

--- a/inc/main.php
+++ b/inc/main.php
@@ -46,5 +46,15 @@ function imagify_init() {
 	if ( $can_boot_mcp_adapter ) {
 		\WP\MCP\Core\McpAdapter::instance();
 	}
+
+	// Boot the shared MCP OAuth library (wp-media/mcp-oauth) so Claude Desktop
+	// (and any other MCP client) can authenticate against the isolated
+	// `mcp-oauth-server` it registers. The library self-wires its own
+	// WordPress hooks; Imagify has no custom OAuth code.
+	if ( class_exists( \WPMedia\MCP\OAuth\Bootstrap::class ) ) {
+		add_filter( 'wpmedia_mcp_oauth_server_enabled', '__return_true' );
+
+		\WPMedia\MCP\OAuth\Bootstrap::instance();
+	}
 }
 add_action( 'plugins_loaded', 'imagify_init' );

--- a/inc/main.php
+++ b/inc/main.php
@@ -45,16 +45,15 @@ function imagify_init() {
 
 	if ( $can_boot_mcp_adapter ) {
 		\WP\MCP\Core\McpAdapter::instance();
-	}
 
-	// Boot the shared MCP OAuth library (wp-media/mcp-oauth) so Claude Desktop
-	// (and any other MCP client) can authenticate against the isolated
-	// `mcp-oauth-server` it registers. The library self-wires its own
-	// WordPress hooks; Imagify has no custom OAuth code.
-	if ( class_exists( \WPMedia\MCP\OAuth\Bootstrap::class ) ) {
-		add_filter( 'wpmedia_mcp_oauth_server_enabled', '__return_true' );
-
-		\WPMedia\MCP\OAuth\Bootstrap::instance();
+		// Boot the shared MCP OAuth library (wp-media/mcp-oauth) so Claude Desktop
+		// (and any other MCP client) can authenticate against the isolated
+		// `mcp-oauth-server` it registers. The library self-wires its own
+		// WordPress hooks and is enabled by default; Imagify has no custom OAuth
+		// code. It relies on the MCP adapter, so it only boots when the adapter can.
+		if ( class_exists( \WPMedia\MCP\OAuth\Bootstrap::class ) ) {
+			\WPMedia\MCP\OAuth\Bootstrap::instance();
+		}
 	}
 }
 add_action( 'plugins_loaded', 'imagify_init' );


### PR DESCRIPTION
# Description

Fixes #1182

Integrates the shared [`wp-media/mcp-oauth`](https://github.com/wp-media/mcp-oauth) library so MCP clients can authenticate against the site via OAuth 2.1 + PKCE, instead of relying on an existing WordPress session. Users can connect Claude Desktop to their site's Imagify MCP server through a standard consent flow — including on browsers where they are already logged into wp-admin. All OAuth flow code lives in the library; the plugin only adds boot glue.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## Detailed scenario

### What was tested


The Claude Desktop OAuth flow itself (acceptance criteria) still needs manual QA, see "How to test".

### How to test

1. Check out this branch and run `composer install`.
2. The OAuth server is enabled by default (`wp-media/mcp-oauth` v1.0.2+ ships with `wpmedia_mcp_oauth_server_enabled` defaulting to `true`; the plugin adds no filter).
3. Visit `https://<site>/.well-known/oauth-authorization-server` — should return the OAuth discovery JSON (confirms rewrite rules were flushed and the server is active).
4. In Claude Desktop, add a custom connector pointing to `https://<site>/wp-json/mcp/mcp-oauth-server` and complete the OAuth flow (login if needed, then the consent screen → "Allow").
5. Repeat step 4 from a browser session already logged into wp-admin — the flow must still complete correctly (AC from #1182).
6. In Claude Desktop, verify the `imagify/*` abilities (e.g. `imagify/get-stats`, `imagify/optimize-media`) are discoverable and callable through the `discover-abilities` / `execute-ability` tools.
7. Disable path: add `add_filter( 'wpmedia_mcp_oauth_server_enabled', '__return_false', 20 );` in a mu-plugin and confirm `/oauth/authorize` and the discovery documents return 404.

### Affected Features & Quality Assurance Scope

- **MCP server / abilities**: the existing unauthenticated default MCP server and all `imagify/*` abilities are untouched (`classes/MCP/`, `classes/Abilities/` unchanged). A second, isolated `mcp-oauth-server` endpoint is added by the library.
- **Rewrite rules**: the library registers `/oauth/*` and `/.well-known/*` rewrite rules with a lazy flush on first `init` — worth a smoke check that permalinks and the existing WebP/AVIF rewrite rules are unaffected.
- No impact on optimization, bulk, or admin UI features.

## Technical description

### Documentation

`docs/api/mcp.md` gained an "OAuth (Claude Desktop / MCP clients)" section.

How it works:
- `inc/main.php` boots `\WPMedia\MCP\OAuth\Bootstrap::instance()` (guarded by `class_exists`) right after the existing `McpAdapter::instance()` boot, **inside the same `$can_boot_mcp_adapter` guard** — the OAuth library depends on the mcp-adapter being available. This runs on `plugins_loaded`, before `rest_api_init` priority 15, as the library requires. No enable filter is needed: v1.0.2+ ships enabled by default.
- `Bootstrap` is a singleton: if another WP Media plugin (e.g. WP Rocket) already booted the library on the same site, Imagify's call is a no-op — no duplicate rewrite rules or MCP servers.
- The library registers its own isolated MCP server (`/wp-json/mcp/mcp-oauth-server`) exposing the mcp-adapter's generic `discover-abilities` / `get-ability-info` / `execute-ability` tools. Those read the **global** WP Abilities registry, so all `imagify/*` abilities registered by `Imagify\MCP\AbilitiesSubscriber` are automatically available through the OAuth server with no extra wiring.
- `Imagify\MCP\ConfigSubscriber` (default-server naming) is unrelated to the OAuth server and remains as-is.

### New dependencies

- `wp-media/mcp-oauth ^1.0.2` (Packagist, GPL-2.0+). Its own requirements (`wordpress/mcp-adapter ^0.5`, `wp-media/apply-filters-typed ^1.0`) were already satisfied by the plugin.

### Risks

- **Auth surface**: new OAuth endpoints are added, but the flow is OAuth 2.1 + PKCE with a trusted-publisher (CIMD) allowlist and JWT-validated transport, implemented and reviewed once in the shared library (already targeted by WP Rocket in wp-media/wp-rocket#8634). Ability execution still goes through the WP Abilities permission callbacks.
- **Enabled by default**: the server is active out of the box (product decision), inherited from `wp-media/mcp-oauth` v1.0.2's default. It can be disabled via the `wpmedia_mcp_oauth_server_enabled` filter.
- **Multi-plugin coexistence**: singleton bootstrap in the library prevents duplicate registration when WP Rocket and Imagify are both active.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

- *Built-in tests*: the change is a few lines of boot glue in `inc/main.php`, a file with no existing test coverage (the pre-existing `McpAdapter::instance()` boot is equally untested), and the local WP integration test library is unavailable to validate a new integration test. The OAuth flow itself is covered by the library's own test suite. A follow-up integration test asserting the bootstrap wiring can be added if desired.
- *Acceptance Criteria*: static/unit validation done; the end-to-end Claude Desktop flow requires manual QA on a publicly reachable site (see "How to test").

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

*(Error handling: the boot glue is guarded by `class_exists`; HTTP/error handling lives inside the library, which logs via its `McpLogger` when `WP_DEBUG` + `WP_DEBUG_LOG` are on.)*

