### PR TITLE
Refs #1011: stop reporting a next-gen version when none was generated

### DIFF
--- a/Tests/Integration/classes/Bulk/WP/GetOptimizedMediaIdsWithoutFormatTest.php
+++ b/Tests/Integration/classes/Bulk/WP/GetOptimizedMediaIdsWithoutFormatTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Imagify\Tests\Integration\classes\Bulk\WP;
+
+use Imagify\Bulk\WP as BulkWP;
+use Imagify\Tests\Integration\TestCase;
+
+/**
+ * Tests for \Imagify\Bulk\WP::get_optimized_media_ids_without_format().
+ *
+ * @covers \Imagify\Bulk\WP::get_optimized_media_ids_without_format
+ * @group  NextGenPermanentError
+ */
+class GetOptimizedMediaIdsWithoutFormatTest extends TestCase {
+	protected $useApi = false;
+
+	/**
+	 * Creates an optimized attachment carrying the given `_imagify_data` sizes.
+	 *
+	 * @param array $sizes The `sizes` sub-array of `_imagify_data`.
+	 *
+	 * @return int
+	 */
+	private function create_optimized_attachment( array $sizes ): int {
+		$attachment_id = $this->factory()->attachment->create_object(
+			[
+				'file'           => 'image.jpg',
+				'post_mime_type' => 'image/jpeg',
+				'post_status'    => 'inherit',
+			]
+		);
+
+		update_post_meta( $attachment_id, '_wp_attached_file', 'image.jpg' );
+		update_post_meta( $attachment_id, '_wp_attachment_metadata', [ 'file' => 'image.jpg' ] );
+		update_post_meta( $attachment_id, '_imagify_status', 'success' );
+		update_post_meta(
+			$attachment_id,
+			'_imagify_data',
+			[
+				'sizes' => $sizes,
+			]
+		);
+
+		return $attachment_id;
+	}
+
+	/**
+	 * Test: a media whose AVIF conversion was permanently refused is not returned any more.
+	 */
+	public function testExcludesMediaWithPermanentNextGenError() {
+		$attachment_id = $this->create_optimized_attachment(
+			[
+				'full'               => [
+					'success'        => true,
+					'original_size'  => 1000,
+					'optimized_size' => 800,
+					'percent'        => 20.0,
+				],
+				'full@imagify-avif' => [
+					'permanent_error' => true,
+					'success'         => false,
+					'error'           => 'AVIF file is larger than the original image',
+				],
+			]
+		);
+
+		$result = ( new BulkWP() )->get_optimized_media_ids_without_format( 'avif' );
+
+		$this->assertNotContains( $attachment_id, $result['ids'] );
+	}
+
+	/**
+	 * Test: a media whose AVIF conversion failed transiently is still returned, so it gets retried.
+	 */
+	public function testKeepsMediaWithTransientNextGenError() {
+		$attachment_id = $this->create_optimized_attachment(
+			[
+				'full'               => [
+					'success'        => true,
+					'original_size'  => 1000,
+					'optimized_size' => 800,
+					'percent'        => 20.0,
+				],
+				'full@imagify-avif' => [
+					'success' => false,
+					'error'   => 'cURL error 28: Operation timed out',
+				],
+			]
+		);
+
+		$result = ( new BulkWP() )->get_optimized_media_ids_without_format( 'avif' );
+
+		$this->assertContains( $attachment_id, $result['ids'] );
+	}
+}

