### PR TITLE
Enhancement #634: Add documentation link to the out-of-quota popup

### DIFF
--- a/views/part-bulk-optimization-overquota-alert.php
+++ b/views/part-bulk-optimization-overquota-alert.php
@@ -16,6 +16,18 @@ $overquota_url = imagify_get_external_url(
 		<strong><?php esc_html_e( 'To continue optimizing your images, you can upgrade your subscription.', 'imagify' ); ?></strong>
 	<?php } ?>
 </div>
+<div class="imagify-swal-content imagify-txt-start">
+	<strong>
+		<?php
+		printf(
+			/* translators: %1$s = opening link tag, %2$s = closing link tag. */
+			esc_html__( 'See %1$sour documentation%2$s on all available options to continue optimizing images.', 'imagify' ),
+			'<a href="https://imagify.io/documentation/continue-optimizing-credits-consumed/" rel="noopener" target="_blank">',
+			'</a>'
+		);
+		?>
+	</strong>
+</div>
 <div class="imagify-swal-buttonswrapper">
 	<a href="<?php echo esc_url( $overquota_url ); ?>" target="_blank" class="imagify-button imagify-button-primary button">
 		<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="#000" fill-rule="nonzero" transform="translate(1 1)" stroke="#fff"><polygon points="8.75 0 8.75 0.7 12.8065 0.7 5.0015 8.5015 5.4985 8.9985 13.3 1.1935 13.3 5.25 14 5.25 14 0"/><polygon points="11.9 13.3 0.7 13.3 0.7 2.1 6.3 2.1 6.3 1.4 0 1.4 0 14 12.6 14 12.6 7.7 11.9 7.7"/></g></svg>


### PR DESCRIPTION
# Description

Fixes #634

The out-of-quota popup (shown during bulk optimization and on the Next-Gen settings page when a user has consumed all their credits) now points users to Imagify's documentation on all available options to keep optimizing images — not just the "upgrade your plan" button. This helps users discover every way to continue (upgrading, freeing credits, etc.) instead of assuming an upgrade is the only path.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Manual — rendered the over-quota SweetAlert popup and confirmed the new documentation line appears with a working link. `php -l` passes on the changed view.

### How to test

1. Use a site whose Imagify account is out of quota (or mock `isOverQuota`).
2. Go to **Media → Bulk Optimization** (or **Settings → Imagify → Next-Gen**) and trigger the bulk/over-quota state so the popup appears.
3. Confirm the popup now shows: *"See our documentation on all available options to continue optimizing images."* with **our documentation** linking to `https://imagify.io/documentation/continue-optimizing-credits-consumed/` (opens in a new tab, `rel="noopener"`).

### Affected Features & Quality Assurance Scope

Over-quota popup only — surfaced by bulk optimization and the Next-Gen settings page. No optimization logic touched.

## Technical description

### Documentation

The popup content is rendered by a single PHP view, `views/part-bulk-optimization-overquota-alert.php`, injected as the `#tmpl-imagify-overquota-alert` JS template used by all popup call sites. A new `imagify-swal-content` block was added, placed outside the `is_api_key_valid()` conditional so the link always shows. The link text is translatable via `printf`/`esc_html__` with link-tag placeholders, matching the existing codebase pattern (e.g. `views/part-settings-webp.php`). No JavaScript or build-step change is required.

### New dependencies

None.

### Risks

None — additive, translatable, static documentation link in an existing template.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Built-in tests: the change is a static, translatable documentation link in a presentational view template with no logic to unit test.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
