### PR TITLE
Closes #1011: fix next-gen generation tool never completing when the converted file is heavier

### DIFF
--- a/Tests/Integration/classes/Bulk/WP/GetOptimizedMediaIdsWithoutFormatTest.php
+++ b/Tests/Integration/classes/Bulk/WP/GetOptimizedMediaIdsWithoutFormatTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Imagify\Tests\Integration\classes\Bulk\WP;
+
+use Imagify\Bulk\WP as BulkWP;
+use Imagify\Tests\Integration\TestCase;
+
+/**
+ * Tests for \Imagify\Bulk\WP::get_optimized_media_ids_without_format().
+ *
+ * @covers \Imagify\Bulk\WP::get_optimized_media_ids_without_format
+ * @group  NextGenPermanentError
+ */
+class GetOptimizedMediaIdsWithoutFormatTest extends TestCase {
+	protected $useApi = false;
+
+	/**
+	 * Creates an optimized attachment carrying the given `_imagify_data` sizes.
+	 *
+	 * @param array $sizes The `sizes` sub-array of `_imagify_data`.
+	 *
+	 * @return int
+	 */
+	private function create_optimized_attachment( array $sizes ): int {
+		$attachment_id = $this->factory()->attachment->create_object(
+			[
+				'file'           => 'image.jpg',
+				'post_mime_type' => 'image/jpeg',
+				'post_status'    => 'inherit',
+			]
+		);
+
+		update_post_meta( $attachment_id, '_wp_attached_file', 'image.jpg' );
+		update_post_meta( $attachment_id, '_wp_attachment_metadata', [ 'file' => 'image.jpg' ] );
+		update_post_meta( $attachment_id, '_imagify_status', 'success' );
+		update_post_meta(
+			$attachment_id,
+			'_imagify_data',
+			[
+				'sizes' => $sizes,
+			]
+		);
+
+		return $attachment_id;
+	}
+
+	/**
+	 * Test: a media whose AVIF conversion was permanently refused is not returned any more.
+	 */
+	public function testExcludesMediaWithPermanentNextGenError() {
+		$attachment_id = $this->create_optimized_attachment(
+			[
+				'full'               => [
+					'success'        => true,
+					'original_size'  => 1000,
+					'optimized_size' => 800,
+					'percent'        => 20.0,
+				],
+				'full@imagify-avif' => [
+					'permanent_error' => true,
+					'success'         => false,
+					'error'           => 'AVIF file is larger than the original image',
+				],
+			]
+		);
+
+		$result = ( new BulkWP() )->get_optimized_media_ids_without_format( 'avif' );
+
+		$this->assertNotContains( $attachment_id, $result['ids'] );
+	}
+
+	/**
+	 * Test: a media whose AVIF conversion failed transiently is still returned, so it gets retried.
+	 */
+	public function testKeepsMediaWithTransientNextGenError() {
+		$attachment_id = $this->create_optimized_attachment(
+			[
+				'full'               => [
+					'success'        => true,
+					'original_size'  => 1000,
+					'optimized_size' => 800,
+					'percent'        => 20.0,
+				],
+				'full@imagify-avif' => [
+					'success' => false,
+					'error'   => 'cURL error 28: Operation timed out',
+				],
+			]
+		);
+
+		$result = ( new BulkWP() )->get_optimized_media_ids_without_format( 'avif' );
+
+		$this->assertContains( $attachment_id, $result['ids'] );
+	}
+}