--- a/Tests/Integration/classes/Bulk/WP/GetOptimizedMediaIdsWithoutFormatTest.php
+++ b/Tests/Integration/classes/Bulk/WP/GetOptimizedMediaIdsWithoutFormatTest.php
@@ -12,26 +12,69 @@ use Imagify\Tests\Integration\TestCase;
  * @group  NextGenPermanentError
  */
 class GetOptimizedMediaIdsWithoutFormatTest extends TestCase {
-	protected $useApi = false;
+	protected $useApi = false; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+
+	/**
+	 * Absolute paths created by the fixtures, removed in tear_down().
+	 *
+	 * @var array
+	 */
+	protected $created_files = [];
+
+	/**
+	 * Cleans up the files created by the fixtures.
+	 */
+	public function tear_down() {
+		foreach ( $this->created_files as $path ) {
+			if ( file_exists( $path ) ) {
+				unlink( $path );
+			}
+		}
+
+		$this->created_files = [];
+
+		parent::tear_down();
+	}
 
 	/**
 	 * Creates an optimized attachment carrying the given `_imagify_data` sizes.
+	 *
+	 * The media file and its backup are really written to disk: the query filters its results
+	 * against the filesystem after the SQL runs, and drops any media whose file or backup is
+	 * missing. Without both files the media never reaches the result set and the test would
+	 * pass whatever the SQL does.
 	 *
 	 * @param array $sizes The `sizes` sub-array of `_imagify_data`.
 	 *
 	 * @return int
 	 */
-	private function create_optimized_attachment( array $sizes ): int {
+	private function create_optimized_attachment( array $sizes ) {
+		$uploads   = wp_upload_dir();
+		$filename  = 'imagify-nextgen-' . uniqid() . '.jpg';
+		$file_path = trailingslashit( $uploads['basedir'] ) . $filename;
+
+		wp_mkdir_p( dirname( $file_path ) );
+		file_put_contents( $file_path, 'not-a-real-jpeg' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+		$this->created_files[] = $file_path;
+
+		$backup_path = get_imagify_attachment_backup_path( $file_path );
+
+		wp_mkdir_p( dirname( $backup_path ) );
+		file_put_contents( $backup_path, 'not-a-real-jpeg' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+		$this->created_files[] = $backup_path;
+
 		$attachment_id = $this->factory()->attachment->create_object(
 			[
-				'file'           => 'image.jpg',
+				'file'           => $filename,
 				'post_mime_type' => 'image/jpeg',
 				'post_status'    => 'inherit',
 			]
 		);
 
-		update_post_meta( $attachment_id, '_wp_attached_file', 'image.jpg' );
-		update_post_meta( $attachment_id, '_wp_attachment_metadata', [ 'file' => 'image.jpg' ] );
+		update_post_meta( $attachment_id, '_wp_attached_file', $filename );
+		update_post_meta( $attachment_id, '_wp_attachment_metadata', [ 'file' => $filename ] );
 		update_post_meta( $attachment_id, '_imagify_status', 'success' );
 		update_post_meta(
 			$attachment_id,
@@ -45,17 +88,42 @@ class GetOptimizedMediaIdsWithoutFormatTest extends TestCase {
 	}
 
 	/**
-	 * Test: a media whose AVIF conversion was permanently refused is not returned any more.
+	 * The optimization data of a size that was optimized normally.
+	 *
+	 * @return array
+	 */
+	private function get_successful_size_data() {
+		return [
+			'success'        => true,
+			'original_size'  => 1000,
+			'optimized_size' => 800,
+			'percent'        => 20.0,
+		];
+	}
+
+	/**
+	 * Guard: a media with no next-gen entry at all is returned, so the fixtures really do reach
+	 * the result set. Without this, the exclusion test below could pass for the wrong reason.
+	 */
+	public function testReturnsMediaWithoutAnyNextGenEntry() {
+		$attachment_id = $this->create_optimized_attachment(
+			[
+				'full' => $this->get_successful_size_data(),
+			]
+		);
+
+		$result = ( new BulkWP() )->get_optimized_media_ids_without_format( 'avif' );
+
+		$this->assertContains( $attachment_id, $result['ids'] );
+	}
+
+	/**
+	 * A media whose AVIF conversion was permanently refused is not returned any more.
 	 */
 	public function testExcludesMediaWithPermanentNextGenError() {
 		$attachment_id = $this->create_optimized_attachment(
 			[
-				'full'               => [
-					'success'        => true,
-					'original_size'  => 1000,
-					'optimized_size' => 800,
-					'percent'        => 20.0,
-				],
+				'full'              => $this->get_successful_size_data(),
 				'full@imagify-avif' => [
 					'permanent_error' => true,
 					'success'         => false,
@@ -70,17 +138,12 @@ class GetOptimizedMediaIdsWithoutFormatTest extends TestCase {
 	}
 
 	/**
-	 * Test: a media whose AVIF conversion failed transiently is still returned, so it gets retried.
+	 * A media whose AVIF conversion failed transiently is still returned, so it gets retried.
 	 */
 	public function testKeepsMediaWithTransientNextGenError() {
 		$attachment_id = $this->create_optimized_attachment(
 			[
-				'full'               => [
-					'success'        => true,
-					'original_size'  => 1000,
-					'optimized_size' => 800,
-					'percent'        => 20.0,
-				],
+				'full'              => $this->get_successful_size_data(),
 				'full@imagify-avif' => [
 					'success' => false,
 					'error'   => 'cURL error 28: Operation timed out',

--- a/Tests/Unit/bootstrap.php
+++ b/Tests/Unit/bootstrap.php
@@ -19,6 +19,7 @@ define( 'IMAGIFY_SLUG', 'imagify' );
  */
 function load_original_files_before_mocking() {
 	$originals = [
+		'inc/functions/admin-ui.php',
 		'inc/functions/api.php',
 		'inc/functions/attachments.php',
 		'inc/functions/common.php',

--- a/Tests/Unit/classes/Optimization/Data/CustomFolders/update_size_optimization_data.php
+++ b/Tests/Unit/classes/Optimization/Data/CustomFolders/update_size_optimization_data.php
@@ -1,0 +1,209 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Optimization\Data\CustomFolders;
+
+use Imagify\Media\MediaInterface;
+use Imagify\Optimization\Data\CustomFolders;
+use Imagify\Tests\Unit\TestCase;
+use Mockery;
+
+/**
+ * Tests for \Imagify\Optimization\Data\CustomFolders::update_size_optimization_data().
+ *
+ * @covers \Imagify\Optimization\Data\CustomFolders::update_size_optimization_data
+ * @group  NextGenPermanentError
+ */
+class Test_UpdateSizeOptimizationData extends TestCase {
+
+	/**
+	 * Builds a data instance bound to a valid media.
+	 *
+	 * @param array $row The row the instance reads before writing.
+	 *
+	 * @return CustomFoldersDataStub
+	 */
+	private function get_data_instance( array $row = [] ): CustomFoldersDataStub {
+		$media = Mockery::mock( MediaInterface::class );
+
+		$media->shouldReceive( 'is_valid' )->andReturn( true );
+
+		return new CustomFoldersDataStub( $media, $row );
+	}
+
+	/**
+	 * Test: a permanent error is stored with `permanent_error` as the very first key.
+	 */
+	public function testShouldStorePermanentErrorAsFirstKey() {
+		$data = $this->get_data_instance();
+
+		$data->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success'         => false,
+				'error'           => 'AVIF file is larger than the original image',
+				'permanent_error' => true,
+			]
+		);
+
+		$size_data = $data->updated['data']['sizes']['full@imagify-avif'];
+
+		$this->assertSame( [ 'permanent_error', 'success', 'error' ], array_keys( $size_data ) );
+		$this->assertTrue( $size_data['permanent_error'] );
+		$this->assertFalse( $size_data['success'] );
+		$this->assertSame( 'AVIF file is larger than the original image', $size_data['error'] );
+	}
+
+	/**
+	 * Test: the serialized entry starts with the prefix the bulk queries match on.
+	 */
+	public function testShouldSerializePermanentErrorWithThePrefixTheBulkQueriesMatch() {
+		$data = $this->get_data_instance();
+
+		$data->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success'         => false,
+				'error'           => 'AVIF file is larger than the original image',
+				'permanent_error' => true,
+			]
+		);
+
+		$this->assertStringContainsString(
+			'full@imagify-avif";a:3:{s:15:"permanent_error";b:1;',
+			serialize( $data->updated['data']['sizes'] ) // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		);
+	}
+
+	/**
+	 * Test: a transient error is stored without the flag, so the file keeps being retried.
+	 */
+	public function testShouldStoreTransientErrorWithoutTheFlag() {
+		$data = $this->get_data_instance();
+
+		$data->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success' => false,
+				'error'   => 'cURL error 28: Operation timed out',
+			]
+		);
+
+		$this->assertSame(
+			[ 'success', 'error' ],
+			array_keys( $data->updated['data']['sizes']['full@imagify-avif'] )
+		);
+	}
+
+	/**
+	 * Test: previously stored sizes are preserved when a permanent error is added.
+	 */
+	public function testShouldPreserveOtherSizesWhenStoringAPermanentError() {
+		$data = $this->get_data_instance(
+			[
+				'data' => [
+					'sizes' => [
+						'thumbnail' => [
+							'success'        => true,
+							'original_size'  => 1000,
+							'optimized_size' => 800,
+							'percent'        => 20,
+						],
+					],
+				],
+			]
+		);
+
+		$data->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success'         => false,
+				'error'           => 'AVIF file is larger than the original image',
+				'permanent_error' => true,
+			]
+		);
+
+		$this->assertTrue( $data->updated['data']['sizes']['thumbnail']['success'] );
+		$this->assertTrue( $data->updated['data']['sizes']['full@imagify-avif']['permanent_error'] );
+	}
+
+	/**
+	 * Test: nothing is written when the media is not valid.
+	 */
+	public function testShouldWriteNothingWhenMediaIsNotValid() {
+		$media = Mockery::mock( MediaInterface::class );
+
+		$media->shouldReceive( 'is_valid' )->andReturn( false );
+
+		$data = new CustomFoldersDataStub( $media, [] );
+
+		$data->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success'         => false,
+				'error'           => 'AVIF file is larger than the original image',
+				'permanent_error' => true,
+			]
+		);
+
+		$this->assertNull( $data->updated );
+	}
+}
+
+/**
+ * Data class with an in-memory row instead of a database row.
+ */
+class CustomFoldersDataStub extends CustomFolders {
+
+	/**
+	 * The data passed to update_row().
+	 *
+	 * @var array|null
+	 */
+	public $updated;
+
+	/**
+	 * The row to return from get_row().
+	 *
+	 * @var array
+	 */
+	private $stub_row;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param MediaInterface $media The media instance.
+	 * @param array          $row   The row to return from get_row().
+	 */
+	public function __construct( $media, array $row ) {
+		$this->media = $media;
+		$this->stub_row   = $row;
+	}
+
+	/**
+	 * Returns the in-memory row.
+	 *
+	 * @return array
+	 */
+	public function get_row() {
+		return $this->stub_row;
+	}
+
+	/**
+	 * Returns empty defaults: the database columns are irrelevant here.
+	 *
+	 * @return array
+	 */
+	protected function get_reset_data() {
+		return [];
+	}
+
+	/**
+	 * Records what would have been written to the database.
+	 *
+	 * @param array $data The data to update.
+	 */
+	public function update_row( $data ) {
+		$this->updated = $data;
+	}
+}

--- a/Tests/Unit/classes/Optimization/Data/WP/update_size_optimization_data.php
+++ b/Tests/Unit/classes/Optimization/Data/WP/update_size_optimization_data.php
@@ -1,0 +1,213 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Optimization\Data\WP;
+
+use Brain\Monkey\Functions;
+use Imagify\Media\MediaInterface;
+use Imagify\Optimization\Data\WP;
+use Imagify\Tests\Unit\TestCase;
+use Mockery;
+
+/**
+ * Tests for \Imagify\Optimization\Data\WP::update_size_optimization_data().
+ *
+ * @covers \Imagify\Optimization\Data\WP::update_size_optimization_data
+ * @group  NextGenPermanentError
+ */
+class Test_UpdateSizeOptimizationData extends TestCase {
+
+	/**
+	 * The `_imagify_data` meta value the class last stored.
+	 *
+	 * @var array
+	 */
+	private $stored = [];
+
+	/**
+	 * The `_imagify_data` meta value the class reads before writing.
+	 *
+	 * @var mixed
+	 */
+	private $existing = [];
+
+	/**
+	 * Sets up the post meta stubs.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->stored   = [];
+		$this->existing = [];
+
+		Functions\when( 'get_post_meta' )->alias(
+			function ( $id, $key ) {
+				return '_imagify_data' === $key ? $this->existing : '';
+			}
+		);
+
+		Functions\when( 'update_post_meta' )->alias(
+			function ( $id, $key, $value ) {
+				if ( '_imagify_data' === $key ) {
+					$this->stored = $value;
+				}
+
+				return true;
+			}
+		);
+	}
+
+	/**
+	 * Builds a data instance bound to a valid media.
+	 *
+	 * @return WP
+	 */
+	private function get_data_instance(): WP {
+		$media = Mockery::mock( MediaInterface::class );
+
+		$media->shouldReceive( 'is_valid' )->andReturn( true );
+		$media->shouldReceive( 'get_id' )->andReturn( 13 );
+
+		return new DataStub( $media );
+	}
+
+	/**
+	 * Test: a permanent error is stored with `permanent_error` as the very first key.
+	 */
+	public function testShouldStorePermanentErrorAsFirstKey() {
+		$this->get_data_instance()->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success'         => false,
+				'error'           => 'AVIF file is larger than the original image',
+				'permanent_error' => true,
+			]
+		);
+
+		$size_data = $this->stored['sizes']['full@imagify-avif'];
+
+		$this->assertSame( [ 'permanent_error', 'success', 'error' ], array_keys( $size_data ) );
+		$this->assertTrue( $size_data['permanent_error'] );
+		$this->assertFalse( $size_data['success'] );
+		$this->assertSame( 'AVIF file is larger than the original image', $size_data['error'] );
+	}
+
+	/**
+	 * Test: the serialized entry starts with the prefix the bulk queries match on.
+	 */
+	public function testShouldSerializePermanentErrorWithThePrefixTheBulkQueriesMatch() {
+		$this->get_data_instance()->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success'         => false,
+				'error'           => 'AVIF file is larger than the original image',
+				'permanent_error' => true,
+			]
+		);
+
+		$this->assertStringContainsString(
+			'full@imagify-avif";a:3:{s:15:"permanent_error";b:1;',
+			serialize( $this->stored['sizes'] ) // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		);
+	}
+
+	/**
+	 * Test: a transient error is stored without the flag, so the media keeps being retried.
+	 */
+	public function testShouldStoreTransientErrorWithoutTheFlag() {
+		$this->get_data_instance()->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success' => false,
+				'error'   => 'cURL error 28: Operation timed out',
+			]
+		);
+
+		$size_data = $this->stored['sizes']['full@imagify-avif'];
+
+		$this->assertSame( [ 'success', 'error' ], array_keys( $size_data ) );
+		$this->assertFalse( $size_data['success'] );
+		$this->assertSame( 'cURL error 28: Operation timed out', $size_data['error'] );
+	}
+
+	/**
+	 * Test: a falsy `permanent_error` value does not add the flag.
+	 */
+	public function testShouldNotAddTheFlagWhenPermanentErrorIsFalsy() {
+		$this->get_data_instance()->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success'         => false,
+				'error'           => 'cURL error 28: Operation timed out',
+				'permanent_error' => false,
+			]
+		);
+
+		$this->assertSame( [ 'success', 'error' ], array_keys( $this->stored['sizes']['full@imagify-avif'] ) );
+	}
+
+	/**
+	 * Test: previously stored sizes are preserved when a permanent error is added.
+	 */
+	public function testShouldPreserveOtherSizesWhenStoringAPermanentError() {
+		$this->existing = [
+			'sizes' => [
+				'full' => [
+					'success'        => true,
+					'original_size'  => 1000,
+					'optimized_size' => 800,
+					'percent'        => 20,
+				],
+			],
+		];
+
+		$this->get_data_instance()->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success'         => false,
+				'error'           => 'AVIF file is larger than the original image',
+				'permanent_error' => true,
+			]
+		);
+
+		$this->assertTrue( $this->stored['sizes']['full']['success'] );
+		$this->assertTrue( $this->stored['sizes']['full@imagify-avif']['permanent_error'] );
+	}
+
+	/**
+	 * Test: nothing is stored when the media is not valid.
+	 */
+	public function testShouldStoreNothingWhenMediaIsNotValid() {
+		$media = Mockery::mock( MediaInterface::class );
+
+		$media->shouldReceive( 'is_valid' )->andReturn( false );
+
+		( new DataStub( $media ) )->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success'         => false,
+				'error'           => 'AVIF file is larger than the original image',
+				'permanent_error' => true,
+			]
+		);
+
+		$this->assertSame( [], $this->stored );
+	}
+}
+
+/**
+ * Data class with a constructor that does not touch the filesystem.
+ */
+class DataStub extends WP {
+
+	/**
+	 * The constructor.
+	 *
+	 * @param MediaInterface $media The media instance.
+	 */
+	public function __construct( $media ) {
+		$this->media = $media;
+	}
+}

