### PR TITLE
Closes #485: harden WP Rocket CDN container resolution

### DIFF
--- a/Tests/Unit/inc/3rd-party/wp-rocket/Main/setCdnSource.php
+++ b/Tests/Unit/inc/3rd-party/wp-rocket/Main/setCdnSource.php
@@ -1,0 +1,240 @@
+<?php
+namespace {
+
+	if ( ! class_exists( 'Imagify_Filesystem', false ) ) {
+		/**
+		 * Lightweight stub for the legacy Imagify_Filesystem class.
+		 *
+		 * The real class (inc/classes/class-imagify-filesystem.php) requires
+		 * ABSPATH and WP core filesystem classes that are not loaded in the
+		 * unit test bootstrap, so it cannot be used here. Declaring this stub
+		 * before the real class is ever referenced pre-empts the classmap
+		 * autoloader, since `Main::set_cdn_source()` reaches
+		 * `\Imagify_Filesystem::get_instance()->get_site_root_url()` on any
+		 * path that resolves a non-empty CDN URL.
+		 */
+		class Imagify_Filesystem {
+			/**
+			 * @var self|null
+			 */
+			private static $instance;
+
+			public static function get_instance() {
+				if ( null === self::$instance ) {
+					self::$instance = new self();
+				}
+
+				return self::$instance;
+			}
+
+			public function get_site_root_url() {
+				return 'https://example.com/';
+			}
+		}
+	}
+
+	if ( ! class_exists( 'Imagify\\ThirdParty\\WPRocket\\Main', false ) ) {
+		// Force-load this worktree's copy: composer's classmap/autoload_psr4 baked-in
+		// $baseDir resolves symlinked vendor/ to the main checkout, not this worktree.
+		require_once IMAGIFY_PLUGIN_ROOT . 'inc/3rd-party/wp-rocket/classes/Main.php';
+	}
+}
+
+namespace Imagify\Tests\Unit\inc\ThirdParty\WPRocket\Main {
+
+	use Brain\Monkey\Filters;
+	use Brain\Monkey\Functions;
+	use Imagify\Tests\Unit\TestCase;
+	use Imagify\ThirdParty\WPRocket\Main;
+
+	/**
+	 * Tests for \Imagify\ThirdParty\WPRocket\Main::set_cdn_source().
+	 *
+	 * @covers \Imagify\ThirdParty\WPRocket\Main::set_cdn_source
+	 * @group  WPRocket
+	 */
+	class Test_SetCdnSource extends TestCase {
+		/**
+		 * The $source array passed to set_cdn_source() when it's not expected to be altered.
+		 *
+		 * @var array
+		 */
+		private $originalSource = [
+			'name' => 'Original',
+			'url'  => 'https://original.example.com',
+		];
+
+		protected function setUp(): void {
+			parent::setUp();
+
+			Functions\when( 'get_rocket_option' )->justReturn( true );
+		}
+
+		/**
+		 * Stub the tail of the method (URL scheme normalisation) so it doesn't blow up
+		 * once a non-empty $url has been resolved, either from the container or the
+		 * get_rocket_cdn_cnames() fallback.
+		 */
+		private function stubUrlSchemeTail() {
+			Functions\when( 'wp_parse_url' )->justReturn( [ 'scheme' => 'https' ] );
+			Functions\when( 'set_url_scheme' )->alias(
+				function ( $url, $scheme ) {
+					return $scheme . ':' . $url;
+				}
+			);
+		}
+
+		/**
+		 * Regression guard for the reported bug: the container exposes get() but does not
+		 * register the 'cdn' alias. has( 'cdn' ) must be checked before get() is attempted,
+		 * so get() throwing here proves it was never called.
+		 */
+		public function testShouldFallBackToCnamesWhenServiceNotRegistered() {
+			$container = new class() {
+				public function has( $id ) {
+					return false;
+				}
+
+				public function get( $id ) {
+					throw new \RuntimeException( 'get() must not be called when has( "cdn" ) returns false.' );
+				}
+			};
+
+			Filters\expectApplied( 'rocket_container' )->once()->andReturn( $container );
+
+			Functions\when( 'get_rocket_cdn_cnames' )->justReturn( [ 'cdn.example.com' ] );
+			$this->stubUrlSchemeTail();
+
+			$source = ( new Main() )->set_cdn_source( $this->originalSource );
+
+			$this->assertSame( 'WP Rocket', $source['name'] );
+			$this->assertSame( 'https://cdn.example.com', $source['url'] );
+		}
+
+		/**
+		 * has( 'cdn' ) returns true but get( 'cdn' ) throws (e.g. a ContainerException):
+		 * the throw must be contained and the CNAME fallback used.
+		 */
+		public function testShouldContainThrowingGet() {
+			$container = new class() {
+				public function has( $id ) {
+					return true;
+				}
+
+				public function get( $id ) {
+					throw new \Exception( 'Alias (cdn) is not being managed by the container.' );
+				}
+			};
+
+			Filters\expectApplied( 'rocket_container' )->once()->andReturn( $container );
+
+			Functions\when( 'get_rocket_cdn_cnames' )->justReturn( [ 'fallback.example.com' ] );
+			$this->stubUrlSchemeTail();
+
+			$source = ( new Main() )->set_cdn_source( $this->originalSource );
+
+			$this->assertSame( 'WP Rocket', $source['name'] );
+			$this->assertSame( 'https://fallback.example.com', $source['url'] );
+		}
+
+		/**
+		 * The resolved $cdn service itself throws from get_cdn_urls(): must be contained
+		 * by the same boundary and fall back.
+		 */
+		public function testShouldContainThrowingGetCdnUrls() {
+			$cdn = new class() {
+				public function get_cdn_urls( $types ) {
+					throw new \Exception( 'CDN service could not build its URLs.' );
+				}
+			};
+
+			$container = new class( $cdn ) {
+				private $cdn;
+
+				public function __construct( $cdn ) {
+					$this->cdn = $cdn;
+				}
+
+				public function has( $id ) {
+					return true;
+				}
+
+				public function get( $id ) {
+					return $this->cdn;
+				}
+			};
+
+			Filters\expectApplied( 'rocket_container' )->once()->andReturn( $container );
+
+			Functions\when( 'get_rocket_cdn_cnames' )->justReturn( [ 'fallback.example.com' ] );
+			$this->stubUrlSchemeTail();
+
+			$source = ( new Main() )->set_cdn_source( $this->originalSource );
+
+			$this->assertSame( 'WP Rocket', $source['name'] );
+			$this->assertSame( 'https://fallback.example.com', $source['url'] );
+		}
+
+		/**
+		 * Happy path is unchanged: the container resolves a working 'cdn' service and its
+		 * URL is used, not the get_rocket_cdn_cnames() fallback.
+		 */
+		public function testShouldUseContainerCdnUrlWhenAvailable() {
+			$cdn = new class() {
+				public function get_cdn_urls( $types ) {
+					return [ 'cdn-from-container.example.com' ];
+				}
+			};
+
+			$container = new class( $cdn ) {
+				private $cdn;
+
+				public function __construct( $cdn ) {
+					$this->cdn = $cdn;
+				}
+
+				public function has( $id ) {
+					return true;
+				}
+
+				public function get( $id ) {
+					return $this->cdn;
+				}
+			};
+
+			Filters\expectApplied( 'rocket_container' )->once()->andReturn( $container );
+
+			Functions\expect( 'get_rocket_cdn_cnames' )->never();
+			$this->stubUrlSchemeTail();
+
+			$source = ( new Main() )->set_cdn_source( $this->originalSource );
+
+			$this->assertSame( 'WP Rocket', $source['name'] );
+			$this->assertSame( 'https://cdn-from-container.example.com', $source['url'] );
+		}
+
+		/**
+		 * The container fails AND get_rocket_cdn_cnames() has nothing to offer: the
+		 * original $source must be returned untouched.
+		 */
+		public function testShouldReturnOriginalSourceWhenNoFallbackAvailable() {
+			$container = new class() {
+				public function has( $id ) {
+					return true;
+				}
+
+				public function get( $id ) {
+					throw new \Exception( 'Container could not resolve the service.' );
+				}
+			};
+
+			Filters\expectApplied( 'rocket_container' )->once()->andReturn( $container );
+
+			Functions\when( 'get_rocket_cdn_cnames' )->justReturn( [] );
+
+			$source = ( new Main() )->set_cdn_source( $this->originalSource );
+
+			$this->assertSame( $this->originalSource, $source );
+		}
+	}
+}