--- a/Tests/Unit/classes/Optimization/Process/AbstractProcess/update_size_optimization_data.php
+++ b/Tests/Unit/classes/Optimization/Process/AbstractProcess/update_size_optimization_data.php
@@ -1,0 +1,199 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Optimization\Process\AbstractProcess;
+
+use Brain\Monkey\Functions;
+use Imagify\Optimization\Data\DataInterface;
+use Imagify\Optimization\Process\AbstractProcess;
+use Imagify\Tests\Unit\TestCase;
+use Mockery;
+use WP_Error;
+
+/**
+ * Tests for \Imagify\Optimization\Process\AbstractProcess::update_size_optimization_data().
+ *
+ * @covers \Imagify\Optimization\Process\AbstractProcess::update_size_optimization_data
+ * @group  NextGenPermanentError
+ */
+class Test_UpdateSizeOptimizationData extends TestCase {
+
+	/**
+	 * Stores the arguments the data layer received.
+	 *
+	 * @var array
+	 */
+	private $stored = [];
+
+	/**
+	 * Sets up the common function stubs.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->stored = [];
+
+		Functions\when( 'imagify_translate_api_message' )->returnArg();
+	}
+
+	/**
+	 * Builds a process whose data layer records what it is asked to store.
+	 *
+	 * @return ProcessStub
+	 */
+	private function get_process(): ProcessStub {
+		$data = Mockery::mock( DataInterface::class );
+
+		$data->shouldReceive( 'update_size_optimization_data' )
+			->andReturnUsing(
+				function ( $size, $size_data ) {
+					$this->stored[ $size ] = $size_data;
+				}
+			);
+
+		return new ProcessStub( $data, ProcessStub::AVIF_SUFFIX );
+	}
+
+	/**
+	 * Test: a next-gen size refused by the API is stored under the suffixed key as a permanent error.
+	 */
+	public function testStoresPermanentErrorUnderSuffixedKeyForNextGenSize(): void {
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$process = $this->get_process();
+		$size    = 'full' . ProcessStub::AVIF_SUFFIX;
+
+		$process->update_size_optimization_data(
+			(object) [ 'message' => 'Avif is less performant than original' ],
+			$size,
+			1
+		);
+
+		$this->assertArrayHasKey( $size, $this->stored );
+		$this->assertFalse( $this->stored[ $size ]['success'] );
+		$this->assertTrue( $this->stored[ $size ]['permanent_error'] );
+		$this->assertSame( 'Avif is less performant than original', $this->stored[ $size ]['error'] );
+	}
+
+	/**
+	 * Test: the base size record is left untouched when a next-gen conversion is refused.
+	 */
+	public function testDoesNotOverwriteBaseSizeWhenNextGenIsRefused(): void {
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$process = $this->get_process();
+
+		$process->update_size_optimization_data(
+			(object) [ 'message' => 'Avif is less performant than original' ],
+			'full' . ProcessStub::AVIF_SUFFIX,
+			1
+		);
+
+		$this->assertArrayNotHasKey( 'full', $this->stored );
+	}
+
+	/**
+	 * Test: a regular size carrying a message keeps its previous behaviour (success, no flag).
+	 */
+	public function testKeepsPreviousBehaviourForNonNextGenSize(): void {
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$process = $this->get_process();
+
+		$process->update_size_optimization_data(
+			(object) [
+				'message'       => 'WELL DONE. This image is already compressed, no further compression required',
+				'original_size' => 100,
+				'new_size'      => 100,
+			],
+			'full',
+			1
+		);
+
+		$this->assertArrayHasKey( 'full', $this->stored );
+		$this->assertTrue( $this->stored['full']['success'] );
+		$this->assertArrayNotHasKey( 'permanent_error', $this->stored['full'] );
+	}
+
+	/**
+	 * Test: a transient next-gen failure is stored without the flag, so it stays retryable.
+	 */
+	public function testKeepsTransientNextGenErrorRetryable(): void {
+		Functions\when( 'is_wp_error' )->justReturn( true );
+
+		$process = $this->get_process();
+		$size    = 'full' . ProcessStub::AVIF_SUFFIX;
+
+		$process->update_size_optimization_data(
+			new WP_Error( 'http_error', 'cURL error 28: Operation timed out' ),
+			$size,
+			1
+		);
+
+		$this->assertArrayHasKey( $size, $this->stored );
+		$this->assertFalse( $this->stored[ $size ]['success'] );
+		$this->assertArrayNotHasKey( 'permanent_error', $this->stored[ $size ] );
+		$this->assertSame( 'error', $this->stored[ $size ]['status'] );
+	}
+
+	/**
+	 * Test: a successful next-gen conversion is still stored as a success under the suffixed key.
+	 */
+	public function testStoresSuccessfulNextGenConversionUnchanged(): void {
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$process = $this->get_process();
+		$size    = 'full' . ProcessStub::AVIF_SUFFIX;
+
+		$process->update_size_optimization_data(
+			(object) [
+				'original_size' => 1000,
+				'new_size'      => 400,
+			],
+			$size,
+			1
+		);
+
+		$this->assertArrayHasKey( $size, $this->stored );
+		$this->assertTrue( $this->stored[ $size ]['success'] );
+		$this->assertArrayNotHasKey( 'permanent_error', $this->stored[ $size ] );
+		$this->assertSame( 400, $this->stored[ $size ]['optimized_size'] );
+	}
+}
+
+/**
+ * Concrete process with a constructor that does not touch the filesystem.
+ */
+class ProcessStub extends AbstractProcess {
+
+	/**
+	 * The constructor.
+	 *
+	 * @param DataInterface $data   The data instance.
+	 * @param string        $format The current next-gen format suffix.
+	 */
+	public function __construct( $data, $format ) {
+		$this->data   = $data;
+		$this->format = $format;
+	}
+
+	/**
+	 * Not used by these tests.
+	 *
+	 * @return array
+	 */
+	public function get_missing_sizes() {
+		return [];
+	}
+
+	/**
+	 * Not used by these tests.
+	 *
+	 * @return bool
+	 */
+	public function optimize_missing_thumbnails() {
+		return true;
+	}
+}

