### PR TITLE
Populate distinct_id for Imagify Mixpanel events

### DIFF
--- a/Tests/Unit/classes/Tracking/McpTracking/Test_TrackAbilityExecuted.php
+++ b/Tests/Unit/classes/Tracking/McpTracking/Test_TrackAbilityExecuted.php
@@ -26,6 +26,11 @@ class Test_TrackAbilityExecuted extends TestCase {
 		$optin->shouldReceive( 'can_track' )->andReturn( false );
 
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
 		$mixpanel->shouldNotReceive( 'track_direct' );
 
 		( new McpTracking( $optin, $mixpanel ) )
@@ -40,6 +45,11 @@ class Test_TrackAbilityExecuted extends TestCase {
 		$optin->shouldReceive( 'can_track' )->andReturn( true );
 
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
 		$mixpanel->shouldReceive( 'track_direct' )
 			->once()
 			->withArgs(
@@ -68,6 +78,11 @@ class Test_TrackAbilityExecuted extends TestCase {
 		$optin->shouldReceive( 'can_track' )->andReturn( true );
 
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
 		$mixpanel->shouldReceive( 'track_direct' )
 			->once()
 			->withArgs(
@@ -93,6 +108,11 @@ class Test_TrackAbilityExecuted extends TestCase {
 		$optin->shouldReceive( 'can_track' )->andReturn( true );
 
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
 		$mixpanel->shouldReceive( 'track_direct' )
 			->once()
 			->withArgs(
@@ -119,6 +139,11 @@ class Test_TrackAbilityExecuted extends TestCase {
 		$optin->shouldReceive( 'can_track' )->andReturn( true );
 
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
 		$mixpanel->shouldReceive( 'track_direct' )
 			->once()
 			->withArgs(

--- a/Tests/Unit/classes/Tracking/McpTracking/Test_TrackMediaOptimized.php
+++ b/Tests/Unit/classes/Tracking/McpTracking/Test_TrackMediaOptimized.php
@@ -25,6 +25,11 @@ class Test_TrackMediaOptimized extends TestCase {
 		$optin = Mockery::mock( Optin::class );
 		$optin->shouldReceive( 'can_track' )->andReturn( false );
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
 		$mixpanel->shouldNotReceive( 'track_direct' );
 
 		$tracking = new McpTracking( $optin, $mixpanel );
@@ -38,6 +43,11 @@ class Test_TrackMediaOptimized extends TestCase {
 		$optin = Mockery::mock( Optin::class );
 		$optin->shouldReceive( 'can_track' )->andReturn( true );
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
 		$mixpanel->shouldNotReceive( 'track_direct' );
 
 		$tracking = new McpTracking( $optin, $mixpanel );
@@ -51,6 +61,11 @@ class Test_TrackMediaOptimized extends TestCase {
 		$optin = Mockery::mock( Optin::class );
 		$optin->shouldReceive( 'can_track' )->andReturn( true );
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
 		$mixpanel->shouldNotReceive( 'track_direct' );
 
 		$tracking = new McpTracking( $optin, $mixpanel );
@@ -73,6 +88,11 @@ class Test_TrackMediaOptimized extends TestCase {
 		$optin->shouldReceive( 'can_track' )->andReturn( true );
 
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
 		$mixpanel->shouldReceive( 'track_direct' )
 			->once()
 			->withArgs(
@@ -120,6 +140,11 @@ class Test_TrackMediaOptimized extends TestCase {
 		$optin->shouldReceive( 'can_track' )->andReturn( true );
 
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
 		$mixpanel->shouldReceive( 'track_direct' )
 			->once()
 			->withArgs(
@@ -157,6 +182,11 @@ class Test_TrackMediaOptimized extends TestCase {
 		$optin->shouldReceive( 'can_track' )->andReturn( true );
 
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
 		$mixpanel->shouldReceive( 'track_direct' )
 			->once()
 			->withArgs(
@@ -201,6 +231,11 @@ class Test_TrackMediaOptimized extends TestCase {
 		$optin->shouldReceive( 'can_track' )->andReturn( true );
 
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
 		$mixpanel->shouldReceive( 'track_direct' )
 			->once()
 			->withArgs(

--- a/Tests/Unit/classes/Tracking/McpTracking/Test_TrackPermissionDenied.php
+++ b/Tests/Unit/classes/Tracking/McpTracking/Test_TrackPermissionDenied.php
@@ -26,6 +26,11 @@ class Test_TrackPermissionDenied extends TestCase {
 		$optin->shouldReceive( 'can_track' )->andReturn( false );
 
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
 		$mixpanel->shouldNotReceive( 'track_direct' );
 
 		( new McpTracking( $optin, $mixpanel ) )
@@ -43,6 +48,11 @@ class Test_TrackPermissionDenied extends TestCase {
 		$wp_user->roles = [ 'editor' ];
 
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
 		$mixpanel->shouldReceive( 'track_direct' )
 			->once()
 			->withArgs(
@@ -75,6 +85,11 @@ class Test_TrackPermissionDenied extends TestCase {
 		$wp_user->roles = [];
 
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
 		$mixpanel->shouldReceive( 'track_direct' )
 			->once()
 			->withArgs(

--- a/Tests/Unit/classes/Tracking/Tracking/Test_GetDefaultEventProperties.php
+++ b/Tests/Unit/classes/Tracking/Tracking/Test_GetDefaultEventProperties.php
@@ -34,12 +34,20 @@ class Test_GetDefaultEventProperties extends TestCase {
 	/**
 	 * Creates a Tracking instance with mocked dependencies.
 	 *
-	 * @return Tracking
+	 * @return array{tracking: Tracking, mixpanel: \Mockery\MockInterface&TrackingPlugin}
 	 */
-	private function create_tracking(): Tracking {
+	private function create_tracking(): array {
 		$optin    = Mockery::mock( Optin::class );
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
-		return new Tracking( $optin, $mixpanel );
+
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
+
+		$tracking = new Tracking( $optin, $mixpanel );
+
+		return compact( 'tracking', 'mixpanel' );
 	}
 
 	/**
@@ -50,7 +58,7 @@ class Test_GetDefaultEventProperties extends TestCase {
 		Functions\when( 'is_wp_error' )->justReturn( false );
 		Functions\when( 'get_current_user_id' )->justReturn( 5 );
 
-		$tracking = $this->create_tracking();
+		$tracking = $this->create_tracking()['tracking'];
 		$props    = $this->call_get_default_event_properties( $tracking );
 
 		$expected_hash = hash( 'sha256', 'user@example.com' );
@@ -70,7 +78,7 @@ class Test_GetDefaultEventProperties extends TestCase {
 		Functions\when( 'is_wp_error' )->justReturn( true );
 		Functions\when( 'get_current_user_id' )->justReturn( 0 );
 
-		$tracking = $this->create_tracking();
+		$tracking = $this->create_tracking()['tracking'];
 		$props    = $this->call_get_default_event_properties( $tracking );
 
 		$this->assertSame( '', $props['license_owner'] );
@@ -84,9 +92,80 @@ class Test_GetDefaultEventProperties extends TestCase {
 		Functions\when( 'is_wp_error' )->justReturn( false );
 		Functions\when( 'get_current_user_id' )->justReturn( 42 );
 
-		$tracking = $this->create_tracking();
+		$tracking = $this->create_tracking()['tracking'];
 		$props    = $this->call_get_default_event_properties( $tracking );
 
 		$this->assertSame( 42, $props['user_id'] );
+	}
+
+	/**
+	 * Tests that the license owner email is used to identify the user in Mixpanel.
+	 */
+	public function testIdentifiesWithLicenseOwnerEmail(): void {
+		Functions\when( 'get_imagify_user' )->justReturn( (object) [ 'email' => 'user@example.com' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'get_current_user_id' )->justReturn( 5 );
+
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$mixpanel->shouldReceive( 'identify' )->once()->with( 'user@example.com' );
+
+		$this->call_get_default_event_properties( $tracking );
+	}
+
+	/**
+	 * Tests that the site host is used as identifier when no license email is available.
+	 */
+	public function testIdentifiesWithSiteHostWhenNoLicenseEmail(): void {
+		Functions\when( 'get_imagify_user' )->justReturn( (object) [ 'email' => '' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'get_current_user_id' )->justReturn( 0 );
+
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$mixpanel->shouldReceive( 'identify' )->once()->with( 'example.com' );
+
+		$this->call_get_default_event_properties( $tracking );
+	}
+
+	/**
+	 * Tests that the user is identified only once, even across several tracked events.
+	 */
+	public function testIdentifiesOnlyOncePerRequest(): void {
+		Functions\when( 'get_imagify_user' )->justReturn( (object) [ 'email' => 'user@example.com' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'get_current_user_id' )->justReturn( 5 );
+
+		$mocks    = $this->create_tracking();
+		$tracking = $mocks['tracking'];
+		$mixpanel = $mocks['mixpanel'];
+
+		$mixpanel->shouldReceive( 'identify' )->once()->with( 'user@example.com' );
+
+		$this->call_get_default_event_properties( $tracking );
+		$this->call_get_default_event_properties( $tracking );
+	}
+
+	/**
+	 * Tests that no identify call is made when neither an email nor a host can be resolved.
+	 */
+	public function testDoesNotIdentifyWhenNoIdentifierAvailable(): void {
+		Functions\when( 'get_imagify_user' )->justReturn( (object) [ 'email' => '' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'get_current_user_id' )->justReturn( 0 );
+
+		$optin    = Mockery::mock( Optin::class );
+		$mixpanel = Mockery::mock( TrackingPlugin::class );
+
+		Functions\when( 'get_home_url' )->justReturn( '' );
+		Functions\when( 'wp_parse_url' )->justReturn( null );
+
+		$mixpanel->shouldNotReceive( 'identify' );
+
+		$this->call_get_default_event_properties( new Tracking( $optin, $mixpanel ) );
 	}
 }

--- a/Tests/Unit/classes/Tracking/Tracking/Test_ResolveTrigger.php
+++ b/Tests/Unit/classes/Tracking/Tracking/Test_ResolveTrigger.php
@@ -31,6 +31,11 @@ class Test_ResolveTrigger extends TestCase {
 		$optin    = Mockery::mock( Optin::class );
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
 
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
+
 		$this->tracking = new Tracking( $optin, $mixpanel );
 	}
 

--- a/Tests/Unit/classes/Tracking/Tracking/Test_TrackInternalStateReset.php
+++ b/Tests/Unit/classes/Tracking/Tracking/Test_TrackInternalStateReset.php
@@ -29,6 +29,11 @@ class Test_TrackInternalStateReset extends TestCase {
 		$optin    = Mockery::mock( Optin::class );
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
 
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
+
 		$optin->shouldReceive( 'can_track' )->andReturn( $can_track );
 
 		Functions\when( 'get_imagify_user' )->justReturn( (object) [ 'email' => 'user@example.com' ] );

--- a/Tests/Unit/classes/Tracking/Tracking/Test_TrackMediaOptimized.php
+++ b/Tests/Unit/classes/Tracking/Tracking/Test_TrackMediaOptimized.php
@@ -31,6 +31,11 @@ class Test_TrackMediaOptimized extends TestCase {
 		$optin    = Mockery::mock( Optin::class );
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
 
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
+
 		$optin->shouldReceive( 'can_track' )->andReturn( $can_track );
 
 		Functions\when( 'get_imagify_user' )->justReturn( (object) [ 'email' => 'user@example.com' ] );

--- a/Tests/Unit/classes/Tracking/Tracking/Test_TrackMediaRestored.php
+++ b/Tests/Unit/classes/Tracking/Tracking/Test_TrackMediaRestored.php
@@ -28,6 +28,11 @@ class Test_TrackMediaRestored extends TestCase {
 		$optin    = Mockery::mock( Optin::class );
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
 
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
+
 		$optin->shouldReceive( 'can_track' )->andReturn( $config['can_track'] );
 
 		Functions\when( 'get_imagify_user' )->justReturn( (object) [ 'email' => 'user@example.com' ] );

--- a/Tests/Unit/classes/Tracking/Tracking/Test_TrackSettingsSaved.php
+++ b/Tests/Unit/classes/Tracking/Tracking/Test_TrackSettingsSaved.php
@@ -29,6 +29,11 @@ class Test_TrackSettingsSaved extends TestCase {
 		$optin    = Mockery::mock( Optin::class );
 		$mixpanel = Mockery::mock( TrackingPlugin::class );
 
+		$mixpanel->shouldReceive( 'identify' )->byDefault();
+
+		Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.com' );
+
 		$optin->shouldReceive( 'can_track' )->andReturn( $can_track );
 
 		Functions\when( 'get_imagify_user' )->justReturn( (object) [ 'email' => 'user@example.com' ] );

--- a/classes/Tracking/BaseTracking.php
+++ b/classes/Tracking/BaseTracking.php
@@ -28,6 +28,13 @@ abstract class BaseTracking {
 	protected $mixpanel;
 
 	/**
+	 * Whether the Mixpanel user has already been identified during this request.
+	 *
+	 * @var bool
+	 */
+	private $identified = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param Optin          $optin    The Mixpanel opt-in service.
@@ -57,17 +64,81 @@ abstract class BaseTracking {
 	 * @return array<string, mixed>
 	 */
 	protected function get_default_event_properties(): array {
-		$user          = get_imagify_user();
-		$license_owner = '';
+		$email         = $this->get_license_owner_email();
+		$license_owner = '' !== $email ? hash( 'sha256', $email ) : '';
 
-		if ( ! is_wp_error( $user ) && ! empty( $user->email ) ) {
-			$license_owner = hash( 'sha256', $user->email );
-		}
+		$this->identify_user( $email );
 
 		return [
 			'context'       => 'wp_plugin',
 			'license_owner' => $license_owner,
 			'user_id'       => (int) get_current_user_id(),
 		];
+	}
+
+	/**
+	 * Registers a stable `distinct_id` super property on the Mixpanel instance.
+	 *
+	 * Mixpanel needs `distinct_id` on every event to compute user-level metrics
+	 * (MAU/DAU, retention, cohorts, funnels). `TrackingPlugin::identify()` hashes
+	 * the identifier with sha224 before it is registered, so no raw email or
+	 * domain ever leaves the site.
+	 *
+	 * The identifier is the Imagify license owner email — the same strategy as
+	 * WP Rocket, so one license maps to one Mixpanel user across all its sites.
+	 * When no license email is available (unlicensed or unreachable API), the
+	 * site host is used instead so events are still attributed to a stable,
+	 * anonymized identity rather than none at all.
+	 *
+	 * Called from `get_default_event_properties()` — the single choke point every
+	 * tracked event goes through — so the license user is fetched only once and
+	 * never on plugin bootstrap. Runs at most once per instance per request; the
+	 * underlying Mixpanel instance is shared, so the property applies to every
+	 * subsequent event.
+	 *
+	 * @param string $email The license owner email, or an empty string when unknown.
+	 *
+	 * @return void
+	 */
+	protected function identify_user( string $email ): void {
+		if ( $this->identified ) {
+			return;
+		}
+
+		$identifier = '' !== $email ? $email : $this->get_site_identifier();
+
+		if ( '' === $identifier ) {
+			return;
+		}
+
+		$this->mixpanel->identify( $identifier );
+
+		$this->identified = true;
+	}
+
+	/**
+	 * Returns the Imagify license owner email.
+	 *
+	 * @return string The email, or an empty string when the account is unknown.
+	 */
+	private function get_license_owner_email(): string {
+		$user = get_imagify_user();
+
+		if ( is_wp_error( $user ) || empty( $user->email ) ) {
+			return '';
+		}
+
+		return (string) $user->email;
+	}
+
+	/**
+	 * Returns the site host, used as a fallback identifier when no license email exists.
+	 *
+	 * @return string The host, or an empty string when it cannot be resolved.
+	 */
+	private function get_site_identifier(): string {
+		$host = wp_parse_url( get_home_url(), PHP_URL_HOST );
+
+		return is_string( $host ) ? $host : '';
 	}
 }

--- a/docs/api/tracking.md
+++ b/docs/api/tracking.md
@@ -8,7 +8,7 @@ The `Imagify\Tracking` module wires the `wp-media/wp-mixpanel` Composer package 
 
 | Class | Role |
 |---|---|
-| `Imagify\Tracking\BaseTracking` | Abstract base: `can_track()`, `get_default_event_properties()` |
+| `Imagify\Tracking\BaseTracking` | Abstract base: `can_track()`, `get_default_event_properties()`, `identify_user()` |
 | `Imagify\Tracking\Tracking` | Concrete: `track_media_optimized()`, `track_settings_saved()` |
 | `Imagify\Tracking\Subscriber` | Subscribes to WordPress hooks and delegates to `Tracking` |
 | `Imagify\Tracking\ServiceProvider` | Registers all module services into the DI container |
@@ -17,6 +17,29 @@ The module depends on two Strauss-prefixed vendor classes:
 
 - `Imagify\Dependencies\WPMedia\Mixpanel\Optin` — manages opt-in state
 - `Imagify\Dependencies\WPMedia\Mixpanel\TrackingPlugin` — sends events to Mixpanel
+
+---
+
+## User identification (`distinct_id`)
+
+Mixpanel needs a `distinct_id` on every event to compute user-level metrics — MAU/DAU, retention, cohorts, funnels, unique users by feature. Without it, events are only aggregatable in bulk.
+
+`BaseTracking::identify_user()` registers it by calling `TrackingPlugin::identify()`, which hashes the identifier with **sha224** and registers it as a Mixpanel *super property* on the shared Mixpanel instance — so it lands on every event sent afterwards, including MCP events. No raw email or domain ever leaves the site.
+
+| Priority | Identifier | Rationale |
+|---|---|---|
+| 1 | `get_imagify_user()->email` | Same strategy as WP Rocket: one license = one Mixpanel user across all of its sites |
+| 2 | Host of `get_home_url()` | Fallback for unlicensed sites or an unreachable API, so events still get a stable anonymized identity |
+| 3 | *(none)* | If neither resolves, `identify()` is not called and the event carries no `distinct_id` |
+
+It is called from `get_default_event_properties()` — the single choke point every tracked event goes through. That placement is deliberate:
+
+- It reuses the `get_imagify_user()` result already needed for `license_owner` (transient-cached for 5 minutes), so no extra API call.
+- It never runs on plugin bootstrap, unlike identifying in the constructor.
+
+A per-instance `identified` flag keeps it to one call per instance per request.
+
+> `distinct_id` is a Mixpanel super property, not an event property — it will not appear in `get_default_event_properties()` return values or in the `track_direct()` `$properties` argument.
 
 ---
 


### PR DESCRIPTION
# Description

Fixes #1198

Imagify's Mixpanel events were sent without a `distinct_id`, so Mixpanel could not tie events to a user. Every user-level report was impossible to build: MAU, DAU/WAU, retention, cohorts, funnels, unique users by feature, and MCP adoption rate.

This PR registers a stable, hashed `distinct_id` on every Imagify Mixpanel event (UI and MCP), using the same strategy as WP Rocket. No user-visible behavior changes — the impact is entirely on the analytics side, where user-level reporting now works.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Automated (unit, `--group Tracking`, 109 tests / 153 assertions green):

- `distinct_id` is registered from the license owner email when the account is connected.
- It falls back to the site host when no license email is available (unlicensed site, or `get_imagify_user()` returning a `WP_Error`).
- `identify()` is called **once** per instance per request, even across several tracked events.
- `identify()` is **not** called when neither an email nor a host can be resolved — no bogus identifier is sent.
- All pre-existing tracking tests still pass unchanged (event properties, guards, opt-in behavior).

Full unit suite: 359 tests, 837 assertions, no failures. `phpcs` clean on `classes/Tracking/BaseTracking.php`. The 2 remaining PHPStan errors are pre-existing in `classes/Media/WP.php` and unrelated to this change.

### How to test

1. Check out this branch on a site with a connected Imagify API key.
2. Enable analytics opt-in: `wp option update imagify_mixpanel_optin 1`
3. Enable Mixpanel debug logging so events are dumped to `debug.log` — set `WP_DEBUG` and `WP_DEBUG_LOG` to `true` in `wp-config.php`.
4. Trigger any tracked event — e.g. optimize a single image from the Media Library, or save the Imagify settings page.
5. Inspect `wp-content/debug.log`. The logged `Mixpanel event:` payload does **not** print `distinct_id` (it is a super property merged at the transport layer, not an event property) — so verify the payload actually sent instead: check the event in Mixpanel (Events / Live View) and confirm `distinct_id` is populated and identical across events from the same site.
6. Repeat step 4 with the API key removed (`wp option patch delete imagify_settings api_key`, then `wp transient delete imagify_user_cache`). `distinct_id` must still be populated — this time derived from the site host — and must remain stable across events.
7. Repeat step 4 through an MCP ability call (e.g. `imagify/optimize-media`) and confirm the MCP events carry the same `distinct_id` as the UI events.

### Affected Features & Quality Assurance Scope

- **Analytics / Mixpanel tracking** (`Imagify\Tracking`) — all events, both the UI path (`Tracking`) and the MCP path (`McpTracking`): `Media Optimized`, `Media Restored`, `Settings Saved`, `Internal State Reset`, `MCP Ability Executed`, `MCP Ability Permission Denied`.
- **Opt-in behavior** — unchanged, but worth a smoke check: nothing must be sent while `imagify_mixpanel_optin` is off.
- Everything else is untouched. No changes to optimization, restore, settings persistence, or the MCP abilities themselves.

## Technical description

### Documentation

`docs/api/tracking.md` gains a **User identification (`distinct_id`)** section documenting the identifier priority, the hashing, and why the call sits where it does.

**What was added** — `BaseTracking::identify_user()` calls `TrackingPlugin::identify()`, which hashes the identifier with **sha224** and registers it as a Mixpanel *super property* on the shared Mixpanel instance. Super properties are merged into every event sent afterwards, so a single call covers both the UI and MCP tracking paths (they share the same `TrackingPlugin` singleton via the DI container).

**Identifier priority:**

| Priority | Identifier | Rationale |
|---|---|---|
| 1 | `get_imagify_user()->email` | Same strategy as WP Rocket (`$this->mixpanel->identify( consumer_email )`), so one license maps to one Mixpanel user across all of its sites |
| 2 | Host of `get_home_url()` | Fallback for unlicensed sites or an unreachable API, so events still get a stable anonymized identity instead of none |
| 3 | *(none)* | If neither resolves, `identify()` is not called and no bogus `distinct_id` is sent |

**Where it is called from** — `get_default_event_properties()`, the single choke point every tracked event already goes through. That placement was chosen deliberately over WP Rocket's constructor call:

- It reuses the `get_imagify_user()` result already needed for the `license_owner` property, so it adds **zero** API calls. `get_imagify_user()` is transient-cached for 5 minutes.
- Identifying in the constructor would fire an Imagify API request on plugin bootstrap for every page load with an expired transient — a real performance regression. The lazy call only runs when an event is actually about to be tracked, which is already behind the opt-in guard.

A private `$identified` flag caps it at one call per instance per request. The two instances (`Tracking`, `McpTracking`) may each call it, which is harmless — `register()` is idempotent for the same value.

The `license_owner` computation was factored out into `get_license_owner_email()` so the email is fetched once and used for both the hashed `license_owner` event property (sha256) and the `distinct_id` super property (sha224). Behavior for `license_owner` is unchanged.

### New dependencies

None. `identify()` already existed on the vendored `wp-media/wp-mixpanel` `Tracking` class; it was simply never called by Imagify.

### Risks

- **Privacy** — no raw PII is transmitted. The email (or host) is hashed with sha224 inside `TrackingPlugin::identify()` before being registered, mirroring what WP Rocket already ships. The whole path stays behind the existing `can_track()` opt-in guard, so nothing is sent for users who have not opted in.
- **Performance** — no additional HTTP request. The identifier is derived from data the tracking path already fetches (`get_imagify_user()`, transient-cached), and identification is skipped entirely when tracking is off. Nothing runs on plugin bootstrap.
- **Identity semantics** — using the license email means all sites under one license share a `distinct_id`. This is intentional and matches WP Rocket, which is what makes cross-plugin, user-level reporting consistent. Per-site breakdown remains available through the `domain` property that `track_direct()` already injects.
- **Fallback collisions** — the host fallback groups all unlicensed events from the same host under one identity, which is the desired behavior. Different hosts hash differently, so there is no cross-site merging.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A — all mandatory items apply and are ticked. On "output messages": this change adds no user-facing message; the existing Mixpanel debug log (`wp_media_mixpanel_debug`) remains the observability channel.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