--- a/inc/3rd-party/wp-rocket/classes/Main.php
+++ b/inc/3rd-party/wp-rocket/classes/Main.php
@@ -50,10 +50,18 @@ class Main {
 		$container = apply_filters( 'rocket_container', null );
 
 		if ( is_object( $container ) && method_exists( $container, 'get' ) ) {
-			$cdn = $container->get( 'cdn' );
+			try {
+				// WP Rocket does not register the 'cdn' service in every context.
+				if ( ! method_exists( $container, 'has' ) || $container->has( 'cdn' ) ) {
+					$cdn = $container->get( 'cdn' );
 
-			if ( $cdn && method_exists( $cdn, 'get_cdn_urls' ) ) {
-				$url = $cdn->get_cdn_urls( [ 'all', 'images' ] );
+					if ( $cdn && method_exists( $cdn, 'get_cdn_urls' ) ) {
+						$url = $cdn->get_cdn_urls( [ 'all', 'images' ] );
+					}
+				}
+			} catch ( \Throwable $e ) {
+				// Container could not resolve or build the service: fall back to get_rocket_cdn_cnames().
+				$url = null;
 			}
 		}
 


### PR DESCRIPTION
# Description

Closes #485

`Imagify\ThirdParty\WPRocket\Main::set_cdn_source()` resolves WP Rocket's `cdn` service through the public `rocket_container` filter, guarded only by `method_exists( $container, 'get' )`. That guard proves the method exists — it does not prove `cdn` is registered, and it does not cover a container whose resolution throws. This PR adds a `has( 'cdn' )` pre-check and a `try/catch ( \Throwable )`, falling through to the pre-existing `get_rocket_cdn_cnames()` fallback.

## Scope, stated honestly: this is hardening, not a reproducible bug fix

Issue #485 was filed in 2020 and reports an uncaught `NotFoundException: Alias (cdn) is not being managed by the container`. **The mechanism it describes could not be reproduced — then or now.**

The issue (and the grooming comment on it, since corrected) assumed WP Rocket does not register `cdn` in every context. That is not true, and was not true when the issue was filed. `cdn` is registered unconditionally in every version checked:

| WP Rocket version | Registration site | Conditional? |
|---|---|---|
| v3.3 | `inc/classes/class-plugin.php:110` → `Common_Subscribers` | No |
| v3.4.4 | `inc/classes/class-plugin.php:119` | No |
| **v3.5.1** (current when #485 was filed) | `inc/classes/class-plugin.php:124`, `class-common-subscribers.php:66` | No |
| current `develop` | `inc/Plugin.php:287` → `inc/Engine/CDN/ServiceProvider.php:63` | No |

In each case the provider is added at method-body top level — not gated on the `cdn` option, not on `is_admin()`, not on license validity. (Compare `CloudflareServiceProvider`, which *is* gated, on `do_cloudflare`.)

There is one genuine structural window: `rocket_container` is hooked in `Plugin::__construct()` (`inc/Plugin.php:116`) but `cdn` is not registered until `load()` (`inc/Plugin.php:287`), so between those the filter returns a live-but-empty container. **Imagify cannot reach it** — all three appliers of `imagify_cdn_source_url` run long after `plugins_loaded`.

So the original 2020 crash remains unexplained. It was real — there is a genuine stack trace — but neither the option-gate hypothesis nor the constructor/`load()` window accounts for a fatal during an admin settings-page render. Rather than invent a mechanism, this PR treats it as unexplained and fixes the unsafe assumption that is demonstrably present in Imagify's code.

### Why guard it anyway

The residual risk is version-independent and does not depend on reproducing #485:

- `rocket_container` is a **public filter**. Any third-party plugin can return a partial, foreign, or non-container object. Imagify cannot control this and WP Rocket cannot fix it upstream.
- `get()` can throw even when `has()` is true — league/container raises `ContainerException` if a provider claims a service in `provides()` but fails to define it, or if the definition's own dependencies (`options`) fail to resolve.
- `CDN::get_cdn_urls()` is third-party code in the same block and can throw on its own, via `cname_validator->is_valid()`.

### Blast radius if it does throw

`imagify_cdn_source_url` has three appliers, all reachable:

| Call site | Trigger |
|---|---|
| `views/part-settings-webp.php:89` | Imagify settings page render — unconditional, not gated on the next-gen checkbox |
| `inc/classes/class-imagify-options.php:183` | Saving Imagify options |
| `classes/Picture/Display.php:735` | **Frontend page load**, during `<picture>` rewriting |

The third was not in the original report and is the reason this is worth guarding: an uncaught throw there fatals **public pages**, not just the admin screen. The issue's `severity: minor` label is understated on impact, though defensible on frequency.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #485
- [ ] Chore
- [ ] Release

## Technical description

### How it works

```php
if ( is_object( $container ) && method_exists( $container, 'get' ) ) {
	try {
		// WP Rocket does not guarantee the 'cdn' service is registered on a filtered container.
		if ( ! method_exists( $container, 'has' ) || $container->has( 'cdn' ) ) {
			$cdn = $container->get( 'cdn' );

			if ( $cdn && method_exists( $cdn, 'get_cdn_urls' ) ) {
				$url = $cdn->get_cdn_urls( [ 'all', 'images' ] );
			}
		}
	} catch ( \Throwable $e ) {
		$url = null;
	}
}
```

- `\Throwable` rather than `\Exception`: league/container 3.x `NotFoundException` extends `InvalidArgumentException`, but a foreign container can raise an `Error`. The leading backslash is required — the file is namespaced `Imagify\ThirdParty\WPRocket`.
- `has()` is a pre-check inside the `try`, not a replacement for it. PSR-11 only promises that `has() === true` means no `NotFoundException`; it does not rule out a `ContainerException` from the definition's own dependency resolution. `method_exists( $container, 'has' )` keeps foreign containers that lack `has()` working.
- `$url = null` in the catch, not an empty catch: the following `if ( ! isset( $url ) && function_exists( 'get_rocket_cdn_cnames' ) )` relies on `isset( null ) === false`, so the pre-existing CNAME fallback still fires. Everything after the guarded block is untouched — **the happy path is byte-identical**.

### Documentation

None required — no public API, hook, or user-facing behaviour changes.

### New dependencies

None.

### Risks

**Behavioural:** none on the happy path. When the container resolves normally the code is byte-identical to before. When it throws, the method now falls back to `get_rocket_cdn_cnames()` instead of fataling — strictly an improvement.

**Observability:** the caught `\Throwable` is discarded rather than logged, so a genuinely broken container fails silently rather than loudly. This is deliberate and consistent with the existing no-container path, but it means a future occurrence of #485's mechanism would produce no diagnostic. Adding a debug-only log is a reasonable follow-up if this area ever needs investigation.

## Detailed scenario

### What was tested

**Unit tests:** `Tests/Unit/inc/3rd-party/wp-rocket/Main/setCdnSource.php` — 5 tests, 15 assertions, all passing.

```
composer test-unit -- --filter="Test_SetCdnSource"
.....                                                               5 / 5 (100%)
OK (5 tests, 15 assertions)
```

Container and CDN doubles are anonymous classes, so the suite has no dependency on WP Rocket or league/container being installed in CI.

| Test | Covers |
|---|---|
| `testShouldFallBackToCnamesWhenServiceNotRegistered` | `has()` false, `get()` throws if reached — proves the pre-check gates the call |
| `testShouldContainThrowingGet` | `has()` true but `get()` throws — contained, falls back |
| `testShouldContainThrowingGetCdnUrls` | resolved CDN's `get_cdn_urls()` throws — contained, falls back |
| `testShouldUseContainerCdnUrlWhenAvailable` | happy path; asserts the CNAME fallback is never called |
| `testShouldReturnOriginalSourceWhenNoFallbackAvailable` | container throws **and** CNAMEs empty — original `$source` returned untouched |

**Full suite:** 360 tests / 848 assertions / 17 risky, against an `origin/develop` baseline of 355 / 833 / 17. Delta is exactly the 5 new tests; the 17 risky are pre-existing `ReflectionProperty::setValue()` deprecation warnings, identical on both branches.

**Lint / static analysis:** `vendor/bin/phpcs inc/3rd-party/wp-rocket/classes/Main.php` → 0 violations. `composer run-stan` reports 5 errors, all of which reproduce identically on `origin/develop` (2 in `classes/Media/WP.php:214`, 3 in `Tests/Unit/classes/Optimization/File/MaybeCorrectExifOrientationTest.php`) — **no new errors introduced**.

### How to test

1. `composer test-unit -- --filter="Test_SetCdnSource"` — all 5 scenarios pass.
2. **Regression (the important one):** with WP Rocket active and its CDN option enabled, confirm the Imagify settings page still shows the WP Rocket CDN URL as the detected source, and that frontend `<picture>` rewriting still resolves CDN URLs. The happy path must be unchanged.
3. Disable WP Rocket's CDN option and confirm the settings page falls back as before.

### Affected Features & Quality Assurance Scope

- **WP Rocket CDN detection** — `Main::set_cdn_source()` is the only changed production code.
- **Imagify settings page** — CDN source display.
- **Frontend next-gen `<picture>` rewriting** — `classes/Picture/Display.php:735` consumes the same filter.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
  - Covered by the 5 unit tests. Note the AC here is "does not throw", not "reproduces #485" — the original mechanism is unreproducible, as documented above.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
  - Every branch of the guarded block is executed by the unit suite.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
  - This PR is precisely that: the third-party container is now treated as untrusted.
- [x] I did not introduce unnecessary complexity.
  - 12 added lines, one method, no new abstractions.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
  - N/A — no user-facing output. See the observability note under Risks.

## Remaining QA note

No manual verification against a live WP Rocket install was performed. The regression check in "How to test" (step 2) is the meaningful manual gate — confirming the happy path still works matters more here than trying to reproduce a crash that appears to be unreproducible.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
  - Partially — see the observability caveat under Risks; the exception is intentionally swallowed.
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