--- a/Tests/Unit/classes/Optimization/Process/AbstractProcess/update_size_optimization_data.php
+++ b/Tests/Unit/classes/Optimization/Process/AbstractProcess/update_size_optimization_data.php
@@ -1,0 +1,199 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Optimization\Process\AbstractProcess;
+
+use Brain\Monkey\Functions;
+use Imagify\Optimization\Data\DataInterface;
+use Imagify\Optimization\Process\AbstractProcess;
+use Imagify\Tests\Unit\TestCase;
+use Mockery;
+use WP_Error;
+
+/**
+ * Tests for \Imagify\Optimization\Process\AbstractProcess::update_size_optimization_data().
+ *
+ * @covers \Imagify\Optimization\Process\AbstractProcess::update_size_optimization_data
+ * @group  NextGenPermanentError
+ */
+class Test_UpdateSizeOptimizationData extends TestCase {
+
+	/**
+	 * Stores the arguments the data layer received.
+	 *
+	 * @var array
+	 */
+	private $stored = [];
+
+	/**
+	 * Sets up the common function stubs.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->stored = [];
+
+		Functions\when( 'imagify_translate_api_message' )->returnArg();
+	}
+
+	/**
+	 * Builds a process whose data layer records what it is asked to store.
+	 *
+	 * @return ProcessStub
+	 */
+	private function get_process(): ProcessStub {
+		$data = Mockery::mock( DataInterface::class );
+
+		$data->shouldReceive( 'update_size_optimization_data' )
+			->andReturnUsing(
+				function ( $size, $size_data ) {
+					$this->stored[ $size ] = $size_data;
+				}
+			);
+
+		return new ProcessStub( $data, ProcessStub::AVIF_SUFFIX );
+	}
+
+	/**
+	 * Test: a next-gen size refused by the API is stored under the suffixed key as a permanent error.
+	 */
+	public function testStoresPermanentErrorUnderSuffixedKeyForNextGenSize(): void {
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$process = $this->get_process();
+		$size    = 'full' . ProcessStub::AVIF_SUFFIX;
+
+		$process->update_size_optimization_data(
+			(object) [ 'message' => 'Avif is less performant than original' ],
+			$size,
+			1
+		);
+
+		$this->assertArrayHasKey( $size, $this->stored );
+		$this->assertFalse( $this->stored[ $size ]['success'] );
+		$this->assertTrue( $this->stored[ $size ]['permanent_error'] );
+		$this->assertSame( 'Avif is less performant than original', $this->stored[ $size ]['error'] );
+	}
+
+	/**
+	 * Test: the base size record is left untouched when a next-gen conversion is refused.
+	 */
+	public function testDoesNotOverwriteBaseSizeWhenNextGenIsRefused(): void {
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$process = $this->get_process();
+
+		$process->update_size_optimization_data(
+			(object) [ 'message' => 'Avif is less performant than original' ],
+			'full' . ProcessStub::AVIF_SUFFIX,
+			1
+		);
+
+		$this->assertArrayNotHasKey( 'full', $this->stored );
+	}
+
+	/**
+	 * Test: a regular size carrying a message keeps its previous behaviour (success, no flag).
+	 */
+	public function testKeepsPreviousBehaviourForNonNextGenSize(): void {
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$process = $this->get_process();
+
+		$process->update_size_optimization_data(
+			(object) [
+				'message'       => 'WELL DONE. This image is already compressed, no further compression required',
+				'original_size' => 100,
+				'new_size'      => 100,
+			],
+			'full',
+			1
+		);
+
+		$this->assertArrayHasKey( 'full', $this->stored );
+		$this->assertTrue( $this->stored['full']['success'] );
+		$this->assertArrayNotHasKey( 'permanent_error', $this->stored['full'] );
+	}
+
+	/**
+	 * Test: a transient next-gen failure is stored without the flag, so it stays retryable.
+	 */
+	public function testKeepsTransientNextGenErrorRetryable(): void {
+		Functions\when( 'is_wp_error' )->justReturn( true );
+
+		$process = $this->get_process();
+		$size    = 'full' . ProcessStub::AVIF_SUFFIX;
+
+		$process->update_size_optimization_data(
+			new WP_Error( 'http_error', 'cURL error 28: Operation timed out' ),
+			$size,
+			1
+		);
+
+		$this->assertArrayHasKey( $size, $this->stored );
+		$this->assertFalse( $this->stored[ $size ]['success'] );
+		$this->assertArrayNotHasKey( 'permanent_error', $this->stored[ $size ] );
+		$this->assertSame( 'error', $this->stored[ $size ]['status'] );
+	}
+
+	/**
+	 * Test: a successful next-gen conversion is still stored as a success under the suffixed key.
+	 */
+	public function testStoresSuccessfulNextGenConversionUnchanged(): void {
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$process = $this->get_process();
+		$size    = 'full' . ProcessStub::AVIF_SUFFIX;
+
+		$process->update_size_optimization_data(
+			(object) [
+				'original_size' => 1000,
+				'new_size'      => 400,
+			],
+			$size,
+			1
+		);
+
+		$this->assertArrayHasKey( $size, $this->stored );
+		$this->assertTrue( $this->stored[ $size ]['success'] );
+		$this->assertArrayNotHasKey( 'permanent_error', $this->stored[ $size ] );
+		$this->assertSame( 400, $this->stored[ $size ]['optimized_size'] );
+	}
+}
+
+/**
+ * Concrete process with a constructor that does not touch the filesystem.
+ */
+class ProcessStub extends AbstractProcess {
+
+	/**
+	 * The constructor.
+	 *
+	 * @param DataInterface $data   The data instance.
+	 * @param string        $format The current next-gen format suffix.
+	 */
+	public function __construct( $data, $format ) {
+		$this->data   = $data;
+		$this->format = $format;
+	}
+
+	/**
+	 * Not used by these tests.
+	 *
+	 * @return array
+	 */
+	public function get_missing_sizes() {
+		return [];
+	}
+
+	/**
+	 * Not used by these tests.
+	 *
+	 * @return bool
+	 */
+	public function optimize_missing_thumbnails() {
+		return true;
+	}
+}

