### PR TITLE
Fix wrong orientation of next-gen images generated from EXIF-rotated backups (#859)

### DIFF
--- a/Tests/Fixtures/classes/Optimization/File/MaybeCorrectExifOrientationTest.php
+++ b/Tests/Fixtures/classes/Optimization/File/MaybeCorrectExifOrientationTest.php
@@ -1,0 +1,154 @@
+<?php
+
+return [
+	'test_data' => [
+		// When EXIF data can't be read at all, nothing should happen.
+		'shouldReturnFalseWhenExifIsNotAvailable'   => [
+			'config'   => [
+				'can_get_exif' => false,
+				'file_type'    => [
+					'ext'  => 'jpg',
+					'type' => 'image/jpeg',
+				],
+				'orientation'  => null,
+				'editor'       => 'none',
+				'save'         => null,
+			],
+			'expected' => [
+				'get_image_exif_called' => false,
+				'rotate'                => null,
+				'flip'                  => null,
+				'save_called'           => false,
+				'result'                => 'false',
+			],
+		],
+
+		// When the file isn't a JPEG, EXIF orientation is irrelevant.
+		'shouldReturnFalseWhenNotJpeg'              => [
+			'config'   => [
+				'can_get_exif' => true,
+				'file_type'    => [
+					'ext'  => 'png',
+					'type' => 'image/png',
+				],
+				'orientation'  => null,
+				'editor'       => 'none',
+				'save'         => null,
+			],
+			'expected' => [
+				'get_image_exif_called' => false,
+				'rotate'                => null,
+				'flip'                  => null,
+				'save_called'           => false,
+				'result'                => 'false',
+			],
+		],
+
+		// When the orientation is already 1 (or absent), the file must not be touched: this also
+		// guards against rotating the same working copy twice.
+		'shouldReturnFalseWhenOrientationIsAlreadyOne' => [
+			'config'   => [
+				'can_get_exif' => true,
+				'file_type'    => [
+					'ext'  => 'jpg',
+					'type' => 'image/jpeg',
+				],
+				'orientation'  => 1,
+				'editor'       => 'valid',
+				'save'         => null,
+			],
+			'expected' => [
+				'get_image_exif_called' => true,
+				'rotate'                => null,
+				'flip'                  => null,
+				'save_called'           => false,
+				'result'                => 'false',
+			],
+		],
+
+		// Orientation 6 (the common "rotated 90 CW on capture" case) must rotate the editor by 270
+		// and save the result back over the same (temporary) path.
+		'shouldRotateAndSaveForOrientationSix'      => [
+			'config'   => [
+				'can_get_exif' => true,
+				'file_type'    => [
+					'ext'  => 'jpg',
+					'type' => 'image/jpeg',
+				],
+				'orientation'  => 6,
+				'editor'       => 'valid',
+				'save'         => 'success',
+			],
+			'expected' => [
+				'get_image_exif_called' => true,
+				'rotate'                => 270,
+				'flip'                  => null,
+				'save_called'           => true,
+				'result'                => 'true',
+			],
+		],
+
+		// Orientation 5 involves a rotation followed by a flip.
+		'shouldRotateAndFlipForOrientationFive'     => [
+			'config'   => [
+				'can_get_exif' => true,
+				'file_type'    => [
+					'ext'  => 'jpg',
+					'type' => 'image/jpeg',
+				],
+				'orientation'  => 5,
+				'editor'       => 'valid',
+				'save'         => 'success',
+			],
+			'expected' => [
+				'get_image_exif_called' => true,
+				'rotate'                => 90,
+				'flip'                  => [ false, true ],
+				'save_called'           => true,
+				'result'                => 'true',
+			],
+		],
+
+		// If the editor can't be retrieved, the WP_Error must be surfaced (and nothing saved).
+		'shouldReturnWpErrorWhenEditorFails'        => [
+			'config'   => [
+				'can_get_exif' => true,
+				'file_type'    => [
+					'ext'  => 'jpg',
+					'type' => 'image/jpeg',
+				],
+				'orientation'  => 6,
+				'editor'       => 'error',
+				'save'         => null,
+			],
+			'expected' => [
+				'get_image_exif_called' => true,
+				'rotate'                => null,
+				'flip'                  => null,
+				'save_called'           => false,
+				'result'                => 'wp_error',
+			],
+		],
+
+		// If saving the rotated file fails, the WP_Error must be surfaced.
+		'shouldReturnWpErrorWhenSaveFails'          => [
+			'config'   => [
+				'can_get_exif' => true,
+				'file_type'    => [
+					'ext'  => 'jpg',
+					'type' => 'image/jpeg',
+				],
+				'orientation'  => 6,
+				'editor'       => 'valid',
+				'save'         => 'error',
+			],
+			'expected' => [
+				'get_image_exif_called' => true,
+				'rotate'                => 270,
+				'flip'                  => null,
+				'save_called'           => true,
+				'result'                => 'wp_error',
+			],
+		],
+	],
+];

--- a/Tests/Unit/classes/Optimization/File/MaybeCorrectExifOrientationTest.php
+++ b/Tests/Unit/classes/Optimization/File/MaybeCorrectExifOrientationTest.php
@@ -1,0 +1,192 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Optimization\File;
+
+use Imagify\Optimization\File;
+use Imagify\Tests\Unit\TestCase;
+use Mockery;
+use WP_Error;
+
+/**
+ * Tests for \Imagify\Optimization\File::maybe_correct_exif_orientation().
+ *
+ * @covers \Imagify\Optimization\File::maybe_correct_exif_orientation
+ * @covers \Imagify\Optimization\File::rotate_editor_by_exif_orientation
+ * @group  Optimization
+ */
+class MaybeCorrectExifOrientationTest extends TestCase {
+
+	/**
+	 * Path used for the fake file under test.
+	 *
+	 * @var string
+	 */
+	private $path = '/tmp/fake-image@imagify-tmp.jpg';
+
+	/**
+	 * Builds a File instance with a mocked filesystem (and optionally editor) injected, bypassing
+	 * WordPress/filesystem globals.
+	 *
+	 * @param \Mockery\MockInterface $filesystem Mock for the Imagify_Filesystem dependency.
+	 * @param mixed                  $editor     Optional. Value to inject as the cached editor.
+	 * @param object|null            $file_type  Optional. Value to inject as the cached file type.
+	 *
+	 * @return File
+	 */
+	private function make_file( $filesystem, $editor = null, $file_type = null ): File {
+		// Bypass the real constructor: it instantiates Imagify_Filesystem::get_instance(), which
+		// requires a full WordPress environment that isn't available in unit tests.
+		$file = ( new \ReflectionClass( File::class ) )->newInstanceWithoutConstructor();
+
+		$this->setPropertyValue( 'path', $file, $this->path );
+		$this->setPropertyValue( 'filesystem', $file, $filesystem );
+
+		if ( null !== $file_type ) {
+			$this->setPropertyValue( 'file_type', $file, $file_type );
+		} else {
+			$this->setPropertyValue(
+				'file_type',
+				$file,
+				(object) [
+					'ext'  => 'jpg',
+					'type' => 'image/jpeg',
+				]
+			);
+		}
+
+		if ( null !== $editor ) {
+			$this->setPropertyValue( 'editor', $file, $editor );
+		}
+
+		return $file;
+	}
+
+	/**
+	 * When EXIF data can't be read at all, nothing should happen.
+	 */
+	public function testReturnsFalseWhenExifIsNotAvailable(): void {
+		$filesystem = Mockery::mock();
+		$filesystem->shouldReceive( 'can_get_exif' )->andReturn( false );
+		$filesystem->shouldNotReceive( 'get_image_exif' );
+
+		$file = $this->make_file( $filesystem );
+
+		$this->assertFalse( $file->maybe_correct_exif_orientation() );
+	}
+
+	/**
+	 * When the file isn't a JPEG, EXIF orientation is irrelevant.
+	 */
+	public function testReturnsFalseWhenNotJpeg(): void {
+		$filesystem = Mockery::mock();
+		$filesystem->shouldReceive( 'can_get_exif' )->andReturn( true );
+		$filesystem->shouldNotReceive( 'get_image_exif' );
+
+		$file = $this->make_file(
+			$filesystem,
+			null,
+			(object) [
+				'ext'  => 'png',
+				'type' => 'image/png',
+			]
+		);
+
+		$this->assertFalse( $file->maybe_correct_exif_orientation() );
+	}
+
+	/**
+	 * When the orientation is already 1 (or absent), the file must not be touched: this also
+	 * guards against rotating the same working copy twice.
+	 */
+	public function testReturnsFalseWhenOrientationIsAlreadyOne(): void {
+		$filesystem = Mockery::mock();
+		$filesystem->shouldReceive( 'can_get_exif' )->andReturn( true );
+		$filesystem->shouldReceive( 'get_image_exif' )->with( $this->path )->andReturn( [ 'Orientation' => 1 ] );
+
+		$editor = Mockery::mock();
+		$editor->shouldNotReceive( 'rotate' );
+		$editor->shouldNotReceive( 'flip' );
+		$editor->shouldNotReceive( 'save' );
+
+		$file = $this->make_file( $filesystem, $editor );
+
+		$this->assertFalse( $file->maybe_correct_exif_orientation() );
+	}
+
+	/**
+	 * Orientation 6 (the common "rotated 90° CW on capture" case) must rotate the editor by 270°
+	 * and save the result back over the same (temporary) path.
+	 */
+	public function testRotatesAndSavesForOrientationSix(): void {
+		$filesystem = Mockery::mock();
+		$filesystem->shouldReceive( 'can_get_exif' )->andReturn( true );
+		$filesystem->shouldReceive( 'get_image_exif' )->with( $this->path )->andReturn( [ 'Orientation' => 6 ] );
+
+		$editor = Mockery::mock();
+		$editor->shouldReceive( 'rotate' )->once()->with( 270 );
+		$editor->shouldNotReceive( 'flip' );
+		$editor->shouldReceive( 'save' )->once()->with( $this->path )->andReturn( [ 'path' => $this->path ] );
+
+		$file = $this->make_file( $filesystem, $editor );
+
+		$this->assertTrue( $file->maybe_correct_exif_orientation() );
+	}
+
+	/**
+	 * Orientation 5 involves a rotation followed by a flip.
+	 */
+	public function testRotatesAndFlipsForOrientationFive(): void {
+		$filesystem = Mockery::mock();
+		$filesystem->shouldReceive( 'can_get_exif' )->andReturn( true );
+		$filesystem->shouldReceive( 'get_image_exif' )->with( $this->path )->andReturn( [ 'Orientation' => 5 ] );
+
+		$editor = Mockery::mock();
+		$editor->shouldReceive( 'rotate' )->once()->with( 90 )->andReturn( true );
+		$editor->shouldReceive( 'flip' )->once()->with( false, true );
+		$editor->shouldReceive( 'save' )->once()->with( $this->path )->andReturn( [ 'path' => $this->path ] );
+
+		$file = $this->make_file( $filesystem, $editor );
+
+		$this->assertTrue( $file->maybe_correct_exif_orientation() );
+	}
+
+	/**
+	 * If the editor can't be retrieved, the WP_Error must be surfaced (and nothing saved).
+	 */
+	public function testReturnsWpErrorWhenEditorFails(): void {
+		$filesystem = Mockery::mock();
+		$filesystem->shouldReceive( 'can_get_exif' )->andReturn( true );
+		$filesystem->shouldReceive( 'get_image_exif' )->with( $this->path )->andReturn( [ 'Orientation' => 6 ] );
+
+		$error = new WP_Error( 'image_editor', 'No editor available.' );
+		$file  = $this->make_file( $filesystem, $error );
+
+		$result = $file->maybe_correct_exif_orientation();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( $error, $result );
+	}
+
+	/**
+	 * If saving the rotated file fails, the WP_Error must be surfaced.
+	 */
+	public function testReturnsWpErrorWhenSaveFails(): void {
+		$filesystem = Mockery::mock();
+		$filesystem->shouldReceive( 'can_get_exif' )->andReturn( true );
+		$filesystem->shouldReceive( 'get_image_exif' )->with( $this->path )->andReturn( [ 'Orientation' => 6 ] );
+
+		$save_error = new WP_Error( 'image_save_error', 'Could not save.' );
+
+		$editor = Mockery::mock();
+		$editor->shouldReceive( 'rotate' )->once()->with( 270 );
+		$editor->shouldReceive( 'save' )->once()->with( $this->path )->andReturn( $save_error );
+
+		$file = $this->make_file( $filesystem, $editor );
+
+		$result = $file->maybe_correct_exif_orientation();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( $save_error, $result );
+	}
+}

--- a/Tests/Unit/classes/Optimization/File/MaybeCorrectExifOrientationTest.php
+++ b/Tests/Unit/classes/Optimization/File/MaybeCorrectExifOrientationTest.php
@@ -63,130 +63,71 @@ class MaybeCorrectExifOrientationTest extends TestCase {
 	}
 
 	/**
-	 * When EXIF data can't be read at all, nothing should happen.
+	 * @dataProvider configTestData
 	 */
-	public function testReturnsFalseWhenExifIsNotAvailable(): void {
+	public function testShouldReturnExpected( $config, $expected ): void {
 		$filesystem = Mockery::mock();
-		$filesystem->shouldReceive( 'can_get_exif' )->andReturn( false );
-		$filesystem->shouldNotReceive( 'get_image_exif' );
+		$filesystem->shouldReceive( 'can_get_exif' )->andReturn( $config['can_get_exif'] );
 
-		$file = $this->make_file( $filesystem );
+		if ( $expected['get_image_exif_called'] ) {
+			$filesystem->shouldReceive( 'get_image_exif' )
+				->with( $this->path )
+				->andReturn( [ 'Orientation' => $config['orientation'] ] );
+		} else {
+			$filesystem->shouldNotReceive( 'get_image_exif' );
+		}
 
-		$this->assertFalse( $file->maybe_correct_exif_orientation() );
-	}
+		$editor     = null;
+		$save_error = null;
 
-	/**
-	 * When the file isn't a JPEG, EXIF orientation is irrelevant.
-	 */
-	public function testReturnsFalseWhenNotJpeg(): void {
-		$filesystem = Mockery::mock();
-		$filesystem->shouldReceive( 'can_get_exif' )->andReturn( true );
-		$filesystem->shouldNotReceive( 'get_image_exif' );
+		if ( 'valid' === $config['editor'] ) {
+			$editor = Mockery::mock();
 
-		$file = $this->make_file(
-			$filesystem,
-			null,
-			(object) [
-				'ext'  => 'png',
-				'type' => 'image/png',
-			]
-		);
+			if ( null !== $expected['rotate'] ) {
+				$editor->shouldReceive( 'rotate' )->once()->with( $expected['rotate'] )->andReturn( true );
+			} else {
+				$editor->shouldNotReceive( 'rotate' );
+			}
 
-		$this->assertFalse( $file->maybe_correct_exif_orientation() );
-	}
+			if ( null !== $expected['flip'] ) {
+				$editor->shouldReceive( 'flip' )->once()->with( ...$expected['flip'] );
+			} else {
+				$editor->shouldNotReceive( 'flip' );
+			}
 
-	/**
-	 * When the orientation is already 1 (or absent), the file must not be touched: this also
-	 * guards against rotating the same working copy twice.
-	 */
-	public function testReturnsFalseWhenOrientationIsAlreadyOne(): void {
-		$filesystem = Mockery::mock();
-		$filesystem->shouldReceive( 'can_get_exif' )->andReturn( true );
-		$filesystem->shouldReceive( 'get_image_exif' )->with( $this->path )->andReturn( [ 'Orientation' => 1 ] );
+			if ( $expected['save_called'] ) {
+				if ( 'error' === $config['save'] ) {
+					$save_error = new WP_Error( 'image_save_error', 'Could not save.' );
+					$editor->shouldReceive( 'save' )->once()->with( $this->path )->andReturn( $save_error );
+				} else {
+					$editor->shouldReceive( 'save' )->once()->with( $this->path )->andReturn( [ 'path' => $this->path ] );
+				}
+			} else {
+				$editor->shouldNotReceive( 'save' );
+			}
+		} elseif ( 'error' === $config['editor'] ) {
+			$editor = new WP_Error( 'image_editor', 'No editor available.' );
+		}
 
-		$editor = Mockery::mock();
-		$editor->shouldNotReceive( 'rotate' );
-		$editor->shouldNotReceive( 'flip' );
-		$editor->shouldNotReceive( 'save' );
-
-		$file = $this->make_file( $filesystem, $editor );
-
-		$this->assertFalse( $file->maybe_correct_exif_orientation() );
-	}
-
-	/**
-	 * Orientation 6 (the common "rotated 90° CW on capture" case) must rotate the editor by 270°
-	 * and save the result back over the same (temporary) path.
-	 */
-	public function testRotatesAndSavesForOrientationSix(): void {
-		$filesystem = Mockery::mock();
-		$filesystem->shouldReceive( 'can_get_exif' )->andReturn( true );
-		$filesystem->shouldReceive( 'get_image_exif' )->with( $this->path )->andReturn( [ 'Orientation' => 6 ] );
-
-		$editor = Mockery::mock();
-		$editor->shouldReceive( 'rotate' )->once()->with( 270 );
-		$editor->shouldNotReceive( 'flip' );
-		$editor->shouldReceive( 'save' )->once()->with( $this->path )->andReturn( [ 'path' => $this->path ] );
-
-		$file = $this->make_file( $filesystem, $editor );
-
-		$this->assertTrue( $file->maybe_correct_exif_orientation() );
-	}
-
-	/**
-	 * Orientation 5 involves a rotation followed by a flip.
-	 */
-	public function testRotatesAndFlipsForOrientationFive(): void {
-		$filesystem = Mockery::mock();
-		$filesystem->shouldReceive( 'can_get_exif' )->andReturn( true );
-		$filesystem->shouldReceive( 'get_image_exif' )->with( $this->path )->andReturn( [ 'Orientation' => 5 ] );
-
-		$editor = Mockery::mock();
-		$editor->shouldReceive( 'rotate' )->once()->with( 90 )->andReturn( true );
-		$editor->shouldReceive( 'flip' )->once()->with( false, true );
-		$editor->shouldReceive( 'save' )->once()->with( $this->path )->andReturn( [ 'path' => $this->path ] );
-
-		$file = $this->make_file( $filesystem, $editor );
-
-		$this->assertTrue( $file->maybe_correct_exif_orientation() );
-	}
-
-	/**
-	 * If the editor can't be retrieved, the WP_Error must be surfaced (and nothing saved).
-	 */
-	public function testReturnsWpErrorWhenEditorFails(): void {
-		$filesystem = Mockery::mock();
-		$filesystem->shouldReceive( 'can_get_exif' )->andReturn( true );
-		$filesystem->shouldReceive( 'get_image_exif' )->with( $this->path )->andReturn( [ 'Orientation' => 6 ] );
-
-		$error = new WP_Error( 'image_editor', 'No editor available.' );
-		$file  = $this->make_file( $filesystem, $error );
+		$file_type = isset( $config['file_type'] ) ? (object) $config['file_type'] : null;
+		$file      = $this->make_file( $filesystem, $editor, $file_type );
 
 		$result = $file->maybe_correct_exif_orientation();
 
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( $error, $result );
-	}
+		switch ( $expected['result'] ) {
+			case 'true':
+				$this->assertTrue( $result );
+				break;
 
-	/**
-	 * If saving the rotated file fails, the WP_Error must be surfaced.
-	 */
-	public function testReturnsWpErrorWhenSaveFails(): void {
-		$filesystem = Mockery::mock();
-		$filesystem->shouldReceive( 'can_get_exif' )->andReturn( true );
-		$filesystem->shouldReceive( 'get_image_exif' )->with( $this->path )->andReturn( [ 'Orientation' => 6 ] );
+			case 'false':
+				$this->assertFalse( $result );
+				break;
 
-		$save_error = new WP_Error( 'image_save_error', 'Could not save.' );
-
-		$editor = Mockery::mock();
-		$editor->shouldReceive( 'rotate' )->once()->with( 270 );
-		$editor->shouldReceive( 'save' )->once()->with( $this->path )->andReturn( $save_error );
-
-		$file = $this->make_file( $filesystem, $editor );
-
-		$result = $file->maybe_correct_exif_orientation();
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( $save_error, $result );
+			case 'wp_error':
+				$this->assertInstanceOf( WP_Error::class, $result );
+				// The very same WP_Error instance must be surfaced, unchanged.
+				$this->assertSame( 'error' === $config['editor'] ? $editor : $save_error, $result );
+				break;
+		}
 	}
 }

--- a/classes/Optimization/File.php
+++ b/classes/Optimization/File.php
@@ -216,45 +216,7 @@ class File {
 			$exif        = $this->filesystem->get_image_exif( $this->path );
 			$orientation = isset( $exif['Orientation'] ) ? (int) $exif['Orientation'] : 1;
 
-			switch ( $orientation ) {
-				case 2:
-					// Flip horizontally.
-					$editor->flip( true, false );
-					break;
-				case 3:
-					// Rotate 180 degrees or flip horizontally and vertically.
-					// Flipping seems faster/uses less resources.
-					$editor->flip( true, true );
-					break;
-				case 4:
-					// Flip vertically.
-					$editor->flip( false, true );
-					break;
-				case 5:
-					// Rotate 90 degrees counter-clockwise and flip vertically.
-					$result = $editor->rotate( 90 );
-
-					if ( ! is_wp_error( $result ) ) {
-						$editor->flip( false, true );
-					}
-					break;
-				case 6:
-					// Rotate 90 degrees clockwise (270 counter-clockwise).
-					$editor->rotate( 270 );
-					break;
-				case 7:
-					// Rotate 90 degrees counter-clockwise and flip horizontally.
-					$result = $editor->rotate( 90 );
-
-					if ( ! is_wp_error( $result ) ) {
-						$editor->flip( true, false );
-					}
-					break;
-				case 8:
-					// Rotate 90 degrees counter-clockwise.
-					$editor->rotate( 90 );
-					break;
-			}
+			$this->rotate_editor_by_exif_orientation( $editor, $orientation );
 		}
 
 		if ( ! $dimensions ) {
@@ -283,6 +245,111 @@ class File {
 		}
 
 		return $resized_image_path;
+	}
+
+	/**
+	 * Rotate/flip an image editor instance according to a JPEG EXIF "Orientation" value.
+	 *
+	 * @since  2.3.1
+	 *
+	 * @param  \WP_Image_Editor_Imagick|\WP_Image_Editor_GD $editor      The image editor instance.
+	 * @param  int                                          $orientation The EXIF "Orientation" value.
+	 * @return void
+	 */
+	protected function rotate_editor_by_exif_orientation( $editor, $orientation ) {
+		switch ( $orientation ) {
+			case 2:
+				// Flip horizontally.
+				$editor->flip( true, false );
+				break;
+			case 3:
+				// Rotate 180 degrees or flip horizontally and vertically.
+				// Flipping seems faster/uses less resources.
+				$editor->flip( true, true );
+				break;
+			case 4:
+				// Flip vertically.
+				$editor->flip( false, true );
+				break;
+			case 5:
+				// Rotate 90 degrees counter-clockwise and flip vertically.
+				$result = $editor->rotate( 90 );
+
+				if ( ! is_wp_error( $result ) ) {
+					$editor->flip( false, true );
+				}
+				break;
+			case 6:
+				// Rotate 90 degrees clockwise (270 counter-clockwise).
+				$editor->rotate( 270 );
+				break;
+			case 7:
+				// Rotate 90 degrees counter-clockwise and flip horizontally.
+				$result = $editor->rotate( 90 );
+
+				if ( ! is_wp_error( $result ) ) {
+					$editor->flip( true, false );
+				}
+				break;
+			case 8:
+				// Rotate 90 degrees counter-clockwise.
+				$editor->rotate( 90 );
+				break;
+		}
+	}
+
+	/**
+	 * Correct the EXIF orientation of the current file, in place, if needed.
+	 *
+	 * WordPress auto-rotates JPEGs with a non-default EXIF orientation on upload (the resulting,
+	 * rotated file has its orientation reset to 1), but Imagify's backup keeps a copy of the
+	 * original, un-rotated file. When a temporary working copy is created from that backup (for
+	 * example to generate a Next-Gen version of an already-optimized "full" size), the copy must
+	 * be rotated the same way WordPress would have rotated it, otherwise the resulting file (WebP,
+	 * AVIF...) ends up with the wrong orientation.
+	 *
+	 * This method must only ever be called on a disposable working copy: it saves the rotated
+	 * image over $this->path, and must never be used on the actual backup file.
+	 *
+	 * @since  2.3.1
+	 *
+	 * @return bool|WP_Error True if the file was rotated and saved. False if no rotation was
+	 *                       needed (or EXIF data isn't available/readable). A WP_Error object on
+	 *                       failure.
+	 */
+	public function maybe_correct_exif_orientation() {
+		if ( ! $this->filesystem->can_get_exif() || 'image/jpeg' !== $this->get_mime_type() ) {
+			return false;
+		}
+
+		$exif        = $this->filesystem->get_image_exif( $this->path );
+		$orientation = isset( $exif['Orientation'] ) ? (int) $exif['Orientation'] : 1;
+
+		if ( 1 === $orientation ) {
+			// Nothing to correct: either there is no orientation data, or the file is already
+			// upright (this also prevents rotating the same file twice).
+			return false;
+		}
+
+		$editor = $this->get_editor();
+
+		if ( is_wp_error( $editor ) ) {
+			return $editor;
+		}
+
+		$this->rotate_editor_by_exif_orientation( $editor, $orientation );
+
+		$saved = $editor->save( $this->path );
+
+		if ( is_wp_error( $saved ) ) {
+			return $saved;
+		}
+
+		// The file on disk changed: reset the cached data related to it.
+		$this->file_type = null;
+		$this->editor    = null;
+
+		return true;
 	}
 
 	/**

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -1084,6 +1084,15 @@ abstract class AbstractProcess implements ProcessInterface {
 			return false;
 		}
 
+		/**
+		 * The backup file may be the original, un-rotated JPEG that WordPress auto-rotated on
+		 * upload (WordPress resets the orientation on the rotated file, but keeps the original
+		 * orientation in the backup). Correct the orientation of this disposable temporary copy
+		 * so that a Next-Gen version (or a thumbnail) generated from it isn't mis-oriented.
+		 * The backup file itself is never touched.
+		 */
+		$tmp_file->maybe_correct_exif_orientation();
+
 		if ( 'full' === $size ) {
 			/**
 			 * We create a copy of the backup to be able to create a next-gen version from it.


### PR DESCRIPTION
# Description

Fixes #859

When WordPress uploads a JPEG with a non-default EXIF orientation, it auto-rotates the pixels for the working (attached) file and resets that file's orientation to `1`. Imagify's backup, however, keeps a copy of the *original*, un-rotated JPEG (still carrying its original `Orientation` EXIF tag), because that's what's needed to losslessly restore the media later.

This becomes a problem when Imagify generates a Next-Gen (WebP/AVIF) version of the **full size** for a media that was already optimized (non-Next-Gen) beforehand: instead of re-deriving the Next-Gen file from the already-optimized full-size file (which would be re-compressing an already-lossy JPEG), Imagify creates a temporary working copy **from the backup** and converts that. Since the backup is the pre-rotation original, the resulting WebP/AVIF file ends up with the wrong orientation, even though the full-size JPEG on disk (and all its resized thumbnails, which are derived from it) display correctly.

This PR corrects the EXIF orientation of that temporary, disposable working copy right after it's created from the backup — before it's used to generate the Next-Gen version (or a thumbnail) — so the output always matches the orientation of the real, on-disk full-size file. **The backup file itself is never modified.**

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Automated only (see "Unticked items justification" below for the manual gap):

- New unit tests in `Tests/Unit/classes/Optimization/File/MaybeCorrectExifOrientationTest.php` cover `Imagify\Optimization\File::maybe_correct_exif_orientation()`:
  - no-op when EXIF can't be read, when the file isn't a JPEG, or when the orientation is already `1` (this last case is also the guard that prevents double-rotating the same working copy on repeated runs).
  - correct rotate/flip calls for orientation `5` and `6` (representative of the rotate-only and rotate+flip code paths), followed by `save()` over the same (temporary) path.
  - `WP_Error` from `wp_get_image_editor()` or from `$editor->save()` is surfaced without side effects.
- Full unit suite (`composer test-unit`): 318 tests, 0 failures (17 pre-existing risky-test notices, unrelated to this change).
- `composer run-stan`: 0 errors.
- `vendor/bin/phpcs --standard=phpcs.xml` on changed files: 0 errors/warnings.

### How to test

1. Upload a JPEG with EXIF orientation `6` (rotated 90° on capture) to the Media Library, with WebP and/or AVIF "Display" format enabled in Imagify settings, and with backup enabled.
2. Optimize the media normally first (non-Next-Gen), then trigger Next-Gen generation for it afterwards (e.g. via "Generate Next-Gen versions" bulk action, or by enabling the Next-Gen format after the fact and re-optimizing/completing the process) so that the code path that derives the Next-Gen full size from the backup is exercised.
3. Verify the resulting full-size `.webp`/`.avif` file has the same (correct) orientation as the full-size `.jpg` on disk — not the orientation of the pre-upload original.
4. Compute a checksum (e.g. `md5sum`) of the backup file (`wp-content/uploads/backup/.../image.jpg`) before and after the optimization/Next-Gen generation runs, and confirm it is unchanged — the backup must never be modified by this fix.

### Affected Features & Quality Assurance Scope

- Next-Gen (WebP/AVIF) generation for the **full** media size, specifically when it is (re)generated from the backup (i.e. the non-Next-Gen full size was already successfully optimized beforehand). This is the same code path used to create resized thumbnails from the backup, so thumbnail generation from the backup benefits from the same correction.
- Backup/restore integrity: the backup file must remain byte-identical.
- Re-optimize flows: repeated re-optimization from the backup must keep producing correctly-rotated output and must never double-rotate (guarded by only acting when EXIF orientation ≠ 1).

## Technical description

### Documentation

Root cause: `Imagify\Optimization\Process\AbstractProcess::create_temporary_copy()` copies the backup file to a disposable temporary path (`...@imagify-tmp.<ext>`) whenever a size's non-Next-Gen version was already successfully optimized and a Next-Gen (or thumbnail) version needs to be derived from an unmodified source. That temporary copy — not the backup itself — is what gets resized/converted by `Imagify\Optimization\File`.

The fix adds `Imagify\Optimization\File::maybe_correct_exif_orientation()`, which:
- only acts on JPEGs, and only when `exif_read_data()` is available (same guard already used by `File::resize()`),
- reads the `Orientation` EXIF tag of `$this->path`; does nothing if it's `1` (already upright, or not an EXIF-rotatable value — this is also what prevents double-rotation on repeated calls),
- otherwise gets a `WP_Image_Editor` instance for `$this->path`, applies the rotate/flip sequence (extracted into a new shared `rotate_editor_by_exif_orientation()` helper, reused by the existing `resize()` logic to avoid duplicating the orientation switch/case), and saves the result back over the same path.

`AbstractProcess::create_temporary_copy()` now calls `$tmp_file->maybe_correct_exif_orientation()` right after copying the backup into the temporary path, before that temporary file is used to generate the full-size Next-Gen version or a thumbnail. Because this only ever operates on the disposable `@imagify-tmp` copy (never on `$backup_path`), the backup file is guaranteed to stay untouched.

### New dependencies

None.

### Risks

- **Backup mutation risk**: mitigated by construction — `maybe_correct_exif_orientation()` is only ever called on the `File` instance wrapping the temporary copy (`$tmp_file`, pointing at `$tmp_path`), never on a `File` instance wrapping the backup path itself.
- **Double-rotation risk** (e.g. on repeated re-optimize runs): mitigated by the orientation check — once a temporary copy has been rotated and saved, its EXIF orientation is no longer `6` (or whichever original value), so a subsequent call is a no-op. In addition, `create_temporary_copy()` skips regenerating the temporary copy altogether if it already exists on disk.
- **Non-JPEG / no-EXIF-support environments**: the method safely no-ops (matches the existing behavior/guards already used by `File::resize()`), so no new failure mode is introduced there.
- **Editor/save failures**: surfaced as `WP_Error` but not currently treated as fatal by the caller (the temporary copy is used as-is if rotation fails) — this keeps behavior consistent with "no worse than before" rather than blocking the whole optimization pipeline on an EXIF-correction failure.

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

- Manual, real-upload validation with an actual EXIF-6 JPEG and a live WP install (checking the produced WebP/AVIF orientation visually, and diffing the backup file's checksum) was **not performed in this session** (no WordPress runtime available in this environment). Automated coverage is limited to unit tests exercising `File::maybe_correct_exif_orientation()` in isolation (mocked filesystem/editor); the integration suite (which would exercise the real `AbstractProcess::create_temporary_copy()` flow end-to-end) is known-broken locally (`WP_TESTS_DIR` missing) and was not run. Please perform the manual "How to test" steps above before/while reviewing.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