--- a/classes/Bulk/CustomFolders.php
+++ b/classes/Bulk/CustomFolders.php
@@ -185,8 +185,18 @@ class CustomFolders extends AbstractBulk {
 				fi.mime_type IN ( $mime_types )
 				AND ( fi.status = 'success' OR fi.status = 'already_optimized' )
 				AND ( fi.data NOT LIKE %s OR fi.data IS NULL )
+				AND ( fi.data NOT LIKE %s OR fi.data IS NULL )
 			ORDER BY fi.file_id DESC",
-				'%' . $wpdb->esc_like( $nextgen_suffix . '";a:4:{s:7:"success";b:1;' ) . '%'
+				'%' . $wpdb->esc_like( $nextgen_suffix . '";a:4:{s:7:"success";b:1;' ) . '%',
+				/**
+				 * Second predicate: skip files the API permanently refused to convert (the next-gen file
+				 * would be heavier than the original, or the file is already compressed). Those are stored
+				 * as `<size><suffix>";a:3:{s:15:"permanent_error";b:1;s:7:"success";b:0;s:5:"error";…`.
+				 * Transient failures serialize as a 2-element array without the `permanent_error` key, so
+				 * they keep being retried. Matching serialized data with LIKE is fragile: the key order
+				 * written in Optimization\Data\CustomFolders must not change.
+				 */
+				'%' . $wpdb->esc_like( $nextgen_suffix . '";a:3:{s:15:"permanent_error";b:1;' ) . '%'
 			)
 		);
 

--- a/classes/Bulk/WP.php
+++ b/classes/Bulk/WP.php
@@ -316,12 +316,22 @@ class WP extends AbstractBulk {
 				p.post_mime_type IN ( $mime_types )
 				AND (mt1.meta_key IS NULL OR mt1.meta_value = 'success' OR mt1.meta_value = 'already_optimized' )
 				AND mt2.meta_value NOT LIKE %s
+				AND mt2.meta_value NOT LIKE %s
 				AND p.post_type = 'attachment'
 				AND p.post_status IN ( $statuses )
 				$nodata_where
 			ORDER BY p.ID DESC
 			LIMIT 0, %d",
 				'%' . $wpdb->esc_like( $nextgen_suffix . '";a:4:{s:7:"success";b:1;' ) . '%',
+				/**
+				 * Second predicate: skip media the API permanently refused to convert (the next-gen file
+				 * would be heavier than the original, or the file is already compressed). Those are stored
+				 * as `<size><suffix>";a:3:{s:15:"permanent_error";b:1;s:7:"success";b:0;s:5:"error";…`.
+				 * Transient failures (network, quota, timeout) serialize as a 2-element array without the
+				 * `permanent_error` key, so they keep being retried. Matching serialized data with LIKE is
+				 * fragile: the key order written in Optimization\Data\WP must not change.
+				 */
+				'%' . $wpdb->esc_like( $nextgen_suffix . '";a:3:{s:15:"permanent_error";b:1;' ) . '%',
 				imagify_get_unoptimized_attachment_limit()
 			)
 		);