--- a/Tests/Unit/inc/3rd-party/nextgen-gallery/classes/Optimization/Data/NGG/update_size_optimization_data.php
+++ b/Tests/Unit/inc/3rd-party/nextgen-gallery/classes/Optimization/Data/NGG/update_size_optimization_data.php
@@ -1,0 +1,209 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\ThirdParty\NGG\Optimization\Data\NGG;
+
+use Imagify\Media\MediaInterface;
+use Imagify\Tests\Unit\TestCase;
+use Imagify\ThirdParty\NGG\Optimization\Data\NGG;
+use Mockery;
+
+/**
+ * Tests for \Imagify\ThirdParty\NGG\Optimization\Data\NGG::update_size_optimization_data().
+ *
+ * @covers \Imagify\ThirdParty\NGG\Optimization\Data\NGG::update_size_optimization_data
+ * @group  NextGenPermanentError
+ */
+class Test_UpdateSizeOptimizationData extends TestCase {
+
+	/**
+	 * Builds a data instance bound to a valid media.
+	 *
+	 * @param array $row The row the instance reads before writing.
+	 *
+	 * @return NggDataStub
+	 */
+	private function get_data_instance( array $row = [] ): NggDataStub {
+		$media = Mockery::mock( MediaInterface::class );
+
+		$media->shouldReceive( 'is_valid' )->andReturn( true );
+
+		return new NggDataStub( $media, $row );
+	}
+
+	/**
+	 * Test: a permanent error is stored with `permanent_error` as the very first key.
+	 */
+	public function testShouldStorePermanentErrorAsFirstKey() {
+		$data = $this->get_data_instance();
+
+		$data->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success'         => false,
+				'error'           => 'AVIF file is larger than the original image',
+				'permanent_error' => true,
+			]
+		);
+
+		$size_data = $data->updated['data']['sizes']['full@imagify-avif'];
+
+		$this->assertSame( [ 'permanent_error', 'success', 'error' ], array_keys( $size_data ) );
+		$this->assertTrue( $size_data['permanent_error'] );
+		$this->assertFalse( $size_data['success'] );
+		$this->assertSame( 'AVIF file is larger than the original image', $size_data['error'] );
+	}
+
+	/**
+	 * Test: the serialized entry starts with the prefix the bulk query matches on.
+	 */
+	public function testShouldSerializePermanentErrorWithThePrefixTheBulkQueryMatches() {
+		$data = $this->get_data_instance();
+
+		$data->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success'         => false,
+				'error'           => 'AVIF file is larger than the original image',
+				'permanent_error' => true,
+			]
+		);
+
+		$this->assertStringContainsString(
+			'full@imagify-avif";a:3:{s:15:"permanent_error";b:1;',
+			serialize( $data->updated['data']['sizes'] ) // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		);
+	}
+
+	/**
+	 * Test: a transient error is stored without the flag, so the image keeps being retried.
+	 */
+	public function testShouldStoreTransientErrorWithoutTheFlag() {
+		$data = $this->get_data_instance();
+
+		$data->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success' => false,
+				'error'   => 'cURL error 28: Operation timed out',
+			]
+		);
+
+		$this->assertSame(
+			[ 'success', 'error' ],
+			array_keys( $data->updated['data']['sizes']['full@imagify-avif'] )
+		);
+	}
+
+	/**
+	 * Test: previously stored sizes are preserved when a permanent error is added.
+	 */
+	public function testShouldPreserveOtherSizesWhenStoringAPermanentError() {
+		$data = $this->get_data_instance(
+			[
+				'data' => [
+					'sizes' => [
+						'thumbnail' => [
+							'success'        => true,
+							'original_size'  => 1000,
+							'optimized_size' => 800,
+							'percent'        => 20,
+						],
+					],
+				],
+			]
+		);
+
+		$data->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success'         => false,
+				'error'           => 'AVIF file is larger than the original image',
+				'permanent_error' => true,
+			]
+		);
+
+		$this->assertTrue( $data->updated['data']['sizes']['thumbnail']['success'] );
+		$this->assertTrue( $data->updated['data']['sizes']['full@imagify-avif']['permanent_error'] );
+	}
+
+	/**
+	 * Test: nothing is written when the media is not valid.
+	 */
+	public function testShouldWriteNothingWhenMediaIsNotValid() {
+		$media = Mockery::mock( MediaInterface::class );
+
+		$media->shouldReceive( 'is_valid' )->andReturn( false );
+
+		$data = new NggDataStub( $media, [] );
+
+		$data->update_size_optimization_data(
+			'full@imagify-avif',
+			[
+				'success'         => false,
+				'error'           => 'AVIF file is larger than the original image',
+				'permanent_error' => true,
+			]
+		);
+
+		$this->assertNull( $data->updated );
+	}
+}
+
+/**
+ * Data class with an in-memory row instead of a database row.
+ */
+class NggDataStub extends NGG {
+
+	/**
+	 * The data passed to update_row().
+	 *
+	 * @var array|null
+	 */
+	public $updated;
+
+	/**
+	 * The row to return from get_row().
+	 *
+	 * @var array
+	 */
+	private $stub_row;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param MediaInterface $media The media instance.
+	 * @param array          $row   The row to return from get_row().
+	 */
+	public function __construct( $media, array $row ) {
+		$this->media    = $media;
+		$this->stub_row = $row;
+	}
+
+	/**
+	 * Returns the in-memory row.
+	 *
+	 * @return array
+	 */
+	public function get_row() {
+		return $this->stub_row;
+	}
+
+	/**
+	 * Returns empty defaults: the database columns are irrelevant here.
+	 *
+	 * @return array
+	 */
+	protected function get_reset_data() {
+		return [];
+	}
+
+	/**
+	 * Records what would have been written to the database.
+	 *
+	 * @param array $data The data to update.
+	 */
+	public function update_row( $data ) {
+		$this->updated = $data;
+	}
+}

