### PR TITLE
Enhancement #516: Add imagify_bulk_optimize_media filter to exclude media from bulk optimization

### DIFF
--- a/Tests/Unit/classes/Bulk/RunOptimizeTest.php
+++ b/Tests/Unit/classes/Bulk/RunOptimizeTest.php
@@ -6,8 +6,8 @@ namespace Imagify\Tests\Unit\classes\Bulk;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Imagify\Bulk\Bulk;
-use Imagify\Bulk\BulkInterface;
 use Imagify\Tests\Unit\TestCase;
+use Imagify\Tests\Unit\classes\Bulk\Stubs\BulkWithThreeOptimizeIdsStub;
 use Mockery;
 
 /**
@@ -62,14 +62,16 @@ class RunOptimizeTest extends TestCase {
 
 		Functions\expect( 'as_enqueue_async_action' )
 			->twice()
-			->withArgs(
-				function ( $hook, $args, $group ) {
-					return 'imagify_optimize_media' === $hook
-						&& in_array( $args['id'], [ 1, 3 ], true )
-						&& 'wp' === $args['context']
-						&& 1 === $args['level']
-						&& 'imagify-wp-optimize-media' === $group;
-				}
+			->with(
+				'imagify_optimize_media',
+				Mockery::on(
+					function ( $args ) {
+						return in_array( $args['id'], [ 1, 3 ], true )
+							&& 'wp' === $args['context']
+							&& 1 === $args['level'];
+					}
+				),
+				'imagify-wp-optimize-media'
 			);
 
 		Functions\expect( 'set_transient' )
@@ -122,52 +124,5 @@ class RunOptimizeTest extends TestCase {
 			],
 			$result
 		);
-	}
-}
-
-/**
- * Stub bulk: three eligible media IDs for optimization.
- */
-class BulkWithThreeOptimizeIdsStub implements BulkInterface {
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function get_unoptimized_media_ids( $optimization_level ) {
-		return [ 1, 2, 3 ];
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function get_optimized_media_ids(): array {
-		return [];
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function get_optimized_media_ids_without_format( $format ) {
-		return [
-			'ids'    => [],
-			'errors' => [
-				'no_file_path' => [],
-				'no_backup'    => [],
-			],
-		];
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function has_optimized_media_without_nextgen() {
-		return 0;
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function get_context_data() {
-		return [];
 	}
 }

--- a/Tests/Unit/classes/Bulk/RunOptimizeTest.php
+++ b/Tests/Unit/classes/Bulk/RunOptimizeTest.php
@@ -1,0 +1,173 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Bulk;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Imagify\Bulk\Bulk;
+use Imagify\Bulk\BulkInterface;
+use Imagify\Tests\Unit\TestCase;
+use Mockery;
+
+/**
+ * Tests for \Imagify\Bulk\Bulk::run_optimize().
+ *
+ * `Imagify_Requirements` is a legacy classmap-autoloaded class; it is stubbed via a
+ * Mockery alias mock in every test, so every test in this class runs in its own
+ * process (`@runTestsInSeparateProcesses`) to guarantee the alias is registered
+ * before the real class would otherwise be autoloaded.
+ *
+ * @covers \Imagify\Bulk\Bulk::run_optimize
+ * @group  BulkRunOptimize
+ * @since  2.3
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class RunOptimizeTest extends TestCase {
+
+	/**
+	 * Stubs `Imagify_Requirements::is_api_key_valid()` / `is_over_quota()` via a Mockery
+	 * alias mock so can_optimize() lets execution reach the enqueue loop.
+	 *
+	 * @param bool $api_key_valid Value returned by is_api_key_valid().
+	 * @param bool $over_quota    Value returned by is_over_quota().
+	 */
+	private function stubRequirements( bool $api_key_valid, bool $over_quota ): void {
+		$mock = Mockery::mock( 'alias:Imagify_Requirements' );
+		$mock->shouldReceive( 'is_api_key_valid' )->andReturn( $api_key_valid );
+		$mock->shouldReceive( 'is_over_quota' )->andReturn( $over_quota );
+	}
+
+	/**
+	 * Test: the imagify_bulk_optimize_media filter excludes a specific media ID
+	 * from being enqueued, and the total/remaining count reflects the exclusion.
+	 */
+	public function testExcludesMediaIdVetoedByFilter(): void {
+		$this->stubRequirements( true, false );
+
+		Filters\expectApplied( 'imagify_bulk_class_name' )
+			->once()
+			->andReturn( BulkWithThreeOptimizeIdsStub::class );
+
+		// Exclude media ID 2 (e.g. a PDF), keep 1 and 3.
+		Filters\expectApplied( 'imagify_bulk_optimize_media' )
+			->times( 3 )
+			->andReturnUsing(
+				function ( $optimize, $media_id ) {
+					return 2 !== $media_id;
+				}
+			);
+
+		Functions\expect( 'as_enqueue_async_action' )
+			->twice()
+			->withArgs(
+				function ( $hook, $args, $group ) {
+					return 'imagify_optimize_media' === $hook
+						&& in_array( $args['id'], [ 1, 3 ], true )
+						&& 'wp' === $args['context']
+						&& 1 === $args['level']
+						&& 'imagify-wp-optimize-media' === $group;
+				}
+			);
+
+		Functions\expect( 'set_transient' )
+			->once()
+			->with(
+				'imagify_wp_optimize_running',
+				[
+					'total'     => 2,
+					'remaining' => 2,
+				],
+				DAY_IN_SECONDS
+			)
+			->andReturn( true );
+
+		$result = ( new Bulk() )->run_optimize( 'wp', 1 );
+
+		$this->assertSame(
+			[
+				'success' => true,
+				'message' => 'success',
+			],
+			$result
+		);
+	}
+
+	/**
+	 * Test: when the filter excludes every media ID, run_optimize() returns the
+	 * same 'no-images' result as if the underlying list was empty to begin with.
+	 */
+	public function testReturnsNoImagesWhenFilterExcludesAllMedia(): void {
+		$this->stubRequirements( true, false );
+
+		Filters\expectApplied( 'imagify_bulk_class_name' )
+			->once()
+			->andReturn( BulkWithThreeOptimizeIdsStub::class );
+
+		Filters\expectApplied( 'imagify_bulk_optimize_media' )
+			->times( 3 )
+			->andReturn( false );
+
+		Functions\expect( 'as_enqueue_async_action' )->never();
+		Functions\expect( 'set_transient' )->never();
+
+		$result = ( new Bulk() )->run_optimize( 'wp', 1 );
+
+		$this->assertSame(
+			[
+				'success' => false,
+				'message' => 'no-images',
+			],
+			$result
+		);
+	}
+}
+
+/**
+ * Stub bulk: three eligible media IDs for optimization.
+ */
+class BulkWithThreeOptimizeIdsStub implements BulkInterface {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_unoptimized_media_ids( $optimization_level ) {
+		return [ 1, 2, 3 ];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_optimized_media_ids(): array {
+		return [];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_optimized_media_ids_without_format( $format ) {
+		return [
+			'ids'    => [],
+			'errors' => [
+				'no_file_path' => [],
+				'no_backup'    => [],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function has_optimized_media_without_nextgen() {
+		return 0;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_context_data() {
+		return [];
+	}
+}

--- a/Tests/Unit/classes/Bulk/Stubs/BulkWithThreeOptimizeIdsStub.php
+++ b/Tests/Unit/classes/Bulk/Stubs/BulkWithThreeOptimizeIdsStub.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Bulk\Stubs;
+
+use Imagify\Bulk\BulkInterface;
+
+/**
+ * Stub bulk: three eligible media IDs for optimization.
+ */
+class BulkWithThreeOptimizeIdsStub implements BulkInterface {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_unoptimized_media_ids( $optimization_level ) {
+		return [ 1, 2, 3 ];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_optimized_media_ids(): array {
+		return [];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_optimized_media_ids_without_format( $format ) {
+		return [
+			'ids'    => [],
+			'errors' => [
+				'no_file_path' => [],
+				'no_backup'    => [],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function has_optimized_media_without_nextgen() {
+		return 0;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_context_data() {
+		return [];
+	}
+}

--- a/classes/Bulk/Bulk.php
+++ b/classes/Bulk/Bulk.php
@@ -183,24 +183,24 @@ final class Bulk implements BulkOptimizerInterface {
 
 		$media_ids = $this->get_bulk_instance( $context )->get_unoptimized_media_ids( $optimization_level );
 
-		/**
-		 * Filter the list of media to optimize during a bulk optimization, per media.
-		 *
-		 * Return false to exclude a given media from the bulk optimization run
-		 * (e.g. to skip a specific file type such as PDFs).
-		 *
-		 * @since 2.3
-		 *
-		 * @param bool   $optimize           True to optimize this media, false to exclude it.
-		 * @param int    $media_id           The media ID (attachment ID, or custom-folder file ID).
-		 * @param string $context            The optimization context ('wp' or 'custom-folders').
-		 * @param int    $optimization_level The optimization level.
-		 */
 		$media_ids = array_values(
 			array_filter(
 				$media_ids,
 				function ( $media_id ) use ( $context, $optimization_level ) {
-					return apply_filters( 'imagify_bulk_optimize_media', true, $media_id, $context, $optimization_level );
+					/**
+					 * Filter the list of media to optimize during a bulk optimization, per media.
+					 *
+					 * Return false to exclude a given media from the bulk optimization run
+					 * (e.g. to skip a specific file type such as PDFs).
+					 *
+					 * @since 2.3
+					 *
+					 * @param bool   $optimize           True to optimize this media, false to exclude it.
+					 * @param int    $media_id           The media ID (attachment ID, or custom-folder file ID).
+					 * @param string $context            The optimization context ('wp' or 'custom-folders').
+					 * @param int    $optimization_level The optimization level.
+					 */
+					return wpm_apply_filters_typed( 'boolean', 'imagify_bulk_optimize_media', true, $media_id, $context, $optimization_level );
 				}
 			)
 		);

--- a/classes/Bulk/Bulk.php
+++ b/classes/Bulk/Bulk.php
@@ -183,6 +183,28 @@ final class Bulk implements BulkOptimizerInterface {
 
 		$media_ids = $this->get_bulk_instance( $context )->get_unoptimized_media_ids( $optimization_level );
 
+		/**
+		 * Filter the list of media to optimize during a bulk optimization, per media.
+		 *
+		 * Return false to exclude a given media from the bulk optimization run
+		 * (e.g. to skip a specific file type such as PDFs).
+		 *
+		 * @since 2.3
+		 *
+		 * @param bool   $optimize           True to optimize this media, false to exclude it.
+		 * @param int    $media_id           The media ID (attachment ID, or custom-folder file ID).
+		 * @param string $context            The optimization context ('wp' or 'custom-folders').
+		 * @param int    $optimization_level The optimization level.
+		 */
+		$media_ids = array_values(
+			array_filter(
+				$media_ids,
+				function ( $media_id ) use ( $context, $optimization_level ) {
+					return apply_filters( 'imagify_bulk_optimize_media', true, $media_id, $context, $optimization_level );
+				}
+			)
+		);
+
 		if ( empty( $media_ids ) ) {
 			return [
 				'success' => false,


### PR DESCRIPTION
# Description

Fixes #516

Developers can now exclude specific media (typically file types like PDFs) from the **bulk optimization** process, mirroring the existing `imagify_auto_optimize_attachment` filter that already covers the automatic on-upload path. This is the most-requested use case in the issue thread: skipping PDFs during bulk runs so their accessibility (508/ADA) features and large originals aren't touched.

A new filter is introduced:

```php
/**
 * @param bool   $optimize           True to optimize this media, false to exclude it.
 * @param int    $media_id           The media ID (attachment ID, or custom-folder file ID).
 * @param string $context            The optimization context ('wp' or 'custom-folders').
 * @param int    $optimization_level The optimization level.
 */
apply_filters( 'imagify_bulk_optimize_media', true, $media_id, $context, $optimization_level );
```

Example — skip PDFs from bulk optimization:

```php
add_filter( 'imagify_bulk_optimize_media', function ( $optimize, $media_id, $context ) {
    if ( 'wp' === $context && 'application/pdf' === get_post_mime_type( $media_id ) ) {
        return false;
    }
    return $optimize;
}, 10, 3 );
```

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Automated — new unit test `Tests/Unit/classes/Bulk/RunOptimizeTest.php`:
- `testExcludesMediaIdVetoedByFilter` — stub returns IDs `[1,2,3]`, filter vetoes `2`; asserts only `1` and `3` are enqueued and the running transient is set with `total: 2, remaining: 2`.
- `testReturnsNoImagesWhenFilterExcludesAllMedia` — filter vetoes everything → `no-images` result, nothing enqueued.

`composer run test-unit -- --filter RunOptimizeTest` → **OK (2 tests, 10 assertions)**. Regression `--group BulkRunOptimize,BulkRunRestore` → OK (6 tests, 18 assertions). `phpcs` clean on `Bulk.php`.

### How to test

1. Add the example snippet above to a theme/plugin.
2. Upload a PDF and some images, ensuring they are eligible for optimization.
3. Run **Bulk Optimization**. The PDF is excluded from the run; the progress total reflects the exclusion; images optimize normally.
4. Without the filter, behavior is unchanged (PDFs/media still processed as before).

### Affected Features & Quality Assurance Scope

Bulk optimization (`Imagify\Bulk\Bulk::run_optimize()`), both `wp` (media library) and `custom-folders` contexts. Automatic on-upload optimization is unaffected.

## Technical description

### Documentation

The filter is applied once per media ID inside `run_optimize()`, immediately after `get_unoptimized_media_ids()` builds the eligible list and before the emptiness check and enqueue loop. It is purely subtractive — a developer can only remove already-eligible items, never add ineligible ones — exactly like `imagify_auto_optimize_attachment`. Because it runs before `count( $media_ids )` is used for the running transient, the total/remaining progress counters stay correct. The single insertion point covers both contexts, since both flow through `run_optimize()`.

### New dependencies

None.

### Risks

None by default — the filter defaults to `true`, so behavior is unchanged unless a developer opts in. A misbehaving callback can only reduce the work list, never corrupt counts (they are derived after filtering).

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A — all mandatory items addressed.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