--- a/classes/Optimization/Data/CustomFolders.php
+++ b/classes/Optimization/Data/CustomFolders.php
@@ -194,10 +194,21 @@ class CustomFolders extends AbstractData {
 				/**
 				 * Error.
 				 */
-				$old_data['data']['sizes'][ $size ] = [
+				$size_data = [
 					'success' => false,
 					'error'   => $data['error'],
 				];
+
+				if ( ! empty( $data['permanent_error'] ) ) {
+					/**
+					 * `permanent_error` is written as the FIRST key on purpose: the bulk queries match the
+					 * serialized data with a LIKE on the `<size>";a:3:{s:15:"permanent_error";b:1;` prefix,
+					 * which only stays deterministic if the key order does.
+					 */
+					$size_data = array_merge( [ 'permanent_error' => true ], $size_data );
+				}
+
+				$old_data['data']['sizes'][ $size ] = $size_data;
 			} else {
 				/**
 				 * Success.

--- a/classes/Optimization/Data/WP.php
+++ b/classes/Optimization/Data/WP.php
@@ -105,10 +105,21 @@ class WP extends AbstractData {
 			/**
 			 * Error.
 			 */
-			$old_data['sizes'][ $size ] = [
+			$size_data = [
 				'success' => false,
 				'error'   => $data['error'],
 			];
+
+			if ( ! empty( $data['permanent_error'] ) ) {
+				/**
+				 * `permanent_error` is written as the FIRST key on purpose: the bulk queries match the
+				 * serialized meta value with a LIKE on the `<size>";a:3:{s:15:"permanent_error";b:1;`
+				 * prefix, which only stays deterministic if the key order does.
+				 */
+				$size_data = array_merge( [ 'permanent_error' => true ], $size_data );
+			}
+
+			$old_data['sizes'][ $size ] = $size_data;
 		} else {
 			/**
 			 * Success.

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -1971,12 +1971,44 @@ abstract class AbstractProcess implements ProcessInterface {
 		$data = (array) apply_filters( "imagify{$_unauthorized}_file_optimization_data", $data, $response, $size, $level, $this->get_data() );
 
 		if ( property_exists( $response, 'message' ) ) {
-			$size = str_replace( $this->format, '', $size );
+			if ( $this->is_next_gen_size( $size ) ) {
+				/**
+				 * The API answered with a 200 and a message instead of a converted file: it declined the
+				 * conversion (the next-gen version would be heavier than the original, or the file is
+				 * already compressed). This is a permanent refusal, not a transient failure, so we store a
+				 * terminal entry under the next-gen size name. The suffix is kept, otherwise the entry would
+				 * overwrite the base size record and the media would be picked up again on every bulk run.
+				 */
+				$data['success']         = false;
+				$data['error']           = $data['message'];
+				$data['permanent_error'] = true;
+			} else {
+				$size = str_replace( $this->format, '', $size );
+			}
 		}
 		// Store.
 		$this->get_data()->update_size_optimization_data( $size, $data );
 
 		return $data;
+	}
+
+	/**
+	 * Tell if a size name refers to a next-gen (AVIF or WebP) version.
+	 *
+	 * @param string $size The size name.
+	 *
+	 * @return bool
+	 */
+	private function is_next_gen_size( $size ) {
+		$size = (string) $size;
+
+		foreach ( [ static::AVIF_SUFFIX, static::WEBP_SUFFIX ] as $suffix ) {
+			if ( '' !== $suffix && substr( $size, - strlen( $suffix ) ) === $suffix ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/inc/3rd-party/nextgen-gallery/classes/Bulk/NGG.php
+++ b/inc/3rd-party/nextgen-gallery/classes/Bulk/NGG.php
@@ -170,8 +170,18 @@ class NGG extends AbstractBulk {
 				WHERE
 					( data.status = 'success' OR data.status = 'already_optimized' )
 					AND data.data NOT LIKE %s
+					AND data.data NOT LIKE %s
 				ORDER BY ngg.pid DESC",
-				'%' . $wpdb->esc_like( $suffix . '";a:4:{s:7:"success";b:1;' ) . '%'
+				'%' . $wpdb->esc_like( $suffix . '";a:4:{s:7:"success";b:1;' ) . '%',
+				/**
+				 * Second predicate: skip images the API permanently refused to convert (the next-gen file
+				 * would be heavier than the original, or the file is already compressed). Those are stored
+				 * as `<size><suffix>";a:3:{s:15:"permanent_error";b:1;s:7:"success";b:0;s:5:"error";…`.
+				 * Transient failures serialize as a 2-element array without the `permanent_error` key, so
+				 * they keep being retried. Matching serialized data with LIKE is fragile: the key order
+				 * written in Imagify\NGG\Optimization\Data\NGG must not change.
+				 */
+				'%' . $wpdb->esc_like( $suffix . '";a:3:{s:15:"permanent_error";b:1;' ) . '%'
 			)
 		);
 

--- a/inc/3rd-party/nextgen-gallery/classes/Optimization/Data/NGG.php
+++ b/inc/3rd-party/nextgen-gallery/classes/Optimization/Data/NGG.php
@@ -157,10 +157,21 @@ class NGG extends \Imagify\Optimization\Data\AbstractData {
 			/**
 			 * Error.
 			 */
-			$old_data['data']['sizes'][ $size ] = [
+			$size_data = [
 				'success' => false,
 				'error'   => $data['error'],
 			];
+
+			if ( ! empty( $data['permanent_error'] ) ) {
+				/**
+				 * `permanent_error` is written as the FIRST key on purpose: the bulk query matches the
+				 * serialized data with a LIKE on the `<size>";a:3:{s:15:"permanent_error";b:1;` prefix,
+				 * which only stays deterministic if the key order does.
+				 */
+				$size_data = array_merge( [ 'permanent_error' => true ], $size_data );
+			}
+
+			$old_data['data']['sizes'][ $size ] = $size_data;
 		} else {
 			/**
 			 * Success.

--- a/inc/functions/admin-ui.php
+++ b/inc/functions/admin-ui.php
@@ -101,6 +101,22 @@ function get_imagify_attachment_optimization_text( $process ) {
 		}
 		$output .= $output_before . '<span class="data">' . __( 'Next-Gen generated:', 'imagify' ) . '</span> <strong class="big">' . esc_html( $has_nextgen ) . '</strong>' . $output_after;
 
+		// When the API permanently refused the conversion, show the reason it gave.
+		$nextgen_reason = '';
+
+		if ( ! empty( $optimized_data['sizes'] ) && is_array( $optimized_data['sizes'] ) ) {
+			foreach ( $optimized_data['sizes'] as $size_data ) {
+				if ( ! empty( $size_data['permanent_error'] ) && ! empty( $size_data['error'] ) ) {
+					$nextgen_reason = $size_data['error'];
+					break;
+				}
+			}
+		}
+
+		if ( $nextgen_reason ) {
+			$output .= $output_before . '<span class="data">' . __( 'Next-Gen status:', 'imagify' ) . '</span> <strong>' . esc_html( $nextgen_reason ) . '</strong>' . $output_after;
+		}
+
 		$total_optimized_thumbnails = $data->get_optimized_sizes_count();
 
 		if ( $total_optimized_thumbnails ) {

--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -223,6 +223,13 @@ function imagify_translate_api_message( $message ) {
 		),
 		'Your image is too big to be uploaded on our server' => __( 'Your file is too big to be uploaded on our server.', 'imagify' ),
 		'Webp is less performant than original'         => __( 'WebP file is larger than the original image', 'imagify' ),
+
+		/*
+		 * The AVIF wording below has not been confirmed against a live API response: it mirrors the WebP
+		 * pattern. Both casings are mapped so the message is translated whichever one the API returns.
+		 */
+		'Avif is less performant than original'         => __( 'AVIF file is larger than the original image', 'imagify' ),
+		'AVIF is less performant than original'         => __( 'AVIF file is larger than the original image', 'imagify' ),
 		'Our server returned an invalid response'       => __( 'Our server returned an invalid response.', 'imagify' ),
 		'cURL isn\'t installed on the server'           => __( 'cURL is not available on the server.', 'imagify' ),
 		// API messages.

--- a/readme.txt
+++ b/readme.txt
@@ -327,6 +327,9 @@ You can report any security bugs found in the source code of the site-reviews pl
 4. Other Media Page
 
 == Changelog ==
+= 2.3.1 =
+- Bugfix: The "Generate missing next-gen versions" tool no longer runs indefinitely when a WebP or AVIF version would be heavier than the optimized image.
+
 = 2.3.0 =
 - New feature: Added support for the Model Context Protocol (MCP), enabling compatible AI assistants to optimize images and manage Imagify through natural language.
 - Enhancement: Improved validation to ensure only supported image files can be optimized through MCP.


### PR DESCRIPTION
# Description

Fixes #1011

"Generate missing next-gen versions" never finishes when a WebP or AVIF version would be heavier than the optimized image. Affected media stay in the "missing next-gen versions" count forever, the progress bar never reaches the end, and every run re-uploads those files to the API — spending credits on conversions that cannot succeed. Users read this as a broken tool and open support tickets.

After this PR the tool completes, those media are no longer counted as missing, and the media library shows the reason the API gave instead of silently skipping them.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

**Automated — unit (`composer test-unit`), all passing:**

Baseline on `develop` was 345 tests / 798 assertions / 17 risky. With this branch: **350 tests / 814 assertions / 17 risky, 0 failures.** The delta is exactly the 5 new tests; the 17 risky are pre-existing `ReflectionProperty::setValue()` deprecation warnings, identical on both branches.

New file `Tests/Unit/classes/Optimization/Process/AbstractProcess/update_size_optimization_data.php`:

| Test | What it pins |
|---|---|
| `testStoresPermanentErrorUnderSuffixedKeyForNextGenSize` | Refused conversion is stored under `full@imagify-avif`, `success => false`, flagged |
| `testDoesNotOverwriteBaseSizeWhenNextGenIsRefused` | The base size's optimization record is left alone |
| `testKeepsPreviousBehaviourForNonNextGenSize` | Plain sizes carrying a message behave exactly as before |
| `testKeepsTransientNextGenErrorRetryable` | A `WP_Error` failure is stored **without** the flag, so it is still retried |
| `testStoresSuccessfulNextGenConversionUnchanged` | A normal successful conversion is untouched |

The fourth is the important one — it pins the distinction the queries rely on to decide what may be retried.

**Automated — serialization check.** The stored shape and the SQL predicate were verified against real `serialize()` output:

```
permanent: a:1:{s:17:"full@imagify-avif";a:3:{s:15:"permanent_error";b:1;s:7:"success";b:0;s:5:"error";s:43:"…";}}  → matched by the predicate
transient: a:1:{s:17:"full@imagify-avif";a:2:{s:7:"success";b:0;s:5:"error";s:10:"cURL error";}}                    → not matched, stays retryable
```

**Lint / static analysis.** `vendor/bin/phpcs` on all 9 changed production files → 0 violations. `composer run-stan` → 2 errors, both pre-existing in `classes/Media/WP.php:214` and both present on `develop`; **no new errors**.

**Not run — integration.** `Tests/Integration/classes/Bulk/WP/GetOptimizedMediaIdsWithoutFormatTest.php` covers the query-level exclusion but could not be executed here (no WordPress test installation configured). **It needs a CI run before this is considered verified.**

**Not run — manual reproduction.** The end-to-end scenario from the issue was not reproduced against a live Imagify API. See "Unticked items justification".

### How to test

1. Enable Lossless compression and the AVIF format in Imagify settings.
2. Upload the small example images attached to #1011 and let them auto-optimize.
3. In the Media Library, confirm the message saying the next-gen version is larger than the original, and that a **"Next-Gen status:"** line now shows that reason.
4. Go to Imagify settings and click **"Generate missing next-gen versions"**.
5. **Expected:** the process completes instead of hanging, and those images are no longer counted as missing.
6. Repeat the click and confirm from your Imagify account that no further credits are consumed for those images.
7. **Regression:** on media where next-gen conversion succeeds normally, confirm the files are still generated and the counts still drop to zero as before.
8. **Regression (retry path):** simulate a transient failure (block outgoing HTTP, or exhaust quota) on a convertible image, restore normal conditions, and confirm the image is picked up again on the next run — it must **not** be permanently skipped.

Step 8 is the one most worth QA attention: it is the behaviour that separates this fix from simply hiding failures.

### Affected Features & Quality Assurance Scope

- **"Generate missing next-gen versions" bulk tool** — the reported symptom.
- **Missing next-gen counts everywhere** — a single query feeds the settings AJAX tool, the settings-save hook, the WP-CLI `generate-missing-nextgen` command, the `GenerateMissingNextgen` and `GetNextgenCoverage` abilities, and the Imagifybeat progress poll. All six change behaviour together.
- **Media library optimization details** — a new "Next-Gen status:" line.
- **Custom folders and NextGEN Gallery** — each has its own data writer and query; both were updated in step with the media library context.
- **Optimization data written per size** — the base size record is no longer overwritten by a refused next-gen attempt, so displayed per-size figures change for affected media.

## Technical description

### Documentation

The API answers a refused conversion with **HTTP 200 and a `message`**, not an error. `AbstractProcess::update_size_optimization_data()` therefore took its success branch, and then stripped the next-gen suffix from the size name:

```php
if ( property_exists( $response, 'message' ) ) {
	$size = str_replace( $this->format, '', $size );
}
```

So `full@imagify-avif` was written as `full`. No next-gen entry ever existed, and the base size's genuine optimization record was overwritten by the refused attempt's figures.

The bulk queries exclude a media only when its data contains a *successful* next-gen entry (`<suffix>";a:4:{s:7:"success";b:1;`). With no entry at all, affected media were re-selected on every run. Imagifybeat reports that same query re-executed as "remaining", and the JS stops only at `remaining === 0` — so the bar could never complete, and each pass re-uploaded the files.

The fix keeps the suffix and records a terminal entry under the next-gen size name:

```php
if ( $this->is_next_gen_size( $size ) ) {
	$data['success']         = false;
	$data['error']           = $data['message'];
	$data['permanent_error'] = true;
} else {
	$size = str_replace( $this->format, '', $size );
}
```

Non-next-gen sizes are untouched — a plain `full` size legitimately carries "already compressed" messages today.

**Why a flag rather than just `success => false`.** Transient failures (network, timeout, quota) already write `success => false` under the suffixed key and are correctly retried. Marking permanent refusals identically would strand an image forever after a single API blip. The flag is written as the **first** key of the size entry so the serialized value has a deterministic prefix; with `success`/`error` first, the variable-length error string sits in the middle and cannot be matched. The queries then add:

```php
'%' . $wpdb->esc_like( $nextgen_suffix . '";a:3:{s:15:"permanent_error";b:1;' ) . '%'
```

Matching serialized data with `LIKE` is fragile, and the code says so in a comment at both the write and read sites: the key order must not change. This follows the pattern already used by the existing predicate rather than introducing a new meta key, which would have required a migration on every install plus parallel handling in the custom-folders table.

**No backfill migration**, deliberately. The database never recorded *why* a next-gen version was missing, so a migration would have to guess, and guessing wrong permanently strands images that would convert successfully. The marker is written on the next attempt instead: self-healing, and it bounds the wasted credits at one further pass per image.

### New dependencies

None.

### Risks

**Retry behaviour is the main risk.** If the permanent/transient distinction were wrong, images would be skipped forever. This is covered by `testKeepsTransientNextGenErrorRetryable` and by the serialization check above, and is called out as step 8 of "How to test".

**Serialized `LIKE` matching is fragile.** Changing the key order in the data writers silently breaks the exclusion. Commented at all four sites. The pre-existing predicate has the same property.

**Per-size figures change for affected media.** Because the base size record is no longer overwritten, media previously showing the refused attempt's numbers will show their genuine optimization data. This is a correction, but it is a visible change.

**Performance:** one additional `NOT LIKE` on an already-`LIKE`-filtered query. No new joins, no new meta reads. Net positive in practice, since affected media stop being re-uploaded on every run.

**Security:** none. No new input, output, or capability surface. The added predicate is built with `esc_like()` and `prepare()` like the existing one; the displayed reason is escaped with `esc_html()`.

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

**"I validated all the Acceptance Criteria"** is unticked because the end-to-end scenario from the issue was not reproduced against a live Imagify API, and the integration test covering the query-level exclusion could not be executed (no WordPress test installation in this environment). The unit tests and the serialization check establish the logic; they do not establish the live behaviour. Both gaps are QA gates, listed under "How to test".

Two further items need confirmation and are flagged rather than assumed:

1. **The AVIF message wording is unverified.** Only the WebP string was mapped, so AVIF users saw the raw untranslated API string. Two casings are mapped following the WebP pattern, with a comment recording that the exact wording was not confirmed against a live response. If the API returns different wording, the message falls through untranslated — the same behaviour as today, so this is not a regression, but it should be confirmed.
2. **`$data['status']` is left as `'success'`** on the refusal path even though `success` is now `false`. Changing it risks affecting the top-level `_imagify_status` meta and the existing "Convert:" message display, which is beyond the scope of this fix. Worth a reviewer's opinion.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
  - The stored `permanent_error` flag and its reason are readable in `_imagify_data` and surfaced in the media library, so an affected media can be diagnosed without reproducing the API call.
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
  - This PR is itself the error-handling path for a refused API conversion.