--- a/Tests/Unit/inc/functions/AdminUi/getImagifyAttachmentOptimizationText.php
+++ b/Tests/Unit/inc/functions/AdminUi/getImagifyAttachmentOptimizationText.php
@@ -48,7 +48,7 @@ class Test_GetImagifyAttachmentOptimizationText extends TestCase {
 	 *
 	 * @param array $sizes The `sizes` entry of the optimization data.
 	 *
-	 * @return Mockery\MockInterface
+	 * @return \Imagify\Optimization\Process\ProcessInterface
 	 */
 	private function get_process( array $sizes ) {
 		$data = Mockery::mock( 'Imagify\Optimization\Data\DataInterface' );

--- a/Tests/Unit/inc/functions/AdminUi/getImagifyAttachmentOptimizationText.php
+++ b/Tests/Unit/inc/functions/AdminUi/getImagifyAttachmentOptimizationText.php
@@ -1,0 +1,200 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\Functions\AdminUi;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Imagify\Tests\Unit\TestCase;
+use Mockery;
+
+/**
+ * Tests for get_imagify_attachment_optimization_text().
+ *
+ * @covers get_imagify_attachment_optimization_text
+ * @group  NextGenPermanentError
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class Test_GetImagifyAttachmentOptimizationText extends TestCase {
+
+	/**
+	 * Sets up the WordPress and plugin function stubs.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		Monkey\Functions\stubTranslationFunctions();
+		Monkey\Functions\stubEscapeFunctions();
+
+		Functions\when( 'get_imagify_attachment_reoptimize_link' )->justReturn( '' );
+		Functions\when( 'get_imagify_attachment_optimize_missing_thumbnails_link' )->justReturn( '' );
+		Functions\when( 'get_imagify_attachment_generate_nextgen_versions_link' )->justReturn( '' );
+		Functions\when( 'get_imagify_attachment_delete_nextgen_versions_link' )->justReturn( '' );
+		Functions\when( 'imagify_get_optimization_level_label' )->justReturn( 'Smart compression' );
+
+		$views = Mockery::mock( 'alias:Imagify_Views' );
+
+		$views->shouldReceive( 'get_instance' )->andReturn( $views );
+		$views->shouldReceive( 'is_media_page' )->andReturn( true );
+		$views->shouldReceive( 'is_wp_library_page' )->andReturn( false );
+	}
+
+	/**
+	 * Builds a process whose data layer returns the given optimization data.
+	 *
+	 * @param array $sizes The `sizes` entry of the optimization data.
+	 *
+	 * @return Mockery\MockInterface
+	 */
+	private function get_process( array $sizes ) {
+		$data = Mockery::mock( 'Imagify\Optimization\Data\DataInterface' );
+
+		$data->shouldReceive( 'get_optimization_data' )->andReturn(
+			[
+				'status'  => 'success',
+				'message' => '',
+				'level'   => 1,
+				'sizes'   => $sizes,
+				'stats'   => [],
+			]
+		);
+		$data->shouldReceive( 'get_optimization_level' )->andReturn( 1 );
+		$data->shouldReceive( 'get_optimized_size' )->andReturn( '800 B' );
+		$data->shouldReceive( 'get_original_size' )->andReturn( '1 kB' );
+		$data->shouldReceive( 'get_saving_percent' )->andReturn( 20 );
+		$data->shouldReceive( 'get_optimized_sizes_count' )->andReturn( 0 );
+
+		$media = Mockery::mock( 'Imagify\Media\MediaInterface' );
+
+		$media->shouldReceive( 'get_id' )->andReturn( 13 );
+		$media->shouldReceive( 'is_image' )->andReturn( true );
+		$media->shouldReceive( 'has_backup' )->andReturn( false );
+
+		$process = Mockery::mock( 'Imagify\Optimization\Process\ProcessInterface' );
+
+		$process->shouldReceive( 'is_valid' )->andReturn( true );
+		$process->shouldReceive( 'get_data' )->andReturn( $data );
+		$process->shouldReceive( 'get_media' )->andReturn( $media );
+		$process->shouldReceive( 'has_next_gen' )->andReturn( false );
+		$process->shouldReceive( 'is_full_next_gen' )->andReturn( false );
+
+		return $process;
+	}
+
+	/**
+	 * Test: the reason given by the API is printed when a size holds a permanent error.
+	 */
+	public function testShouldPrintTheReasonWhenASizeHoldsAPermanentError() {
+		$output = get_imagify_attachment_optimization_text(
+			$this->get_process(
+				[
+					'full@imagify-avif' => [
+						'permanent_error' => true,
+						'success'         => false,
+						'error'           => 'AVIF file is larger than the original image',
+					],
+				]
+			)
+		);
+
+		$this->assertStringContainsString( 'Next-Gen status:', $output );
+		$this->assertStringContainsString( 'AVIF file is larger than the original image', $output );
+	}
+
+	/**
+	 * Test: the first flagged size wins when several sizes hold a permanent error.
+	 */
+	public function testShouldPrintTheFirstFlaggedReason() {
+		$output = get_imagify_attachment_optimization_text(
+			$this->get_process(
+				[
+					'thumbnail@imagify-avif' => [
+						'permanent_error' => true,
+						'success'         => false,
+						'error'           => 'First reason',
+					],
+					'full@imagify-avif'      => [
+						'permanent_error' => true,
+						'success'         => false,
+						'error'           => 'Second reason',
+					],
+				]
+			)
+		);
+
+		$this->assertStringContainsString( 'First reason', $output );
+		$this->assertStringNotContainsString( 'Second reason', $output );
+	}
+
+	/**
+	 * Test: a size flagged as permanent but carrying no message prints no status line.
+	 */
+	public function testShouldPrintNoStatusWhenTheFlaggedSizeHasNoError() {
+		$output = get_imagify_attachment_optimization_text(
+			$this->get_process(
+				[
+					'full@imagify-avif' => [
+						'permanent_error' => true,
+						'success'         => false,
+						'error'           => '',
+					],
+				]
+			)
+		);
+
+		$this->assertStringNotContainsString( 'Next-Gen status:', $output );
+	}
+
+	/**
+	 * Test: a transient failure prints no status line, so the media does not look permanently refused.
+	 */
+	public function testShouldPrintNoStatusWhenNoSizeIsFlagged() {
+		$output = get_imagify_attachment_optimization_text(
+			$this->get_process(
+				[
+					'full@imagify-avif' => [
+						'success' => false,
+						'error'   => 'cURL error 28: Operation timed out',
+					],
+				]
+			)
+		);
+
+		$this->assertStringNotContainsString( 'Next-Gen status:', $output );
+		$this->assertStringNotContainsString( 'cURL error 28', $output );
+	}
+
+	/**
+	 * Test: no status line is printed when the media has no size data at all.
+	 */
+	public function testShouldPrintNoStatusWhenThereAreNoSizes() {
+		$output = get_imagify_attachment_optimization_text( $this->get_process( [] ) );
+
+		$this->assertStringNotContainsString( 'Next-Gen status:', $output );
+		$this->assertStringContainsString( 'Next-Gen generated:', $output );
+	}
+
+	/**
+	 * Test: the reason is escaped before being printed.
+	 */
+	public function testShouldEscapeTheReason() {
+		$output = get_imagify_attachment_optimization_text(
+			$this->get_process(
+				[
+					'full@imagify-avif' => [
+						'permanent_error' => true,
+						'success'         => false,
+						'error'           => '<script>alert(1)</script>',
+					],
+				]
+			)
+		);
+
+		$this->assertStringNotContainsString( '<script>', $output );
+		$this->assertStringContainsString( '&lt;script&gt;', $output );
+	}
+}

--- a/Tests/Unit/inc/functions/imagifyTranslateApiMessage.php
+++ b/Tests/Unit/inc/functions/imagifyTranslateApiMessage.php
@@ -76,9 +76,12 @@ class Test_ImagifyTranslateApiMessage extends TestCase {
 	}
 
 	/**
-	 * Test: a non-string value is returned untouched.
+	 * Test: an empty message falls back to the unknown error wording rather than staying empty.
 	 */
-	public function testShouldReturnNonStringUnchanged() {
-		$this->assertSame( 42, imagify_translate_api_message( 42 ) );
+	public function testShouldFallBackToUnknownErrorForAnEmptyMessage() {
+		$this->assertStringContainsString(
+			'An unknown error occurred',
+			imagify_translate_api_message( '' )
+		);
 	}
 }

--- a/Tests/Unit/inc/functions/imagifyTranslateApiMessage.php
+++ b/Tests/Unit/inc/functions/imagifyTranslateApiMessage.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\Functions;
+
+use Brain\Monkey;
+use Imagify\Tests\Unit\TestCase;
+
+/**
+ * Tests for imagify_translate_api_message().
+ *
+ * @covers imagify_translate_api_message
+ * @group  NextGenPermanentError
+ */
+class Test_ImagifyTranslateApiMessage extends TestCase {
+
+	/**
+	 * Sets up the translation stubs.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		Monkey\Functions\stubTranslationFunctions();
+	}
+
+	/**
+	 * Test: the lowercase AVIF refusal returned by the API is translated.
+	 */
+	public function testShouldTranslateLowercaseAvifRefusal() {
+		$this->assertSame(
+			'AVIF file is larger than the original image',
+			imagify_translate_api_message( 'Avif is less performant than original' )
+		);
+	}
+
+	/**
+	 * Test: the uppercase AVIF refusal returned by the API is translated the same way.
+	 */
+	public function testShouldTranslateUppercaseAvifRefusal() {
+		$this->assertSame(
+			'AVIF file is larger than the original image',
+			imagify_translate_api_message( 'AVIF is less performant than original' )
+		);
+	}
+
+	/**
+	 * Test: surrounding dots and spaces do not prevent the AVIF message from being matched.
+	 */
+	public function testShouldTranslateAvifRefusalSurroundedByDotsAndSpaces() {
+		$this->assertSame(
+			'AVIF file is larger than the original image',
+			imagify_translate_api_message( ' AVIF is less performant than original. ' )
+		);
+	}
+
+	/**
+	 * Test: the WebP counterpart keeps its own wording.
+	 */
+	public function testShouldTranslateWebpRefusalWithItsOwnWording() {
+		$this->assertSame(
+			'WebP file is larger than the original image',
+			imagify_translate_api_message( 'Webp is less performant than original' )
+		);
+	}
+
+	/**
+	 * Test: an unknown message is returned untouched.
+	 */
+	public function testShouldReturnUnknownMessageUnchanged() {
+		$this->assertSame(
+			'Some message the map does not know',
+			imagify_translate_api_message( 'Some message the map does not know' )
+		);
+	}
+
+	/**
+	 * Test: a non-string value is returned untouched.
+	 */
+	public function testShouldReturnNonStringUnchanged() {
+		$this->assertSame( 42, imagify_translate_api_message( 42 ) );
+	}
+}

--- a/classes/Bulk/CustomFolders.php
+++ b/classes/Bulk/CustomFolders.php
@@ -186,8 +186,18 @@ class CustomFolders extends AbstractBulk {
 				fi.mime_type IN ( $mime_types )
 				AND ( fi.status = 'success' OR fi.status = 'already_optimized' )
 				AND fi.data NOT LIKE %s
+				AND fi.data NOT LIKE %s
 			ORDER BY fi.file_id DESC",
-				'%' . $wpdb->esc_like( $nextgen_suffix . '";a:4:{s:7:"success";b:1;' ) . '%'
+				'%' . $wpdb->esc_like( $nextgen_suffix . '";a:4:{s:7:"success";b:1;' ) . '%',
+				/**
+				 * Second predicate: skip files the API permanently refused to convert (the next-gen file
+				 * would be heavier than the original, or the file is already compressed). Those are stored
+				 * as `<size><suffix>";a:3:{s:15:"permanent_error";b:1;s:7:"success";b:0;s:5:"error";…`.
+				 * Transient failures serialize as a 2-element array without the `permanent_error` key, so
+				 * they keep being retried. Matching serialized data with LIKE is fragile: the key order
+				 * written in Optimization\Data\CustomFolders must not change.
+				 */
+				'%' . $wpdb->esc_like( $nextgen_suffix . '";a:3:{s:15:"permanent_error";b:1;' ) . '%'
 			)
 		);
 

