### PR TITLE
Chunk unbounded IN() queries to avoid WP Engine killed queries (#745)

### DIFF
--- a/Tests/Fixtures/inc/classes/ImagifyDB/chunkInValues.php
+++ b/Tests/Fixtures/inc/classes/ImagifyDB/chunkInValues.php
@@ -1,0 +1,92 @@
+<?php
+
+$long_strings = [];
+
+for ( $i = 0; $i < 50; $i++ ) {
+	$long_strings[] = str_repeat( 'a', 300 ) . $i;
+}
+
+$huge_value = str_repeat( 'x', 5000 );
+
+return [
+	'test_data' => [
+		// An empty input should return an empty array of chunks.
+		'shouldReturnEmptyArrayForEmptyInput'          => [
+			'config'   => [
+				'values' => [],
+				'budget' => 8000,
+			],
+			'expected' => [
+				'chunk_count'     => 0,
+				'preserves_order' => true,
+			],
+		],
+
+		// When the whole list fits under the budget, only one chunk should be returned.
+		'shouldReturnSingleChunkWhenUnderBudget'       => [
+			'config'   => [
+				'values' => range( 1, 100 ),
+				'budget' => 8000,
+			],
+			'expected' => [
+				'chunk_count'     => 1,
+				'preserves_order' => true,
+			],
+		],
+
+		// Integer IDs should split into several chunks once the budget is exceeded,
+		// no value lost, order preserved, every chunk under budget.
+		'shouldSplitIntegersIntoMultipleChunks'        => [
+			'config'   => [
+				'values' => range( 100000, 100999 ),
+				'budget' => 100,
+			],
+			'expected' => [
+				'min_chunks'          => 2,
+				'max_rendered_length' => 100,
+				'preserves_order'     => true,
+			],
+		],
+
+		// Long quoted string values (e.g. file paths) should split once the rendered
+		// (quoted) length exceeds the budget.
+		'shouldSplitLongStringValuesIntoMultipleChunks' => [
+			'config'   => [
+				'values' => $long_strings,
+				'budget' => 1000,
+			],
+			'expected' => [
+				'min_chunks'          => 2,
+				'max_rendered_length' => 1000,
+				'quoted'              => true,
+				'preserves_order'     => true,
+			],
+		],
+
+		// A single value that alone exceeds the budget should still be returned,
+		// alone in its own chunk, rather than being dropped.
+		'shouldKeepOversizedSingleValueAloneInItsOwnChunk' => [
+			'config'   => [
+				'values' => [ 1, $huge_value, 2 ],
+				'budget' => 100,
+			],
+			'expected' => [
+				'oversized_value' => $huge_value,
+				'preserves_order' => true,
+			],
+		],
+
+		// An invalid budget (0 or negative) should fall back to the default budget
+		// instead of producing a chunk per value.
+		'shouldFallBackToDefaultBudgetWhenGivenInvalidValue' => [
+			'config'   => [
+				'values' => range( 1, 10 ),
+				'budget' => 0,
+			],
+			'expected' => [
+				'chunk_count'     => 1,
+				'preserves_order' => true,
+			],
+		],
+	],
+];

--- a/Tests/Fixtures/inc/classes/ImagifyDB/chunkInValues.php
+++ b/Tests/Fixtures/inc/classes/ImagifyDB/chunkInValues.php
@@ -11,7 +11,7 @@ $huge_value = str_repeat( 'x', 5000 );
 return [
 	'test_data' => [
 		// An empty input should return an empty array of chunks.
-		'shouldReturnEmptyArrayForEmptyInput'          => [
+		'shouldReturnEmptyArrayForEmptyInput'              => [
 			'config'   => [
 				'values' => [],
 				'budget' => 8000,
@@ -23,7 +23,7 @@ return [
 		],
 
 		// When the whole list fits under the budget, only one chunk should be returned.
-		'shouldReturnSingleChunkWhenUnderBudget'       => [
+		'shouldReturnSingleChunkWhenUnderBudget'           => [
 			'config'   => [
 				'values' => range( 1, 100 ),
 				'budget' => 8000,
@@ -35,30 +35,55 @@ return [
 		],
 
 		// Integer IDs should split into several chunks once the budget is exceeded,
-		// no value lost, order preserved, every chunk under budget.
-		'shouldSplitIntegersIntoMultipleChunks'        => [
+		// no value lost, order preserved, every chunk under budget and packed full.
+		// 1000 values of 6 chars: 14 per chunk (6 + 13 * 7 = 97), so 71 full chunks + 1.
+		'shouldSplitIntegersIntoMultipleChunks'            => [
 			'config'   => [
 				'values' => range( 100000, 100999 ),
 				'budget' => 100,
 			],
 			'expected' => [
-				'min_chunks'          => 2,
+				'chunk_count'         => 72,
 				'max_rendered_length' => 100,
+				'fully_packed'        => true,
 				'preserves_order'     => true,
 			],
 		],
 
 		// Long quoted string values (e.g. file paths) should split once the rendered
 		// (quoted) length exceeds the budget.
-		'shouldSplitLongStringValuesIntoMultipleChunks' => [
+		// 50 values rendering to 303/304 chars: 3 per chunk, so 16 full chunks + 1.
+		'shouldSplitLongStringValuesIntoMultipleChunks'    => [
 			'config'   => [
 				'values' => $long_strings,
 				'budget' => 1000,
 			],
 			'expected' => [
-				'min_chunks'          => 2,
+				'chunk_count'         => 17,
 				'max_rendered_length' => 1000,
 				'quoted'              => true,
+				'fully_packed'        => true,
+				'preserves_order'     => true,
+			],
+		],
+
+		// Regression: every chunk after the first must be filled up to the budget too.
+		// A chunk length counter that is not reset on flush yields one value per chunk
+		// from the second chunk on (31 chunks instead of 3 here).
+		'shouldFillEveryChunkUpToTheBudget'                => [
+			'config'   => [
+				'values' => range( 1, 50 ),
+				'budget' => 50,
+			],
+			'expected' => [
+				'chunk_count'         => 3,
+				'exact_chunks'        => [
+					range( 1, 20 ),
+					range( 21, 37 ),
+					range( 38, 50 ),
+				],
+				'max_rendered_length' => 50,
+				'fully_packed'        => true,
 				'preserves_order'     => true,
 			],
 		],

--- a/Tests/Unit/inc/classes/ImagifyDB/chunkInValues.php
+++ b/Tests/Unit/inc/classes/ImagifyDB/chunkInValues.php
@@ -39,25 +39,36 @@ class Test_ChunkInValues extends TestCase {
 			$this->assertCount( $expected['chunk_count'], $chunks );
 		}
 
-		if ( isset( $expected['min_chunks'] ) ) {
-			$this->assertGreaterThanOrEqual( $expected['min_chunks'], count( $chunks ) );
+		if ( isset( $expected['exact_chunks'] ) ) {
+			$this->assertSame( $expected['exact_chunks'], $chunks );
 		}
+
+		$quoted = ! empty( $expected['quoted'] );
 
 		if ( ! empty( $expected['max_rendered_length'] ) ) {
 			foreach ( $chunks as $chunk ) {
-				$rendered = empty( $expected['quoted'] )
-					? implode( ',', $chunk )
-					: implode(
-						',',
-						array_map(
-							function ( $value ) {
-								return "'" . $value . "'";
-							},
-							$chunk
-						)
-					);
+				$this->assertLessThanOrEqual(
+					$expected['max_rendered_length'],
+					strlen( $this->render( $chunk, $quoted ) )
+				);
+			}
+		}
 
-				$this->assertLessThanOrEqual( $expected['max_rendered_length'], strlen( $rendered ) );
+		if ( ! empty( $expected['fully_packed'] ) ) {
+			$budget = $expected['max_rendered_length'];
+			$count  = count( $chunks );
+
+			// Every chunk but the last must be full: the next chunk's first value
+			// could not have been appended without going over the budget.
+			for ( $i = 0; $i < $count - 1; $i++ ) {
+				$next_value = $chunks[ $i + 1 ][0];
+				$with_next  = $this->render( array_merge( $chunks[ $i ], [ $next_value ] ), $quoted );
+
+				$this->assertGreaterThan(
+					$budget,
+					strlen( $with_next ),
+					"Chunk $i is not filled up to the budget."
+				);
 			}
 		}
 
@@ -78,5 +89,28 @@ class Test_ChunkInValues extends TestCase {
 			$merged = $chunks ? array_merge( ...$chunks ) : [];
 			$this->assertSame( $config['values'], $merged );
 		}
+	}
+
+	/**
+	 * Render a chunk the way it would appear inside an `IN ()` clause.
+	 *
+	 * @param  array $chunk  The chunk values.
+	 * @param  bool  $quoted Whether the values are quoted (non integer values).
+	 * @return string
+	 */
+	private function render( array $chunk, bool $quoted ): string {
+		if ( ! $quoted ) {
+			return implode( ',', $chunk );
+		}
+
+		return implode(
+			',',
+			array_map(
+				function ( $value ) {
+					return "'" . $value . "'";
+				},
+				$chunk
+			)
+		);
 	}
 }

--- a/Tests/Unit/inc/classes/ImagifyDB/chunkInValues.php
+++ b/Tests/Unit/inc/classes/ImagifyDB/chunkInValues.php
@@ -31,111 +31,53 @@ class Test_ChunkInValues extends TestCase {
 	}
 
 	/**
-	 * An empty input should return an empty array of chunks.
+	 * @dataProvider configTestData
 	 */
-	public function testShouldReturnEmptyArrayForEmptyInput() {
-		$this->assertSame( [], Imagify_DB::chunk_in_values( [] ) );
-	}
+	public function testShouldReturnExpectedChunks( $config, $expected ) {
+		$chunks = Imagify_DB::chunk_in_values( $config['values'], $config['budget'] );
 
-	/**
-	 * When the whole list fits under the budget, only one chunk should be returned.
-	 */
-	public function testShouldReturnSingleChunkWhenUnderBudget() {
-		$values = range( 1, 100 );
-
-		$chunks = Imagify_DB::chunk_in_values( $values, 8000 );
-
-		$this->assertCount( 1, $chunks );
-		$this->assertSame( $values, $chunks[0] );
-	}
-
-	/**
-	 * Integer IDs should be split into several chunks once the budget is exceeded,
-	 * and no value should be lost or reordered across chunks.
-	 */
-	public function testShouldSplitIntegersIntoMultipleChunksWhenOverBudget() {
-		// 1000 integer IDs, small budget forces several chunks.
-		$values = range( 100000, 100999 );
-
-		$chunks = Imagify_DB::chunk_in_values( $values, 100 );
-
-		$this->assertGreaterThan( 1, count( $chunks ) );
-
-		// Every chunk's rendered length must stay under (or at) the budget.
-		foreach ( $chunks as $chunk ) {
-			$rendered_length = strlen( implode( ',', $chunk ) );
-			$this->assertLessThanOrEqual( 100, $rendered_length );
+		if ( isset( $expected['chunk_count'] ) ) {
+			$this->assertCount( $expected['chunk_count'], $chunks );
 		}
 
-		// No value lost, order preserved.
-		$this->assertSame( $values, array_merge( ...$chunks ) );
-	}
-
-	/**
-	 * Long quoted string values (e.g. file paths) should be split into several chunks
-	 * once the rendered (quoted) length exceeds the budget.
-	 */
-	public function testShouldSplitLongStringValuesIntoMultipleChunks() {
-		$values = [];
-
-		for ( $i = 0; $i < 50; $i++ ) {
-			$values[] = str_repeat( 'a', 300 ) . $i;
+		if ( isset( $expected['min_chunks'] ) ) {
+			$this->assertGreaterThanOrEqual( $expected['min_chunks'], count( $chunks ) );
 		}
 
-		$chunks = Imagify_DB::chunk_in_values( $values, 1000 );
+		if ( ! empty( $expected['max_rendered_length'] ) ) {
+			foreach ( $chunks as $chunk ) {
+				$rendered = empty( $expected['quoted'] )
+					? implode( ',', $chunk )
+					: implode(
+						',',
+						array_map(
+							function ( $value ) {
+								return "'" . $value . "'";
+							},
+							$chunk
+						)
+					);
 
-		$this->assertGreaterThan( 1, count( $chunks ) );
-
-		foreach ( $chunks as $chunk ) {
-			$rendered = implode(
-				',',
-				array_map(
-					function ( $value ) {
-						return "'" . $value . "'";
-					},
-					$chunk
-				)
-			);
-
-			$this->assertLessThanOrEqual( 1000, strlen( $rendered ) );
-		}
-
-		$this->assertSame( $values, array_merge( ...$chunks ) );
-	}
-
-	/**
-	 * A single value that alone exceeds the budget should still be returned,
-	 * alone in its own chunk, rather than being dropped.
-	 */
-	public function testShouldKeepOversizedSingleValueAloneInItsOwnChunk() {
-		$huge_value = str_repeat( 'x', 5000 );
-		$values     = [ 1, $huge_value, 2 ];
-
-		$chunks = Imagify_DB::chunk_in_values( $values, 100 );
-
-		// The oversized value must still be present, alone in its own chunk.
-		$found = false;
-
-		foreach ( $chunks as $chunk ) {
-			if ( in_array( $huge_value, $chunk, true ) ) {
-				$this->assertCount( 1, $chunk );
-				$found = true;
+				$this->assertLessThanOrEqual( $expected['max_rendered_length'], strlen( $rendered ) );
 			}
 		}
 
-		$this->assertTrue( $found );
-		$this->assertSame( $values, array_merge( ...$chunks ) );
-	}
+		if ( isset( $expected['oversized_value'] ) ) {
+			$found = false;
 
-	/**
-	 * An invalid budget (e.g. 0 or negative) should fall back to the default budget
-	 * instead of producing a chunk per value.
-	 */
-	public function testShouldFallBackToDefaultBudgetWhenGivenInvalidValue() {
-		$values = range( 1, 10 );
-		$chunks = Imagify_DB::chunk_in_values( $values, 0 );
+			foreach ( $chunks as $chunk ) {
+				if ( in_array( $expected['oversized_value'], $chunk, true ) ) {
+					$this->assertCount( 1, $chunk );
+					$found = true;
+				}
+			}
 
-		$this->assertCount( 1, $chunks );
-		$this->assertSame( $values, $chunks[0] );
+			$this->assertTrue( $found );
+		}
+
+		if ( ! empty( $expected['preserves_order'] ) ) {
+			$merged = $chunks ? array_merge( ...$chunks ) : [];
+			$this->assertSame( $config['values'], $merged );
+		}
 	}
 }

--- a/Tests/Unit/inc/classes/ImagifyDB/chunkInValues.php
+++ b/Tests/Unit/inc/classes/ImagifyDB/chunkInValues.php
@@ -1,0 +1,141 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\inc\classes\ImagifyDB;
+
+use Brain\Monkey\Functions;
+use Imagify_DB;
+use Imagify\Tests\Unit\TestCase;
+
+/**
+ * Tests for Imagify_DB::chunk_in_values().
+ *
+ * @covers Imagify_DB::chunk_in_values
+ *
+ * @group  ImagifyDB
+ */
+class Test_ChunkInValues extends TestCase {
+
+	/**
+	 * Set up the test environment.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		Functions\when( 'esc_sql' )->returnArg();
+		Functions\when( 'apply_filters' )->alias(
+			function ( $tag, $value ) {
+				return $value;
+			}
+		);
+	}
+
+	/**
+	 * An empty input should return an empty array of chunks.
+	 */
+	public function testShouldReturnEmptyArrayForEmptyInput() {
+		$this->assertSame( [], Imagify_DB::chunk_in_values( [] ) );
+	}
+
+	/**
+	 * When the whole list fits under the budget, only one chunk should be returned.
+	 */
+	public function testShouldReturnSingleChunkWhenUnderBudget() {
+		$values = range( 1, 100 );
+
+		$chunks = Imagify_DB::chunk_in_values( $values, 8000 );
+
+		$this->assertCount( 1, $chunks );
+		$this->assertSame( $values, $chunks[0] );
+	}
+
+	/**
+	 * Integer IDs should be split into several chunks once the budget is exceeded,
+	 * and no value should be lost or reordered across chunks.
+	 */
+	public function testShouldSplitIntegersIntoMultipleChunksWhenOverBudget() {
+		// 1000 integer IDs, small budget forces several chunks.
+		$values = range( 100000, 100999 );
+
+		$chunks = Imagify_DB::chunk_in_values( $values, 100 );
+
+		$this->assertGreaterThan( 1, count( $chunks ) );
+
+		// Every chunk's rendered length must stay under (or at) the budget.
+		foreach ( $chunks as $chunk ) {
+			$rendered_length = strlen( implode( ',', $chunk ) );
+			$this->assertLessThanOrEqual( 100, $rendered_length );
+		}
+
+		// No value lost, order preserved.
+		$this->assertSame( $values, array_merge( ...$chunks ) );
+	}
+
+	/**
+	 * Long quoted string values (e.g. file paths) should be split into several chunks
+	 * once the rendered (quoted) length exceeds the budget.
+	 */
+	public function testShouldSplitLongStringValuesIntoMultipleChunks() {
+		$values = [];
+
+		for ( $i = 0; $i < 50; $i++ ) {
+			$values[] = str_repeat( 'a', 300 ) . $i;
+		}
+
+		$chunks = Imagify_DB::chunk_in_values( $values, 1000 );
+
+		$this->assertGreaterThan( 1, count( $chunks ) );
+
+		foreach ( $chunks as $chunk ) {
+			$rendered = implode(
+				',',
+				array_map(
+					function ( $value ) {
+						return "'" . $value . "'";
+					},
+					$chunk
+				)
+			);
+
+			$this->assertLessThanOrEqual( 1000, strlen( $rendered ) );
+		}
+
+		$this->assertSame( $values, array_merge( ...$chunks ) );
+	}
+
+	/**
+	 * A single value that alone exceeds the budget should still be returned,
+	 * alone in its own chunk, rather than being dropped.
+	 */
+	public function testShouldKeepOversizedSingleValueAloneInItsOwnChunk() {
+		$huge_value = str_repeat( 'x', 5000 );
+		$values     = [ 1, $huge_value, 2 ];
+
+		$chunks = Imagify_DB::chunk_in_values( $values, 100 );
+
+		// The oversized value must still be present, alone in its own chunk.
+		$found = false;
+
+		foreach ( $chunks as $chunk ) {
+			if ( in_array( $huge_value, $chunk, true ) ) {
+				$this->assertCount( 1, $chunk );
+				$found = true;
+			}
+		}
+
+		$this->assertTrue( $found );
+		$this->assertSame( $values, array_merge( ...$chunks ) );
+	}
+
+	/**
+	 * An invalid budget (e.g. 0 or negative) should fall back to the default budget
+	 * instead of producing a chunk per value.
+	 */
+	public function testShouldFallBackToDefaultBudgetWhenGivenInvalidValue() {
+		$values = range( 1, 10 );
+		$chunks = Imagify_DB::chunk_in_values( $values, 0 );
+
+		$this->assertCount( 1, $chunks );
+		$this->assertSame( $values, $chunks[0] );
+	}
+}

--- a/Tests/Unit/inc/classes/ImagifyDB/chunkInValues.php
+++ b/Tests/Unit/inc/classes/ImagifyDB/chunkInValues.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Imagify\Tests\Unit\inc\classes\ImagifyDB;
 
-use Brain\Monkey\Functions;
 use Imagify_DB;
 use Imagify\Tests\Unit\TestCase;
 
@@ -22,16 +21,16 @@ class Test_ChunkInValues extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		Functions\when( 'esc_sql' )->returnArg();
-		Functions\when( 'apply_filters' )->alias(
-			function ( $tag, $value ) {
-				return $value;
-			}
-		);
+		$this->stubEscapeFunctions();
 	}
 
 	/**
+	 * Test chunk_in_values() against the configTestData fixture.
+	 *
 	 * @dataProvider configTestData
+	 *
+	 * @param array $config   The test config (values and budget).
+	 * @param array $expected The expected assertions to run.
 	 */
 	public function testShouldReturnExpectedChunks( $config, $expected ) {
 		$chunks = Imagify_DB::chunk_in_values( $config['values'], $config['budget'] );

--- a/inc/classes/class-imagify-custom-folders.php
+++ b/inc/classes/class-imagify-custom-folders.php
@@ -739,10 +739,31 @@ class Imagify_Custom_Folders {
 				}
 			}
 
-			$placeholders  = Imagify_DB::prepare_values_list( array_keys( $folders_by_placeholder ) );
 			$select_fields = "$files_key_esc, folder_id, path" . ( $optimization ? ', optimization_level, status' : '' );
 
-			$results = $wpdb->get_results( "SELECT $select_fields FROM $files_table WHERE path IN ( $placeholders ) ORDER BY folder_id, $files_key_esc;", ARRAY_A ); // WPCS: unprepared SQL ok.
+			$results = [];
+
+			foreach ( Imagify_DB::chunk_in_values( array_keys( $folders_by_placeholder ) ) as $placeholders_chunk ) {
+				$placeholders  = Imagify_DB::prepare_values_list( $placeholders_chunk );
+				$chunk_results = $wpdb->get_results( "SELECT $select_fields FROM $files_table WHERE path IN ( $placeholders );", ARRAY_A ); // WPCS: unprepared SQL ok.
+
+				if ( $chunk_results ) {
+					$results = array_merge( $results, $chunk_results );
+				}
+			}
+
+			if ( $results ) {
+				// Re-apply the ordering that was previously done in SQL (`ORDER BY folder_id, $files_key_esc`).
+				usort(
+					$results,
+					function ( $a, $b ) use ( $files_key_esc ) {
+						if ( $a['folder_id'] !== $b['folder_id'] ) {
+							return $a['folder_id'] <=> $b['folder_id'];
+						}
+						return $a[ $files_key_esc ] <=> $b[ $files_key_esc ];
+					}
+				);
+			}
 
 			if ( $results ) {
 				// Damn...
@@ -904,12 +925,28 @@ class Imagify_Custom_Folders {
 		$files_key     = $files_db->get_primary_key();
 		$files_key_esc = esc_sql( $files_key );
 		$file_ids      = wp_list_pluck( $files, $files_key );
-		$file_ids      = Imagify_DB::prepare_values_list( $file_ids );
-		$results       = $wpdb->get_results( "SELECT * FROM $files_table WHERE $files_key IN ( $file_ids ) ORDER BY $files_key_esc;", ARRAY_A ); // WPCS: unprepared SQL ok.
+		$results       = [];
+
+		foreach ( Imagify_DB::chunk_in_values( $file_ids ) as $file_ids_chunk ) {
+			$file_ids_in   = Imagify_DB::prepare_values_list( $file_ids_chunk );
+			$chunk_results = $wpdb->get_results( "SELECT * FROM $files_table WHERE $files_key IN ( $file_ids_in );", ARRAY_A ); // WPCS: unprepared SQL ok.
+
+			if ( $chunk_results ) {
+				$results = array_merge( $results, $chunk_results );
+			}
+		}
 
 		if ( ! $results ) {
 			return;
 		}
+
+		// Re-apply the ordering that was previously done in SQL (`ORDER BY $files_key_esc`).
+		usort(
+			$results,
+			function ( $a, $b ) use ( $files_key_esc ) {
+				return $a[ $files_key_esc ] <=> $b[ $files_key_esc ];
+			}
+		);
 
 		// Caching the folders will prevent unecessary SQL queries in Imagify_Custom_Folders::refresh_file().
 		foreach ( $folders as $folder_id => $folder ) {
@@ -996,10 +1033,17 @@ class Imagify_Custom_Folders {
 		$folders_key   = $folders_db->get_primary_key();
 
 		$selected_paths = (array) $selected_paths;
-		$selected_in    = Imagify_DB::prepare_values_list( $selected_paths );
+		$folders        = [];
 
 		// Get folders that already are in the DB.
-		$folders = $wpdb->get_results( "SELECT * FROM $folders_table WHERE path IN ( $selected_in );", ARRAY_A ); // WPCS: unprepared SQL ok.
+		foreach ( Imagify_DB::chunk_in_values( $selected_paths ) as $selected_paths_chunk ) {
+			$selected_in   = Imagify_DB::prepare_values_list( $selected_paths_chunk );
+			$chunk_folders = $wpdb->get_results( "SELECT * FROM $folders_table WHERE path IN ( $selected_in );", ARRAY_A ); // WPCS: unprepared SQL ok.
+
+			if ( $chunk_folders ) {
+				$folders = array_merge( $folders, $chunk_folders );
+			}
+		}
 
 		if ( ! $folders ) {
 			return $selected_paths;

--- a/inc/classes/class-imagify-db.php
+++ b/inc/classes/class-imagify-db.php
@@ -108,6 +108,7 @@ class Imagify_DB {
 				// Start a new chunk.
 				$chunks[]      = $current_chunk;
 				$current_chunk = [];
+				$current_len   = 0;
 				$added_len     = $rendered_len;
 			}
 

--- a/inc/classes/class-imagify-db.php
+++ b/inc/classes/class-imagify-db.php
@@ -65,6 +65,65 @@ class Imagify_DB {
 	}
 
 	/**
+	 * Split a list of values into chunks whose rendered `IN ()` comma separated list
+	 * stays under a character budget. This prevents hosts (e.g. WP Engine) that kill
+	 * overly long SQL queries from failing on unbounded `IN ()` lists.
+	 *
+	 * @since  2.4
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @param  array $values     An array of values (integers or strings).
+	 * @param  int   $sql_budget Maximum character length (rendered, comma separated) allowed per chunk.
+	 * @return array             An array of chunks. Each chunk is an array of values (same type as input).
+	 */
+	public static function chunk_in_values( array $values, int $sql_budget = 8000 ): array {
+		if ( ! $values ) {
+			return [];
+		}
+
+		/**
+		 * Filter the SQL character budget used to chunk `IN ()` value lists.
+		 *
+		 * @since  2.4
+		 * @author Grégory Viguier
+		 *
+		 * @param int $sql_budget The character budget.
+		 */
+		$sql_budget = (int) apply_filters( 'imagify_db_in_clause_sql_budget', $sql_budget );
+
+		if ( $sql_budget < 1 ) {
+			$sql_budget = 8000;
+		}
+
+		$chunks        = [];
+		$current_chunk = [];
+		$current_len   = 0;
+
+		foreach ( array_values( $values ) as $value ) {
+			$rendered_len = strlen( self::quote_string( esc_sql( $value ) ) );
+			// +1 for the comma separator, except for the first value in a chunk.
+			$added_len = $current_chunk ? $rendered_len + 1 : $rendered_len;
+
+			if ( $current_chunk && ( $current_len + $added_len ) > $sql_budget ) {
+				// Start a new chunk.
+				$chunks[]      = $current_chunk;
+				$current_chunk = [];
+				$added_len     = $rendered_len;
+			}
+
+			$current_chunk[] = $value;
+			$current_len    += $added_len;
+		}
+
+		if ( $current_chunk ) {
+			$chunks[] = $current_chunk;
+		}
+
+		return $chunks;
+	}
+
+	/**
 	 * Wrap a value in quotes, unless it's an integer.
 	 *
 	 * @since  1.6.13

--- a/inc/classes/class-imagify-db.php
+++ b/inc/classes/class-imagify-db.php
@@ -87,10 +87,12 @@ class Imagify_DB {
 		 *
 		 * @param int $sql_budget The character budget.
 		 */
-		$sql_budget = (int) apply_filters( 'imagify_db_in_clause_sql_budget', $sql_budget );
+		$given_sql_budget = $sql_budget;
+		$sql_budget       = (int) apply_filters( 'imagify_db_in_clause_sql_budget', $sql_budget );
 
 		if ( $sql_budget < 1 ) {
-			$sql_budget = 8000;
+			// Fall back to the caller's own value if it was valid, otherwise the hardcoded default.
+			$sql_budget = ( $given_sql_budget >= 1 ) ? $given_sql_budget : 8000;
 		}
 
 		$chunks        = [];

--- a/inc/classes/class-imagify-db.php
+++ b/inc/classes/class-imagify-db.php
@@ -70,8 +70,6 @@ class Imagify_DB {
 	 * overly long SQL queries from failing on unbounded `IN ()` lists.
 	 *
 	 * @since  2.4
-	 * @access public
-	 * @author Grégory Viguier
 	 *
 	 * @param  array $values     An array of values (integers or strings).
 	 * @param  int   $sql_budget Maximum character length (rendered, comma separated) allowed per chunk.
@@ -86,7 +84,6 @@ class Imagify_DB {
 		 * Filter the SQL character budget used to chunk `IN ()` value lists.
 		 *
 		 * @since  2.4
-		 * @author Grégory Viguier
 		 *
 		 * @param int $sql_budget The character budget.
 		 */

--- a/inc/functions/admin-stats.php
+++ b/inc/functions/admin-stats.php
@@ -321,11 +321,13 @@ function imagify_count_saving_data( $key = '' ) {
 	} else {
 		/**
 		 * Filter the chunk size of the requests fetching the data.
-		 * 15,000 seems to be a good balance between memory used, speed, and number of DB hits.
+		 * 2,000 seems to be a good balance between memory used, speed, and number of DB hits,
+		 * while keeping the resulting `IN ()` clause well under hosts' SQL query size limits
+		 * (e.g. WP Engine's query governor).
 		 *
 		 * @param int $limit The maximum number of elements per chunk.
 		 */
-		$limit = apply_filters( 'imagify_count_saving_data_limit', 15000 );
+		$limit = apply_filters( 'imagify_count_saving_data_limit', 2000 );
 		$limit = absint( $limit );
 
 		$mime_types   = Imagify_DB::get_mime_types();
@@ -359,15 +361,25 @@ function imagify_count_saving_data( $key = '' ) {
 
 		while ( $attachment_ids ) {
 			$limit_ids = array_shift( $attachment_ids );
-			$limit_ids = implode( ',', $limit_ids );
+			// Safety net: further split the chunk if its rendered `IN ()` list would still be too long.
+			$id_chunks   = Imagify_DB::chunk_in_values( $limit_ids );
+			$attachments = [];
 
-			$attachments = $wpdb->get_col( // WPCS: unprepared SQL ok.
-				"
-				SELECT meta_value
-				FROM $wpdb->postmeta
-				WHERE post_id IN ( $limit_ids )
-					AND meta_key = '_imagify_data'"
-			);
+			foreach ( $id_chunks as $id_chunk ) {
+				$id_chunk_list = implode( ',', $id_chunk );
+
+				$chunk_attachments = $wpdb->get_col( // WPCS: unprepared SQL ok.
+					"
+					SELECT meta_value
+					FROM $wpdb->postmeta
+					WHERE post_id IN ( $id_chunk_list )
+						AND meta_key = '_imagify_data'"
+				);
+
+				if ( $chunk_attachments ) {
+					$attachments = array_merge( $attachments, $chunk_attachments );
+				}
+			}
 			$wpdb->flush();
 
 			unset( $limit_ids );


### PR DESCRIPTION
# Description

Fixes #745

On large media libraries, some of Imagify's internal `IN (...)` database queries can grow long enough to be killed by hosts that enforce a SQL query-length limit (notably WP Engine's query governor). When that happens, custom-folder scans/sync and the dashboard savings stats fail with a fatal query error. This PR keeps those queries within a safe length so optimization and stats keep working on big libraries, whatever the host.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Automated (`Tests/Unit/inc/classes/ImagifyDB/chunkInValues.php`):
- Empty input returns an empty chunk list.
- A list that fits under the budget returns a single chunk, values preserved and ordered.
- A large list of integer IDs splits into multiple chunks once a small budget is exceeded; every chunk stays at/under budget; all values preserved, no reordering.
- A list of long quoted strings (simulating file paths) splits correctly, each chunk staying at/under budget.
- A single oversized value is kept alone in its own chunk (not dropped, no infinite loop).
- An invalid budget (0) falls back to the default.

Manual: functional read-through of the callers (custom-folder scan, admin stats). WP Engine-specific reproduction is not practical in this workflow — see below.

### How to test

The fix is a pure SQL query-length mitigation; the unit tests assert the exact invariant WP Engine enforces (rendered `IN ()` payload never exceeds the character budget). To sanity-check functionally:

1. Run `composer test-unit` — all previously passing tests still pass.
2. Optional smoke test: on a site with Custom folders enabled and a few hundred+ files, trigger a folder scan (Settings → Custom folders → scan). Confirm files are found/optimized and no PHP errors are logged.
3. To force chunking without a huge library, lower the budget via a mu-plugin filter (`add_filter( 'imagify_db_in_clause_sql_budget', fn() => 200 );`) and repeat step 2 — confirms the merge + re-order logic drops/duplicates nothing.

### Affected Features & Quality Assurance Scope

- **Custom folders**: file scanning/synchronization and folder activation (`Imagify_Custom_Folders::get_files_from_folders()`, `synchronize_files_from_folders()`, `activate_selected_folders()`).
- **Admin stats / dashboard savings counters** (`imagify_count_saving_data()` in `inc/functions/admin-stats.php`), on the back-compat path only (when the `imagify_count_saving_data` filter isn't overridden by a 3rd party).

Focus QA on custom folders with non-trivial file counts and the dashboard stats widget on large libraries (or the lowered-budget smoke test to force chunking).

## Technical description

### Documentation

New helper on the legacy `Imagify_DB` class (`inc/classes/class-imagify-db.php`, a natural extension of the existing `prepare_values_list()`/`quote_string()` helpers):

```php
Imagify_DB::chunk_in_values( array $values, int $sql_budget = 8000 ): array
```

Splits `$values` into chunks whose *rendered* comma-separated list (after the same escaping/quoting `prepare_values_list()` applies) stays at/under `$sql_budget` characters. A single value that alone exceeds the budget is kept in its own chunk rather than dropped. The budget is filterable via `imagify_db_in_clause_sql_budget` (default 8,000, well under WP Engine's ~16k ceiling). Callers run one query per chunk and merge results, re-applying any `ORDER BY` in PHP.

The helper is applied to the three riskiest `IN (...)` queries in `Imagify_Custom_Folders`: the file-path lookup (`WHERE path IN (...)`, the primary offender since it embeds full absolute paths), the file-ID lookup during synchronization, and the folder-path lookup when activating selected folders.

`inc/functions/admin-stats.php`'s existing ID chunking (`imagify_count_saving_data_limit`) has its default lowered from 15,000 to 2,000, and each chunk is additionally passed through `chunk_in_values()` as a safety net so large custom overrides can't reintroduce oversized queries.

`NOT IN` queries (folder IDs/paths) are left untouched: chunking a `NOT IN` clause changes its semantics, and those lists are small (folder counts, not file counts), so they aren't at risk.

### New dependencies

None.

### Risks

- **Extra DB round-trips**: over-budget lists now run one query per chunk instead of one. Intended trade-off (a few small indexed `IN ()` queries vs. one query the host kills). The default budget keeps this rare for most sites.
- **In-PHP re-sorting**: the two queries that relied on SQL `ORDER BY` now merge + `usort()` in PHP. Behavior-preserving, worth a double-check in review.
- **Lowered `imagify_count_saving_data_limit` default (15,000 → 2,000)**: more round-trips on very large libraries in exchange for bounded query length. The filter is unchanged, back-compat preserved, and `chunk_in_values()` protects overrides that set a larger value.

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

- "I validated all the Acceptance Criteria" is unticked because this is a backend-only, environment-specific fix (WP Engine's query governor); it cannot be reproduced or screenshotted outside a real WP Engine environment. Confidence comes from unit tests asserting the exact invariant WP Engine enforces (rendered `IN ()` length), plus a full green `composer test-unit` (317 tests, 0 failures — 17 pre-existing risky PHP 8.4 deprecation notices unrelated to this change) and `composer run-stan` (0 errors).

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
