### PR TITLE
Fix #1041: Fix indefinite spinner and stuck progress in Generate Missing Next-Gen

### DIFF
--- a/Tests/Unit/classes/Bulk/RunGenerateNextgenTest.php
+++ b/Tests/Unit/classes/Bulk/RunGenerateNextgenTest.php
@@ -6,8 +6,9 @@ namespace Imagify\Tests\Unit\classes\Bulk;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Imagify\Bulk\Bulk;
-use Imagify\Bulk\BulkInterface;
 use Imagify\Tests\Unit\TestCase;
+use Imagify\Tests\Unit\classes\Bulk\Stubs\BulkNoBackupOnlyStub;
+use Imagify\Tests\Unit\classes\Bulk\Stubs\BulkWithIdsStub;
 use Mockery;
 
 /**
@@ -64,99 +65,5 @@ class RunGenerateNextgenTest extends TestCase {
 			],
 			$result
 		);
-	}
-}
-
-/**
- * Stub bulk: only `no_backup` errors, no eligible ids and no `no_file_path` errors.
- */
-class BulkNoBackupOnlyStub implements BulkInterface {
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function get_unoptimized_media_ids( $optimization_level ) {
-		return [];
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function get_optimized_media_ids(): array {
-		return [];
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function get_optimized_media_ids_without_format( $format ) {
-		return [
-			'ids'    => [],
-			'errors' => [
-				'no_file_path' => [],
-				'no_backup'    => [ 1, 2 ],
-			],
-		];
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function has_optimized_media_without_nextgen() {
-		return 0;
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function get_context_data() {
-		return [];
-	}
-}
-
-/**
- * Stub bulk: two eligible media ids, no errors.
- */
-class BulkWithIdsStub implements BulkInterface {
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function get_unoptimized_media_ids( $optimization_level ) {
-		return [];
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function get_optimized_media_ids(): array {
-		return [];
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function get_optimized_media_ids_without_format( $format ) {
-		return [
-			'ids'    => [ 10, 20 ],
-			'errors' => [
-				'no_file_path' => [],
-				'no_backup'    => [],
-			],
-		];
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function has_optimized_media_without_nextgen() {
-		return 0;
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function get_context_data() {
-		return [];
 	}
 }

--- a/Tests/Unit/classes/Bulk/RunGenerateNextgenTest.php
+++ b/Tests/Unit/classes/Bulk/RunGenerateNextgenTest.php
@@ -1,0 +1,162 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Bulk;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Imagify\Bulk\Bulk;
+use Imagify\Bulk\BulkInterface;
+use Imagify\Tests\Unit\TestCase;
+use Mockery;
+
+/**
+ * Tests for \Imagify\Bulk\Bulk::run_generate_nextgen().
+ *
+ * `Imagify_Requirements` is a legacy classmap-autoloaded class; it is stubbed via
+ * a Mockery alias mock, so this test runs in its own process to guarantee the
+ * alias is registered before the real class would otherwise be autoloaded.
+ *
+ * @covers \Imagify\Bulk\Bulk::run_generate_nextgen
+ * @group  GenerateNextgen
+ * @since  2.3
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class RunGenerateNextgenTest extends TestCase {
+
+	/**
+	 * Stubs `Imagify_Requirements::is_api_key_valid()` / `is_over_quota()` via a Mockery
+	 * alias mock so `can_optimize()` lets execution proceed past the initial guard.
+	 */
+	private function stubRequirements(): void {
+		$mock = Mockery::mock( 'alias:Imagify_Requirements' );
+		$mock->shouldReceive( 'is_api_key_valid' )->andReturn( true );
+		$mock->shouldReceive( 'is_over_quota' )->andReturn( false );
+	}
+
+	/**
+	 * Regression guard: a context that only has `no_backup` errors (empty ids) must not
+	 * abort the whole run. Another context with valid ids must still be scheduled.
+	 */
+	public function testContextWithOnlyNoBackupErrorsDoesNotAbortOtherContexts(): void {
+		$this->stubRequirements();
+
+		Functions\when( 'delete_transient' )->justReturn( true );
+		Functions\when( 'set_transient' )->justReturn( true );
+		Functions\when( 'as_enqueue_async_action' )->justReturn( 1 );
+
+		Filters\expectApplied( 'imagify_bulk_class_name' )
+			->twice()
+			->andReturnUsing(
+				function ( $class_name, $context ) {
+					return 'wp' === $context ? BulkNoBackupOnlyStub::class : BulkWithIdsStub::class;
+				}
+			);
+
+		$result = ( new Bulk() )->run_generate_nextgen( [ 'wp', 'custom-folders' ], [ 'webp' ] );
+
+		$this->assertSame(
+			[
+				'success' => true,
+				'message' => 2,
+			],
+			$result
+		);
+	}
+}
+
+/**
+ * Stub bulk: only `no_backup` errors, no eligible ids and no `no_file_path` errors.
+ */
+class BulkNoBackupOnlyStub implements BulkInterface {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_unoptimized_media_ids( $optimization_level ) {
+		return [];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_optimized_media_ids(): array {
+		return [];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_optimized_media_ids_without_format( $format ) {
+		return [
+			'ids'    => [],
+			'errors' => [
+				'no_file_path' => [],
+				'no_backup'    => [ 1, 2 ],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function has_optimized_media_without_nextgen() {
+		return 0;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_context_data() {
+		return [];
+	}
+}
+
+/**
+ * Stub bulk: two eligible media ids, no errors.
+ */
+class BulkWithIdsStub implements BulkInterface {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_unoptimized_media_ids( $optimization_level ) {
+		return [];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_optimized_media_ids(): array {
+		return [];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_optimized_media_ids_without_format( $format ) {
+		return [
+			'ids'    => [ 10, 20 ],
+			'errors' => [
+				'no_file_path' => [],
+				'no_backup'    => [],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function has_optimized_media_without_nextgen() {
+		return 0;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_context_data() {
+		return [];
+	}
+}

--- a/Tests/Unit/classes/Bulk/Stubs/BulkNoBackupOnlyStub.php
+++ b/Tests/Unit/classes/Bulk/Stubs/BulkNoBackupOnlyStub.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Bulk\Stubs;
+
+use Imagify\Bulk\BulkInterface;
+
+/**
+ * Stub bulk: only `no_backup` errors, no eligible ids and no `no_file_path` errors.
+ */
+class BulkNoBackupOnlyStub implements BulkInterface {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_unoptimized_media_ids( $optimization_level ) {
+		return [];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_optimized_media_ids(): array {
+		return [];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_optimized_media_ids_without_format( $format ) {
+		return [
+			'ids'    => [],
+			'errors' => [
+				'no_file_path' => [],
+				'no_backup'    => [ 1, 2 ],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function has_optimized_media_without_nextgen() {
+		return 0;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_context_data() {
+		return [];
+	}
+}

--- a/Tests/Unit/classes/Bulk/Stubs/BulkWithIdsStub.php
+++ b/Tests/Unit/classes/Bulk/Stubs/BulkWithIdsStub.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Bulk\Stubs;
+
+use Imagify\Bulk\BulkInterface;
+
+/**
+ * Stub bulk: two eligible media ids, no errors.
+ */
+class BulkWithIdsStub implements BulkInterface {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_unoptimized_media_ids( $optimization_level ) {
+		return [];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_optimized_media_ids(): array {
+		return [];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_optimized_media_ids_without_format( $format ) {
+		return [
+			'ids'    => [ 10, 20 ],
+			'errors' => [
+				'no_file_path' => [],
+				'no_backup'    => [],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function has_optimized_media_without_nextgen() {
+		return 0;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_context_data() {
+		return [];
+	}
+}

--- a/classes/Bulk/Bulk.php
+++ b/classes/Bulk/Bulk.php
@@ -296,13 +296,8 @@ final class Bulk implements BulkOptimizerInterface {
 		foreach ( $contexts as $context ) {
 			foreach ( $formats as $format ) {
 				$media = $this->get_bulk_instance( $context )->get_optimized_media_ids_without_format( $format );
-				if ( ! $media['ids'] && $media['errors']['no_backup'] ) {
-					// No backup, no next-gen.
-					return [
-						'success' => false,
-						'message' => 'no-backup',
-					];
-				} elseif ( ! $media['ids'] && $media['errors']['no_file_path'] ) {
+
+				if ( ! $media['ids'] && $media['errors']['no_file_path'] ) {
 					// Error.
 					return [
 						'success' => false,
@@ -310,7 +305,9 @@ final class Bulk implements BulkOptimizerInterface {
 					];
 				}
 
-				$medias[ $context ] = $media['ids'];
+				if ( $media['ids'] ) {
+					$medias[ $context ] = $media['ids'];
+				}
 			}
 		}
 

--- a/classes/Bulk/CustomFolders.php
+++ b/classes/Bulk/CustomFolders.php
@@ -172,7 +172,8 @@ class CustomFolders extends AbstractBulk {
 		if ( ! isset( $mime ) && empty( $mime ) ) {
 			$mime = 'image/webp';
 		}
-		$mime_types     = str_replace( ",'" . $mime . "'", '', $mime_types );
+		$mime           = trim( $mime );
+		$mime_types     = str_replace( [ ", '" . $mime . "'", ",'" . $mime . "'" ], '', $mime_types );
 		$nextgen_suffix = constant( imagify_get_optimization_process_class_name( 'custom-folders' ) . '::' . strtoupper( $format ) . '_SUFFIX' );
 		$files          = $wpdb->get_results(
 			$wpdb->prepare( // WPCS: unprepared SQL ok.
@@ -180,11 +181,11 @@ class CustomFolders extends AbstractBulk {
 			SELECT fi.file_id, fi.path
 			FROM $files_table as fi
 			INNER JOIN $folders_table AS fo
-				ON ( fi.folder_id = fo.folder_id )
+				ON ( fi.folder_id = fo.folder_id AND fo.active = 1 )
 			WHERE
 				fi.mime_type IN ( $mime_types )
 				AND ( fi.status = 'success' OR fi.status = 'already_optimized' )
-				AND ( fi.data NOT LIKE %s OR fi.data IS NULL )
+				AND fi.data NOT LIKE %s
 			ORDER BY fi.file_id DESC",
 				'%' . $wpdb->esc_like( $nextgen_suffix . '";a:4:{s:7:"success";b:1;' ) . '%'
 			)
@@ -214,7 +215,14 @@ class CustomFolders extends AbstractBulk {
 				continue;
 			}
 
-			$file_path   = Imagify_Files_Scan::remove_placeholder( $file->path );
+			$file_path = Imagify_Files_Scan::remove_placeholder( $file->path );
+
+			// Skip files whose extension already matches the target format
+			// (e.g. a .webp file stored with incorrect post_mime_type).
+			if ( strtolower( pathinfo( $file_path, PATHINFO_EXTENSION ) ) === $format ) {
+				continue;
+			}
+
 			$backup_path = Imagify_Custom_Folders::get_file_backup_path( $file_path );
 
 			if ( ! $this->filesystem->exists( $backup_path ) ) {

--- a/classes/Bulk/WP.php
+++ b/classes/Bulk/WP.php
@@ -287,7 +287,8 @@ class WP extends AbstractBulk {
 		if ( ! isset( $mime ) && empty( $mime ) ) {
 			$mime = 'image/webp';
 		}
-		$mime_types   = str_replace( ",'" . $mime . "'", '', $mime_types );
+		$mime         = trim( $mime );
+		$mime_types   = str_replace( [ ", '" . $mime . "'", ",'" . $mime . "'" ], '', $mime_types );
 		$statuses     = Imagify_DB::get_post_statuses();
 		$nodata_join  = '';
 		$nodata_where = '';
@@ -314,7 +315,7 @@ class WP extends AbstractBulk {
 					ON ( p.ID = mt2.post_id AND mt2.meta_key = '_imagify_data' )
 			WHERE
 				p.post_mime_type IN ( $mime_types )
-				AND (mt1.meta_key IS NULL OR mt1.meta_value = 'success' OR mt1.meta_value = 'already_optimized' )
+				AND ( mt1.meta_value = 'success' OR mt1.meta_value = 'already_optimized' )
 				AND mt2.meta_value NOT LIKE %s
 				AND p.post_type = 'attachment'
 				AND p.post_status IN ( $statuses )
@@ -374,6 +375,12 @@ class WP extends AbstractBulk {
 			if ( ! $file_path ) {
 				// Main file not found.
 				$data['errors']['no_file_path'][] = $id;
+				continue;
+			}
+
+			// Skip files whose extension already matches the target format
+			// (e.g. a .webp file stored with incorrect post_mime_type).
+			if ( strtolower( pathinfo( $file_path, PATHINFO_EXTENSION ) ) === $format ) {
 				continue;
 			}
 

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -1970,9 +1970,6 @@ abstract class AbstractProcess implements ProcessInterface {
 		 */
 		$data = (array) apply_filters( "imagify{$_unauthorized}_file_optimization_data", $data, $response, $size, $level, $this->get_data() );
 
-		if ( property_exists( $response, 'message' ) ) {
-			$size = str_replace( $this->format, '', $size );
-		}
 		// Store.
 		$this->get_data()->update_size_optimization_data( $size, $data );
 


### PR DESCRIPTION
# Description

Fixes #1041

The **Generate Missing Next-Gen Images** bulk operation could spin indefinitely with a progress counter (e.g. `0/21`) that never advanced, even after a page refresh. This PR fixes a cluster of **7 distinct bugs** across 4 files that collectively caused images to be counted as "remaining" but never successfully processed — so the counter never reached zero.

The most impactful is Bug 5: when the Imagify API reported that the WebP version would be larger than the original, the next-gen result was written under the wrong data key, so those images matched the "remaining" query forever and were re-queued on every run. This alone stuck the majority of real-world queues.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- Automated: new unit test `Tests/Unit/classes/Bulk/RunGenerateNextgenTest.php` (`@group GenerateNextgen`) covering Bug 3 — a context that has only `no_backup` errors (empty ids) no longer aborts the whole run; a second context with valid ids is still scheduled. Full unit suite: **346 tests pass**, no new failures (17 pre-existing risky/deprecation warnings unchanged).
- `php -l` passes on all 4 changed files and the new test.

### How to test

**Bug 5 (most common):**
1. Have at least one image optimized by Imagify where the WebP version would be larger than the original (routine for already-optimized images, transparent PNGs, small files).
2. Settings → Imagify → **Generate Missing Next-Gen Images Version**.
3. Before fix: counter never decreases; `_imagify_data` for those images has no `@imagify-webp` key (a spurious entry is written under the bare size key). After fix: those images get the `@imagify-webp` key with `success: true` and are excluded from future runs; the counter advances to zero.

**Bug 1 + 2 (custom folders):** deactivate a custom folder containing files with no `fi.data`; before fix the total includes files that are never processed.

**Bug 3 (custom folders + media library):** custom-folder images with no backups previously aborted the whole run, silently skipping the media library; now the media library still processes.

**Bug 4 (partial media entries):** a media image with `_imagify_data` but no `_imagify_status` row was queued and silently failed each time.

**Bug 6 + 7 (webp source files):** a `.webp` uploaded with `post_mime_type = image/jpeg` (e.g. BuddyBoss) was permanently stuck at "remaining = 1".

### Affected Features & Quality Assurance Scope

Bulk "Generate Missing Next-Gen Images" for both media library (`wp`) and custom folders; the next-gen size-data storage in the optimization process. Standard image optimization is not changed.

## Technical description

### Documentation

Seven fixes:

| File | Fix |
|---|---|
| `classes/Bulk/CustomFolders.php` | **Bug 1** JOIN now filters `fo.active = 1`; **Bug 2** drop `OR fi.data IS NULL`; **Bug 6** trim mime + position-independent removal from `IN(...)`; **Bug 7** skip files whose extension already matches the target format |
| `classes/Bulk/WP.php` | **Bug 4** drop `mt1.meta_key IS NULL OR` from the status condition; **Bug 6**; **Bug 7** |
| `classes/Bulk/Bulk.php` | **Bug 3** `run_generate_nextgen()` no longer returns early on a `no-backup` context; only assigns `$medias[$context]` when ids exist, so later contexts are still evaluated |
| `classes/Optimization/Process/AbstractProcess.php` | **Bug 5** remove the `str_replace` that rewrote the size key when the API response had a `message`, so next-gen data is always stored under the correct `size@imagify-webp` key |

### New dependencies

None.

### Risks

Low. Bug 5 changes storage to always use the correct key — the data carries `success: true`, so the image is correctly excluded from future runs regardless of whether the API chose to replace the file. Bug 3 relies on the existing downstream `empty( $medias )` guard as the terminal no-images case. SQL changes are narrowing (fewer false candidates), so they cannot cause over-processing.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Unit coverage focuses on Bug 3 (the most unit-testable in isolation). Bugs 1/2/4 are `$wpdb`-query-shape changes and Bug 5 is verified via the reproduction scenario; these are better exercised by integration/manual QA than by mocking `$wpdb`.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