--- a/classes/Bulk/WP.php
+++ b/classes/Bulk/WP.php
@@ -317,12 +317,22 @@ class WP extends AbstractBulk {
 				p.post_mime_type IN ( $mime_types )
 				AND ( mt1.meta_value = 'success' OR mt1.meta_value = 'already_optimized' )
 				AND mt2.meta_value NOT LIKE %s
+				AND mt2.meta_value NOT LIKE %s
 				AND p.post_type = 'attachment'
 				AND p.post_status IN ( $statuses )
 				$nodata_where
 			ORDER BY p.ID DESC
 			LIMIT 0, %d",
 				'%' . $wpdb->esc_like( $nextgen_suffix . '";a:4:{s:7:"success";b:1;' ) . '%',
+				/**
+				 * Second predicate: skip media the API permanently refused to convert (the next-gen file
+				 * would be heavier than the original, or the file is already compressed). Those are stored
+				 * as `<size><suffix>";a:3:{s:15:"permanent_error";b:1;s:7:"success";b:0;s:5:"error";…`.
+				 * Transient failures (network, quota, timeout) serialize as a 2-element array without the
+				 * `permanent_error` key, so they keep being retried. Matching serialized data with LIKE is
+				 * fragile: the key order written in Optimization\Data\WP must not change.
+				 */
+				'%' . $wpdb->esc_like( $nextgen_suffix . '";a:3:{s:15:"permanent_error";b:1;' ) . '%',
 				imagify_get_unoptimized_attachment_limit()
 			)
 		);

--- a/classes/Optimization/Data/CustomFolders.php
+++ b/classes/Optimization/Data/CustomFolders.php
@@ -194,10 +194,21 @@ class CustomFolders extends AbstractData {
 				/**
 				 * Error.
 				 */
-				$old_data['data']['sizes'][ $size ] = [
+				$size_data = [
 					'success' => false,
 					'error'   => $data['error'],
 				];
+
+				if ( ! empty( $data['permanent_error'] ) ) {
+					/**
+					 * `permanent_error` is written as the FIRST key on purpose: the bulk queries match the
+					 * serialized data with a LIKE on the `<size>";a:3:{s:15:"permanent_error";b:1;` prefix,
+					 * which only stays deterministic if the key order does.
+					 */
+					$size_data = array_merge( [ 'permanent_error' => true ], $size_data );
+				}
+
+				$old_data['data']['sizes'][ $size ] = $size_data;
 			} else {
 				/**
 				 * Success.

--- a/classes/Optimization/Data/WP.php
+++ b/classes/Optimization/Data/WP.php
@@ -105,10 +105,21 @@ class WP extends AbstractData {
 			/**
 			 * Error.
 			 */
-			$old_data['sizes'][ $size ] = [
+			$size_data = [
 				'success' => false,
 				'error'   => $data['error'],
 			];
+
+			if ( ! empty( $data['permanent_error'] ) ) {
+				/**
+				 * `permanent_error` is written as the FIRST key on purpose: the bulk queries match the
+				 * serialized meta value with a LIKE on the `<size>";a:3:{s:15:"permanent_error";b:1;`
+				 * prefix, which only stays deterministic if the key order does.
+				 */
+				$size_data = array_merge( [ 'permanent_error' => true ], $size_data );
+			}
+
+			$old_data['sizes'][ $size ] = $size_data;
 		} else {
 			/**
 			 * Success.

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -1979,10 +1979,45 @@ abstract class AbstractProcess implements ProcessInterface {
 		 */
 		$data = (array) apply_filters( "imagify{$_unauthorized}_file_optimization_data", $data, $response, $size, $level, $this->get_data() );
 
+		if ( property_exists( $response, 'message' ) && $this->is_next_gen_size( $size ) ) {
+			/**
+			 * The API answered with a 200 and a message instead of a converted file: it declined the
+			 * conversion, because the next-gen version would be heavier than the original or the file is
+			 * already compressed. No next-gen file is written to disk in that case (see
+			 * Imagify\Optimization\File::optimize()), so recording a success here would make the plugin
+			 * report a next-gen version that does not exist.
+			 *
+			 * Store a terminal entry instead, flagged as a permanent refusal so the bulk queries can skip
+			 * the media without re-sending it to the API on every run. Transient failures go through the
+			 * WP_Error branch above and are not flagged, so they keep being retried.
+			 */
+			$data['success']         = false;
+			$data['error']           = $data['message'];
+			$data['permanent_error'] = true;
+		}
 		// Store.
 		$this->get_data()->update_size_optimization_data( $size, $data );
 
 		return $data;
+	}
+
+	/**
+	 * Tell if a size name refers to a next-gen (AVIF or WebP) version.
+	 *
+	 * @param string $size The size name.
+	 *
+	 * @return bool
+	 */
+	private function is_next_gen_size( $size ) {
+		$size = (string) $size;
+
+		foreach ( [ static::AVIF_SUFFIX, static::WEBP_SUFFIX ] as $suffix ) {
+			if ( '' !== $suffix && substr( $size, - strlen( $suffix ) ) === $suffix ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/inc/3rd-party/nextgen-gallery/classes/Bulk/NGG.php
+++ b/inc/3rd-party/nextgen-gallery/classes/Bulk/NGG.php
@@ -170,8 +170,18 @@ class NGG extends AbstractBulk {
 				WHERE
 					( data.status = 'success' OR data.status = 'already_optimized' )
 					AND data.data NOT LIKE %s
+					AND data.data NOT LIKE %s
 				ORDER BY ngg.pid DESC",
-				'%' . $wpdb->esc_like( $suffix . '";a:4:{s:7:"success";b:1;' ) . '%'
+				'%' . $wpdb->esc_like( $suffix . '";a:4:{s:7:"success";b:1;' ) . '%',
+				/**
+				 * Second predicate: skip images the API permanently refused to convert (the next-gen file
+				 * would be heavier than the original, or the file is already compressed). Those are stored
+				 * as `<size><suffix>";a:3:{s:15:"permanent_error";b:1;s:7:"success";b:0;s:5:"error";…`.
+				 * Transient failures serialize as a 2-element array without the `permanent_error` key, so
+				 * they keep being retried. Matching serialized data with LIKE is fragile: the key order
+				 * written in Imagify\NGG\Optimization\Data\NGG must not change.
+				 */
+				'%' . $wpdb->esc_like( $suffix . '";a:3:{s:15:"permanent_error";b:1;' ) . '%'
 			)
 		);
 

--- a/inc/3rd-party/nextgen-gallery/classes/Optimization/Data/NGG.php
+++ b/inc/3rd-party/nextgen-gallery/classes/Optimization/Data/NGG.php
@@ -157,10 +157,21 @@ class NGG extends \Imagify\Optimization\Data\AbstractData {
 			/**
 			 * Error.
 			 */
-			$old_data['data']['sizes'][ $size ] = [
+			$size_data = [
 				'success' => false,
 				'error'   => $data['error'],
 			];
+
+			if ( ! empty( $data['permanent_error'] ) ) {
+				/**
+				 * `permanent_error` is written as the FIRST key on purpose: the bulk query matches the
+				 * serialized data with a LIKE on the `<size>";a:3:{s:15:"permanent_error";b:1;` prefix,
+				 * which only stays deterministic if the key order does.
+				 */
+				$size_data = array_merge( [ 'permanent_error' => true ], $size_data );
+			}
+
+			$old_data['data']['sizes'][ $size ] = $size_data;
 		} else {
 			/**
 			 * Success.

--- a/inc/functions/admin-ui.php
+++ b/inc/functions/admin-ui.php
@@ -101,6 +101,22 @@ function get_imagify_attachment_optimization_text( $process ) {
 		}
 		$output .= $output_before . '<span class="data">' . __( 'Next-Gen generated:', 'imagify' ) . '</span> <strong class="big">' . esc_html( $has_nextgen ) . '</strong>' . $output_after;
 
+		// When the API permanently refused the conversion, show the reason it gave.
+		$nextgen_reason = '';
+
+		if ( ! empty( $optimized_data['sizes'] ) && is_array( $optimized_data['sizes'] ) ) {
+			foreach ( $optimized_data['sizes'] as $size_data ) {
+				if ( ! empty( $size_data['permanent_error'] ) && ! empty( $size_data['error'] ) ) {
+					$nextgen_reason = $size_data['error'];
+					break;
+				}
+			}
+		}
+
+		if ( $nextgen_reason ) {
+			$output .= $output_before . '<span class="data">' . __( 'Next-Gen status:', 'imagify' ) . '</span> <strong>' . esc_html( $nextgen_reason ) . '</strong>' . $output_after;
+		}
+
 		$total_optimized_thumbnails = $data->get_optimized_sizes_count();
 
 		if ( $total_optimized_thumbnails ) {

--- a/inc/functions/admin-ui.php
+++ b/inc/functions/admin-ui.php
@@ -8,7 +8,7 @@ defined( 'ABSPATH' ) || exit;
  * @since  1.9 Function signature changed.
  * @author Jonathan Buttigieg
  *
- * @param  ProcessInterface $process The optimization process object.
+ * @param  \Imagify\Optimization\Process\ProcessInterface $process The optimization process object.
  * @return string                    The output to print.
  */
 function get_imagify_attachment_optimization_text( $process ) {

--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -223,6 +223,13 @@ function imagify_translate_api_message( $message ) {
 		),
 		'Your image is too big to be uploaded on our server' => __( 'Your file is too big to be uploaded on our server.', 'imagify' ),
 		'Webp is less performant than original'         => __( 'WebP file is larger than the original image', 'imagify' ),
+
+		/*
+		 * The AVIF wording below has not been confirmed against a live API response: it mirrors the WebP
+		 * pattern. Both casings are mapped so the message is translated whichever one the API returns.
+		 */
+		'Avif is less performant than original'         => __( 'AVIF file is larger than the original image', 'imagify' ),
+		'AVIF is less performant than original'         => __( 'AVIF file is larger than the original image', 'imagify' ),
 		'Our server returned an invalid response'       => __( 'Our server returned an invalid response.', 'imagify' ),
 		'cURL isn\'t installed on the server'           => __( 'cURL is not available on the server.', 'imagify' ),
 		// API messages.

--- a/readme.txt
+++ b/readme.txt
@@ -328,7 +328,7 @@ You can report any security bugs found in the source code of the site-reviews pl
 
 == Changelog ==
 = 2.3.1 =
-- Bugfix: The "Generate missing next-gen versions" tool no longer runs indefinitely when a WebP or AVIF version would be heavier than the optimized image.
+- Bugfix: Images are no longer reported as having a next-gen version when none was generated, because the WebP or AVIF file would have been heavier than the optimized image.
 
 = 2.3.0 =
 - New feature: Added support for the Model Context Protocol (MCP), enabling compatible AI assistants to optimize images and manage Imagify through natural language.

--- a/readme.txt
+++ b/readme.txt
@@ -327,6 +327,9 @@ You can report any security bugs found in the source code of the site-reviews pl
 4. Other Media Page
 
 == Changelog ==
+= 2.3.1 =
+- Bugfix: The "Generate missing next-gen versions" tool no longer runs indefinitely when a WebP or AVIF version would be heavier than the optimized image.
+
 = 2.3.0 =
 - New feature: Added support for the Model Context Protocol (MCP), enabling compatible AI assistants to optimize images and manage Imagify through natural language.
 - Enhancement: Improved validation to ensure only supported image files can be optimized through MCP.


### PR DESCRIPTION
# Description

Refs #1011

Since #1194, Imagify reports a next-gen version as generated for images where no next-gen file exists on disk.

When the API declines a conversion — because the WebP/AVIF version would be heavier than the optimized image, or the image is already compressed — it answers with **HTTP 200 and a `message`** rather than an error. `Imagify\Optimization\File::optimize()` correctly writes no next-gen file in that case, but the optimization data records the size as `success => true`. `has_next_gen()` reads that same record, so the media library shows **"Next-Gen generated"** for a file that was never created, and the size's stats are populated from a conversion that produced nothing.

This PR records those refusals as what they are — a permanent refusal, with the reason the API gave — while keeping the media out of the "missing next-gen versions" count so the bulk tool still completes.

**This does not undo #1194.** That fix made the bulk tool terminate by having the refused size match the query's "already has next-gen" pattern. Here the media is excluded explicitly instead, by a second predicate matching the refusal marker. The tool still completes; it just no longer relies on the data claiming a success that did not happen.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #1011
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

**Manual — reproduced end to end against a live Imagify API.** Local WP install, PHP 8.4, real API key, `lossless = 1`, `optimization_format = avif`, backups enabled. Steps as run:

1. Imported a small PNG (attachment **115**) and let it auto-optimize.
2. Inspected `_imagify_data`. The three `…@imagify-avif` sizes recorded:
   `success = false`, `permanent_error = true`, `error = "AVIF file is larger than the original image"`.
   The non-next-gen sizes (`medium`, `thumbnail`) recorded `"WELL DONE. This image is already compressed…"` **without** `permanent_error`, confirming the marker is applied only to next-gen sizes.
3. `has_next_gen()` returned **false**, and no `.avif` file existed on disk. The false claim is gone.
4. Rendered `get_imagify_attachment_optimization_text()` for that media. Output contains:
   `Next-Gen generated: No` … `Next-Gen status: AVIF file is larger than the original image`.
5. `get_optimized_media_ids_without_format( 'avif' )` → attachment 115 **excluded** from the missing-next-gen selection. The count no longer grows forever.
6. **Regression, normal conversions (step 7 below):** imported a 3456×2234 PNG (attachment **116**) → AVIF sizes succeeded, `permanent_error = 0`, `has_next_gen()` **true**, and the `.avif` files were written to disk.
7. **Regression, retry path (step 8 below).** Injected a `WP_Error` on next-gen sizes via `imagify_before_optimize_size` to simulate a transient failure, then imported another large PNG (attachment **118**):
   - sizes recorded `success = false`, **`permanent_error` unset** → correctly treated as transient
   - `get_optimized_media_ids_without_format( 'avif' )` **still selected** attachment 118 → retryable, not stranded
8. Removed the simulated failure and called `generate_nextgen_versions()` on 118 → **7/7 AVIF sizes converted and 7 `.avif` files written.** The retry path completes.

**Result: the permanent/transient discrimination — the core risk in this PR — behaves exactly as designed.** Permanent refusals are excluded from the count; transient failures remain retryable and convert successfully once conditions recover.

**The guessed AVIF wording is now confirmed.** This PR adds `'Avif is less performant than original'` with a comment noting the wording was unverified against a live response. It is verified: that is the exact raw string the API returns, and the translated message *"AVIF file is larger than the original image"* rendered correctly in step 2, which only happens if the mapping matched. The uppercase `'AVIF is less performant than original'` fallback appears unnecessary, though harmless.

*Limitation, stated rather than glossed:* the transient failure in step 7 was injected at the `imagify_before_optimize_size` filter rather than by a real network fault, because Imagify uploads use `Imagify::curl_http_call()` directly and bypass the WP HTTP API, so `pre_http_request` cannot intercept them. Both routes converge on the same `is_wp_error( $response )` branch of `update_size_optimization_data()`, which is the discrimination under test.

### How to test

1. Enable Lossless compression and the AVIF format in Imagify settings.
2. Upload the small example images attached to #1011 and let them auto-optimize.
3. In the Media Library, check the optimization details for one of them.
   - **Before:** "Next-Gen generated: yes", despite no `.avif` file existing next to the image.
   - **After:** no false claim, plus a "Next-Gen status:" line giving the reason returned by the API.
   - Confirm on disk that there is indeed no `.avif` file for that image.
4. Go to Imagify settings and click **"Generate missing next-gen versions"**.
5. **Expected:** the process still completes — this is the #1194 behaviour that must not regress — and those images are not counted as missing.
6. Click it again and confirm from your Imagify account that no further credits are spent on those images.
7. **Regression — normal conversions:** on images where next-gen conversion succeeds, confirm the files are still written, still reported as generated, and the counts still reach zero.
8. **Regression — retry path:** block outgoing HTTP (or exhaust quota) so a convertible image fails transiently, restore normal conditions, then re-run the tool. The image **must** be picked up again and converted. It must not be permanently skipped.

Steps 5 and 8 are the two worth the most QA attention: 5 guards against regressing #1194, 8 guards against the fix silently stranding retryable images.

### Affected Features & Quality Assurance Scope

- **Media library optimization details** — no longer claims a next-gen version that does not exist; adds a "Next-Gen status:" line with the reason.
- **"Generate missing next-gen versions" tool** — still completes, now via an explicit exclusion rather than a false success record.
- **Missing next-gen counts everywhere** — one query feeds the settings AJAX tool, the settings-save hook, the WP-CLI command, the `GenerateMissingNextgen` and `GetNextgenCoverage` abilities, and the Imagifybeat progress poll. All change together.
- **Custom folders and NextGEN Gallery** — each has its own data writer and query; both updated in step.
- **Per-size optimization figures** — refused next-gen sizes no longer carry `original_size` / `optimized_size` from a conversion that produced no file.

## Technical description

### Documentation

In `AbstractProcess::update_size_optimization_data()`, a 200-with-`message` response on a next-gen size is now recorded as a terminal refusal rather than a success:

```php
if ( property_exists( $response, 'message' ) && $this->is_next_gen_size( $size ) ) {
	$data['success']         = false;
	$data['error']           = $data['message'];
	$data['permanent_error'] = true;
}
```

Non-next-gen sizes are untouched: a plain `full` size legitimately carries "already compressed" messages.

**Why a flag rather than plain `success => false`.** Transient failures (network, timeout, quota) already write `success => false` under the suffixed key and are correctly retried. Marking refusals identically would strand an image forever after a single API blip, and would also re-break #1194 by putting the media back into the missing count. The flag is written as the **first** key of the size entry so the serialized value has a deterministic prefix; with `success`/`error` first, the variable-length error string sits in the middle and cannot be matched. The queries then add:

```php
'%' . $wpdb->esc_like( $nextgen_suffix . '";a:3:{s:15:"permanent_error";b:1;' ) . '%'
```

Matching serialized data with `LIKE` is fragile, and both the write and read sites carry a comment saying the key order must not change. This follows the pattern of the existing predicate rather than introducing a new meta key, which would need a migration on every install plus parallel handling in the custom-folders table.

**No backfill migration**, deliberately. Media already in the false-success state will be re-evaluated on their next pass and recorded correctly, at a cost of one further API call each. A migration would have to guess which existing records came from a refusal, and guessing wrong would strand images that would convert successfully.

### New dependencies

None.

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
  - The `permanent_error` flag and its reason are readable in `_imagify_data` and surfaced in the media library, so an affected media can be diagnosed without reproducing the API call.
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

