### PR TITLE
Fix #816: generate Next-Gen files when the API reports the image as already compressed

### DIFF
--- a/Tests/Fixtures/classes/Optimization/File/IsFileFormatTest.php
+++ b/Tests/Fixtures/classes/Optimization/File/IsFileFormatTest.php
@@ -1,0 +1,105 @@
+<?php
+
+return [
+	'test_data' => [
+		// A genuine WebP payload requested as 'webp' must be recognized.
+		'shouldDetectGenuineWebp'           => [
+			'config'   => [
+				'header' => "RIFF\x00\x00\x00\x00WEBP",
+				'format' => 'webp',
+			],
+			'expected' => [
+				'result' => true,
+			],
+		],
+
+		// A genuine AVIF payload (brand "avif") requested as 'avif' must be recognized.
+		'shouldDetectGenuineAvifBrand'      => [
+			'config'   => [
+				'header' => "\x00\x00\x00\x1cftypavif",
+				'format' => 'avif',
+			],
+			'expected' => [
+				'result' => true,
+			],
+		],
+
+		// The "avis" brand (AVIF image sequence) must also be recognized as AVIF.
+		'shouldDetectGenuineAvifAvisBrand'  => [
+			'config'   => [
+				'header' => "\x00\x00\x00\x1cftypavis",
+				'format' => 'avif',
+			],
+			'expected' => [
+				'result' => true,
+			],
+		],
+
+		// This is the #816 failure mode: the API returned the original (non-converted) JPEG
+		// bytes instead of a WebP file. Must NOT be mistaken for the requested format.
+		'shouldRejectOriginalBytesAsWebp'   => [
+			'config'   => [
+				'header' => "\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01",
+				'format' => 'webp',
+			],
+			'expected' => [
+				'result' => false,
+			],
+		],
+
+		// Same failure mode, requested as AVIF.
+		'shouldRejectOriginalBytesAsAvif'   => [
+			'config'   => [
+				'header' => "\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01",
+				'format' => 'avif',
+			],
+			'expected' => [
+				'result' => false,
+			],
+		],
+
+		// A WebP file must not be mistaken for an AVIF file.
+		'shouldRejectWebpAsAvif'            => [
+			'config'   => [
+				'header' => "RIFF\x00\x00\x00\x00WEBP",
+				'format' => 'avif',
+			],
+			'expected' => [
+				'result' => false,
+			],
+		],
+
+		// An AVIF file must not be mistaken for a WebP file.
+		'shouldRejectAvifAsWebp'            => [
+			'config'   => [
+				'header' => "\x00\x00\x00\x1cftypavif",
+				'format' => 'webp',
+			],
+			'expected' => [
+				'result' => false,
+			],
+		],
+
+		// A too-short/empty payload can't be a valid next-gen file.
+		'shouldRejectTruncatedContent'      => [
+			'config'   => [
+				'header' => 'short',
+				'format' => 'webp',
+			],
+			'expected' => [
+				'result' => false,
+			],
+		],
+
+		// If the content couldn't be read at all, treat it as a mismatch (fail safe).
+		'shouldRejectWhenContentUnreadable' => [
+			'config'   => [
+				'header' => false,
+				'format' => 'webp',
+			],
+			'expected' => [
+				'result' => false,
+			],
+		],
+	],
+];

--- a/Tests/Fixtures/classes/Optimization/File/IsFileFormatTest.php
+++ b/Tests/Fixtures/classes/Optimization/File/IsFileFormatTest.php
@@ -3,7 +3,7 @@
 return [
 	'test_data' => [
 		// A genuine WebP payload requested as 'webp' must be recognized.
-		'shouldDetectGenuineWebp'           => [
+		'shouldDetectGenuineWebp'            => [
 			'config'   => [
 				'header' => "RIFF\x00\x00\x00\x00WEBP",
 				'format' => 'webp',
@@ -14,7 +14,7 @@ return [
 		],
 
 		// A genuine AVIF payload (brand "avif") requested as 'avif' must be recognized.
-		'shouldDetectGenuineAvifBrand'      => [
+		'shouldDetectGenuineAvifBrand'       => [
 			'config'   => [
 				'header' => "\x00\x00\x00\x1cftypavif",
 				'format' => 'avif',
@@ -25,7 +25,7 @@ return [
 		],
 
 		// The "avis" brand (AVIF image sequence) must also be recognized as AVIF.
-		'shouldDetectGenuineAvifAvisBrand'  => [
+		'shouldDetectGenuineAvifAvisBrand'   => [
 			'config'   => [
 				'header' => "\x00\x00\x00\x1cftypavis",
 				'format' => 'avif',
@@ -37,7 +37,7 @@ return [
 
 		// This is the #816 failure mode: the API returned the original (non-converted) JPEG
 		// bytes instead of a WebP file. Must NOT be mistaken for the requested format.
-		'shouldRejectOriginalBytesAsWebp'   => [
+		'shouldRejectOriginalBytesAsWebp'    => [
 			'config'   => [
 				'header' => "\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01",
 				'format' => 'webp',
@@ -48,7 +48,7 @@ return [
 		],
 
 		// Same failure mode, requested as AVIF.
-		'shouldRejectOriginalBytesAsAvif'   => [
+		'shouldRejectOriginalBytesAsAvif'    => [
 			'config'   => [
 				'header' => "\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01",
 				'format' => 'avif',
@@ -59,7 +59,7 @@ return [
 		],
 
 		// A WebP file must not be mistaken for an AVIF file.
-		'shouldRejectWebpAsAvif'            => [
+		'shouldRejectWebpAsAvif'             => [
 			'config'   => [
 				'header' => "RIFF\x00\x00\x00\x00WEBP",
 				'format' => 'avif',
@@ -70,7 +70,7 @@ return [
 		],
 
 		// An AVIF file must not be mistaken for a WebP file.
-		'shouldRejectAvifAsWebp'            => [
+		'shouldRejectAvifAsWebp'             => [
 			'config'   => [
 				'header' => "\x00\x00\x00\x1cftypavif",
 				'format' => 'webp',
@@ -80,8 +80,31 @@ return [
 			],
 		],
 
+		// A HEIF-family major brand ("mif1") with "avif" only among the compatible brands is a
+		// legitimate AVIF file and must be recognized as such.
+		'shouldDetectAvifViaCompatibleBrand' => [
+			'config'   => [
+				'header' => "\x00\x00\x00\x18ftypmif1\x00\x00\x00\x00mif1avif",
+				'format' => 'avif',
+			],
+			'expected' => [
+				'result' => true,
+			],
+		],
+
+		// A non-AVIF ftyp box (e.g. MP4) with no "avif"/"avis" anywhere must still be rejected.
+		'shouldRejectNonAvifFtypBox'         => [
+			'config'   => [
+				'header' => "\x00\x00\x00\x14ftypmp42\x00\x00\x00\x00mp42",
+				'format' => 'avif',
+			],
+			'expected' => [
+				'result' => false,
+			],
+		],
+
 		// A too-short/empty payload can't be a valid next-gen file.
-		'shouldRejectTruncatedContent'      => [
+		'shouldRejectTruncatedContent'       => [
 			'config'   => [
 				'header' => 'short',
 				'format' => 'webp',
@@ -92,7 +115,7 @@ return [
 		],
 
 		// If the content couldn't be read at all, treat it as a mismatch (fail safe).
-		'shouldRejectWhenContentUnreadable' => [
+		'shouldRejectWhenContentUnreadable'  => [
 			'config'   => [
 				'header' => false,
 				'format' => 'webp',

--- a/Tests/Fixtures/classes/Optimization/File/OptimizeTest.php
+++ b/Tests/Fixtures/classes/Optimization/File/OptimizeTest.php
@@ -1,0 +1,78 @@
+<?php
+
+return [
+	'test_data' => [
+		// This is the actual #816 regression: a next-gen request whose API response carries a
+		// `message` and returns bytes that are NOT the requested format (the original, unconverted
+		// bytes). No next-gen file must be written, and critically the source file must not be
+		// overwritten either.
+		'shouldRejectNonMatchingBytesForNextGenRequest' => [
+			'config'   => [
+				'convert'   => 'avif',
+				'message'   => 'WELL DONE. This image is already compressed, no further compression required',
+				'temp_body' => "\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01",
+			],
+			'expected' => [
+				'result'        => 'wp_error',
+				'error_code'    => 'no_next_gen_returned',
+				'error_message' => 'WELL DONE. This image is already compressed, no further compression required',
+				'move_called'   => false,
+				'delete_called' => true,
+				'destination'   => null,
+			],
+		],
+
+		// Same trap, but the API response carries the other known message. The raw substring
+		// "This image is already compressed" must survive verbatim into the WP_Error message:
+		// AbstractProcess::update_size_optimization_data() greps for it to resolve the status to
+		// `already_optimized`, which is what unblocks the self-healing recovery path.
+		'shouldPreserveRawAlreadyCompressedSubstring'   => [
+			'config'   => [
+				'convert'   => 'webp',
+				'message'   => 'WELL DONE. This image is already compressed, no further compression required',
+				'temp_body' => "\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01",
+			],
+			'expected' => [
+				'result'        => 'wp_error',
+				'error_code'    => 'no_next_gen_returned',
+				'error_message' => 'WELL DONE. This image is already compressed, no further compression required',
+				'move_called'   => false,
+				'delete_called' => true,
+				'destination'   => null,
+			],
+		],
+
+		// A next-gen request whose response carries a `message` but returns genuine next-gen
+		// bytes must still be written to the next-gen path (a `message` isn't always fatal).
+		'shouldAcceptMatchingBytesForNextGenRequest'    => [
+			'config'   => [
+				'convert'   => 'avif',
+				'message'   => 'Some informational message',
+				'temp_body' => "\x00\x00\x00\x1cftypavif",
+			],
+			'expected' => [
+				'result'        => 'response',
+				'move_called'   => true,
+				'delete_called' => false,
+				'destination'   => 'next_gen',
+			],
+		],
+
+		// The #751 guard: a non-conversion request whose response carries a `message` must behave
+		// exactly as before this fix — `convert` cleared, destination is the source path, no
+		// content verification performed.
+		'shouldClearConvertForNonNextGenRequest'        => [
+			'config'   => [
+				'convert'   => '',
+				'message'   => 'WELL DONE. This image is already compressed, no further compression required',
+				'temp_body' => "\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01",
+			],
+			'expected' => [
+				'result'        => 'response',
+				'move_called'   => true,
+				'delete_called' => false,
+				'destination'   => 'source',
+			],
+		],
+	],
+];

--- a/Tests/Fixtures/classes/Optimization/Process/IsNextGenFileMissingTest.php
+++ b/Tests/Fixtures/classes/Optimization/Process/IsNextGenFileMissingTest.php
@@ -1,0 +1,56 @@
+<?php
+
+return [
+	'test_data' => [
+		// The next-gen file actually exists on disk: not missing.
+		'shouldReturnFalseWhenAvifFileExists'   => [
+			'config'   => [
+				'size'          => 'thumbnail@imagify-avif',
+				'original_path' => '/uploads/thumbnail.jpg',
+				'next_gen_path' => '/uploads/thumbnail.jpg.avif',
+				'file_exists'   => true,
+			],
+			'expected' => [
+				'result' => false,
+			],
+		],
+
+		// The data says success, but the AVIF file is gone: this is the #816 stale-data case.
+		'shouldReturnTrueWhenAvifFileIsMissing' => [
+			'config'   => [
+				'size'          => 'thumbnail@imagify-avif',
+				'original_path' => '/uploads/thumbnail.jpg',
+				'next_gen_path' => '/uploads/thumbnail.jpg.avif',
+				'file_exists'   => false,
+			],
+			'expected' => [
+				'result' => true,
+			],
+		],
+
+		// Same, for the WebP format.
+		'shouldReturnFalseWhenWebpFileExists'   => [
+			'config'   => [
+				'size'          => 'thumbnail@imagify-webp',
+				'original_path' => '/uploads/thumbnail.jpg',
+				'next_gen_path' => '/uploads/thumbnail.jpg.webp',
+				'file_exists'   => true,
+			],
+			'expected' => [
+				'result' => false,
+			],
+		],
+
+		'shouldReturnTrueWhenWebpFileIsMissing' => [
+			'config'   => [
+				'size'          => 'thumbnail@imagify-webp',
+				'original_path' => '/uploads/thumbnail.jpg',
+				'next_gen_path' => '/uploads/thumbnail.jpg.webp',
+				'file_exists'   => false,
+			],
+			'expected' => [
+				'result' => true,
+			],
+		],
+	],
+];

--- a/Tests/Fixtures/classes/Optimization/Process/OptimizeSizeAlreadyOptimizedTest.php
+++ b/Tests/Fixtures/classes/Optimization/Process/OptimizeSizeAlreadyOptimizedTest.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+	'test_data' => [
+		// The data says success and the next-gen file is actually present: must still bail out
+		// with the "already optimized" error, exactly as before this fix.
+		'shouldBailOutWhenNextGenFileExists'       => [
+			'config'   => [
+				'file_exists' => true,
+			],
+			'expected' => [
+				'bails_out' => true,
+			],
+		],
+
+		// The data says success but the next-gen file is missing on disk (the #816 stale-data
+		// case): must NOT bail out, and instead fall through so the file gets regenerated.
+		'shouldNotBailOutWhenNextGenFileIsMissing' => [
+			'config'   => [
+				'file_exists' => false,
+			],
+			'expected' => [
+				'bails_out' => false,
+			],
+		],
+	],
+];

--- a/Tests/Unit/classes/Optimization/File/IsFileFormatTest.php
+++ b/Tests/Unit/classes/Optimization/File/IsFileFormatTest.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Optimization\File;
+
+use Imagify\Optimization\File;
+use Imagify\Tests\Unit\TestCase;
+use Mockery;
+
+/**
+ * Tests for \Imagify\Optimization\File::is_file_format().
+ *
+ * @covers \Imagify\Optimization\File::is_file_format
+ * @group  Optimization
+ */
+class IsFileFormatTest extends TestCase {
+
+	/**
+	 * Path used for the fake file under test.
+	 *
+	 * @var string
+	 */
+	private $path = '/tmp/fake-download-tmpfile';
+
+	/**
+	 * Builds a File instance with a mocked filesystem injected, bypassing the real
+	 * constructor (which requires Imagify_Filesystem::get_instance(), unavailable here).
+	 *
+	 * @param \Mockery\MockInterface $filesystem Mock for the Imagify_Filesystem dependency.
+	 *
+	 * @return File
+	 */
+	private function make_file( $filesystem ): File {
+		$file = ( new \ReflectionClass( File::class ) )->newInstanceWithoutConstructor();
+
+		$this->setPropertyValue( 'path', $file, $this->path );
+		$this->setPropertyValue( 'filesystem', $file, $filesystem );
+
+		return $file;
+	}
+
+	/**
+	 * Tests is_file_format() against genuine and mismatched next-gen payloads.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param array $expected Expected results.
+	 */
+	public function testShouldReturnExpected( $config, $expected ): void {
+		$filesystem = Mockery::mock();
+		$filesystem->shouldReceive( 'get_contents' )
+			->with( $this->path )
+			->andReturn( $config['header'] );
+
+		$file = $this->make_file( $filesystem );
+
+		$method = ( new \ReflectionClass( File::class ) )->getMethod( 'is_file_format' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $file, $this->path, $config['format'] );
+
+		$this->assertSame( $expected['result'], $result );
+	}
+}

--- a/Tests/Unit/classes/Optimization/File/OptimizeTest.php
+++ b/Tests/Unit/classes/Optimization/File/OptimizeTest.php
@@ -1,0 +1,164 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Optimization\File;
+
+use Brain\Monkey\Functions;
+use Imagify\Optimization\File;
+use Imagify\Tests\Unit\TestCase;
+use Mockery;
+use WP_Error;
+
+/**
+ * Tests for \Imagify\Optimization\File::optimize() — the wiring between the API `message`
+ * guard, the next-gen bytes verification, and the file write destination.
+ *
+ * `Imagify_Requirements` is a legacy classmap-autoloaded class; it is stubbed via a Mockery
+ * alias mock in setUp(), so every test in this class runs in its own process
+ * (`@runTestsInSeparateProcesses`) to guarantee the alias is registered before the real class
+ * would otherwise be autoloaded.
+ *
+ * @covers \Imagify\Optimization\File::optimize
+ * @covers \Imagify\Optimization\File::is_file_format
+ * @group  Optimization
+ * @runTestsInSeparateProcesses
+ */
+class OptimizeTest extends TestCase {
+
+	/**
+	 * Path used for the fake source file under test.
+	 *
+	 * @var string
+	 */
+	private $path = '/uploads/thumbnail.jpg';
+
+	/**
+	 * Path to the (fake) temp file returned by download_url().
+	 *
+	 * @var string
+	 */
+	private $temp_file = '/tmp/download-xyz.tmp';
+
+	/**
+	 * Stubs the globals needed to reach the code under test.
+	 *
+	 * @inheritDoc
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		Functions\when( '__' )->returnArg( 1 );
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+		Functions\when( 'do_action' )->justReturn( null );
+		Functions\when( 'do_action_deprecated' )->justReturn( null );
+		Functions\when( 'wp_check_filetype' )->justReturn(
+			[
+				'ext'  => 'jpg',
+				'type' => 'image/jpeg',
+			]
+		);
+
+		Mockery::mock( 'alias:Imagify_Requirements' )
+			->shouldReceive( 'is_imagify_blocked' )
+			->andReturn( false );
+	}
+
+	/**
+	 * Builds a File instance with a mocked filesystem injected, bypassing the real
+	 * constructor (which requires Imagify_Filesystem::get_instance(), unavailable here).
+	 *
+	 * @param \Mockery\MockInterface $filesystem Mock for the Imagify_Filesystem dependency.
+	 *
+	 * @return File
+	 */
+	private function make_file( $filesystem ): File {
+		$file = ( new \ReflectionClass( File::class ) )->newInstanceWithoutConstructor();
+
+		$this->setPropertyValue( 'path', $file, $this->path );
+		$this->setPropertyValue( 'filesystem', $file, $filesystem );
+
+		return $file;
+	}
+
+	/**
+	 * Tests the message-guard / bytes-verification wiring in optimize().
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param array $expected Expected results.
+	 */
+	public function testShouldReturnExpected( $config, $expected ): void {
+		$response = (object) [
+			'image'         => 'https://api.imagify.io/dl/xyz',
+			'original_size' => 1000,
+			'new_size'      => 900,
+			'percent'       => 10,
+		];
+
+		if ( null !== $config['message'] ) {
+			$response->message = $config['message'];
+		}
+
+		Functions\when( 'upload_imagify_image' )->justReturn( $response );
+		Functions\when( 'download_url' )->justReturn( $this->temp_file );
+
+		$filesystem         = Mockery::mock( \stdClass::class );
+		$filesystem->errors = (object) [ 'errors' => [] ];
+		$filesystem->shouldReceive( 'exists' )->with( $this->path )->andReturn( true );
+		$filesystem->shouldReceive( 'is_file' )->with( $this->path )->andReturn( true );
+		$filesystem->shouldReceive( 'is_writable' )->andReturn( true );
+		$filesystem->shouldReceive( 'dir_path' )->andReturn( '/uploads/' );
+		$filesystem->shouldReceive( 'get_contents' )->with( $this->temp_file )->andReturn( $config['temp_body'] );
+
+		$next_gen_path = $this->path . '.' . $config['convert'];
+
+		if ( $expected['move_called'] ) {
+			$destination = 'next_gen' === $expected['destination'] ? $next_gen_path : $this->path;
+
+			$filesystem->shouldReceive( 'move' )
+				->once()
+				->with( $this->temp_file, $destination, true )
+				->andReturn( true );
+		} else {
+			$filesystem->shouldNotReceive( 'move' );
+		}
+
+		if ( $expected['delete_called'] ) {
+			$filesystem->shouldReceive( 'delete' )->once()->with( $this->temp_file );
+		} else {
+			$filesystem->shouldNotReceive( 'delete' );
+		}
+
+		$file = $this->make_file( $filesystem );
+
+		$result = $file->optimize(
+			[
+				'backup'  => false,
+				'convert' => $config['convert'],
+			]
+		);
+
+		if ( 'wp_error' === $expected['result'] ) {
+			$this->assertInstanceOf( WP_Error::class, $result );
+			$this->assertSame( $expected['error_code'], $result->get_error_code() );
+			// The raw API message must survive verbatim: AbstractProcess::
+			// update_size_optimization_data() greps for a substring of it to resolve the
+			// `already_optimized` status, which unblocks the self-healing recovery path.
+			$this->assertSame( $expected['error_message'], $result->get_error_message() );
+
+			// Neither the next-gen path nor the source file was touched: this is the actual
+			// #816 assertion (the bug both failed to create the next-gen file AND overwrote
+			// the source with the wrong bytes).
+			$this->assertSame( $this->path, $file->get_path() );
+		} else {
+			$this->assertSame( $response, $result );
+
+			if ( 'next_gen' === $expected['destination'] ) {
+				$this->assertSame( $next_gen_path, $file->get_path() );
+			} else {
+				$this->assertSame( $this->path, $file->get_path() );
+			}
+		}
+	}
+}

--- a/Tests/Unit/classes/Optimization/Process/IsNextGenFileMissingTest.php
+++ b/Tests/Unit/classes/Optimization/Process/IsNextGenFileMissingTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Optimization\Process;
+
+use Imagify\Optimization\Process\WP;
+use Imagify\Tests\Unit\TestCase;
+use Mockery;
+
+/**
+ * Tests for \Imagify\Optimization\Process\AbstractProcess::is_next_gen_file_missing().
+ *
+ * @covers \Imagify\Optimization\Process\AbstractProcess::is_next_gen_file_missing
+ * @group  Optimization
+ */
+class IsNextGenFileMissingTest extends TestCase {
+
+	/**
+	 * Builds a process instance with a mocked filesystem injected, bypassing the real
+	 * constructor (which requires Imagify_Filesystem::get_instance(), unavailable here).
+	 *
+	 * @param \Mockery\MockInterface $filesystem Mock for the Imagify_Filesystem dependency.
+	 *
+	 * @return WP
+	 */
+	private function make_process( $filesystem ): WP {
+		$process = ( new \ReflectionClass( WP::class ) )->newInstanceWithoutConstructor();
+
+		$this->setPropertyValue( 'filesystem', $process, $filesystem );
+
+		return $process;
+	}
+
+	/**
+	 * Tests is_next_gen_file_missing() for both next-gen formats, file present and missing.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param array $expected Expected results.
+	 */
+	public function testShouldReturnExpected( $config, $expected ): void {
+		$filesystem = Mockery::mock();
+		$filesystem->shouldReceive( 'exists' )
+			->with( $config['next_gen_path'] )
+			->andReturn( $config['file_exists'] );
+
+		$process = $this->make_process( $filesystem );
+
+		$method = ( new \ReflectionClass( WP::class ) )->getMethod( 'is_next_gen_file_missing' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $process, $config['size'], $config['original_path'] );
+
+		$this->assertSame( $expected['result'], $result );
+	}
+}

--- a/Tests/Unit/classes/Optimization/Process/OptimizeSizeAlreadyOptimizedTest.php
+++ b/Tests/Unit/classes/Optimization/Process/OptimizeSizeAlreadyOptimizedTest.php
@@ -1,0 +1,184 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Optimization\Process;
+
+use Brain\Monkey\Functions;
+use Imagify\Optimization\Process\WP;
+use Imagify\Tests\Unit\TestCase;
+use Mockery;
+use WP_Error;
+
+/**
+ * Tests for \Imagify\Optimization\Process\AbstractProcess::optimize_size() — the
+ * "already optimized" bail must not fire for a next-gen size whose file is missing.
+ *
+ * `Imagify_Filesystem` and `Imagify_Options` are legacy classmap-autoloaded classes; they are
+ * stubbed via Mockery alias mocks in the "falls through" case, so every test in this class runs
+ * in its own process (`@runTestsInSeparateProcesses`) to guarantee the aliases are registered
+ * before the real classes would otherwise be autoloaded.
+ *
+ * @covers \Imagify\Optimization\Process\AbstractProcess::optimize_size
+ * @covers \Imagify\Optimization\Process\AbstractProcess::is_next_gen_file_missing
+ * @group  Optimization
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class OptimizeSizeAlreadyOptimizedTest extends TestCase {
+
+	/**
+	 * The (next-gen) size name under test. Must use the "webp" suffix: unit tests stub
+	 * imagify_nextgen_images_formats() to only return the webp format (see
+	 * Tests/Fixtures/inc/functions/nextgen-images-formats.php).
+	 *
+	 * @var string
+	 */
+	private $size = 'thumbnail@imagify-webp';
+
+	/**
+	 * The non-next-gen size name.
+	 *
+	 * @var string
+	 */
+	private $thumb_size = 'thumbnail';
+
+	/**
+	 * Path to the non-next-gen version of the size.
+	 *
+	 * @var string
+	 */
+	private $original_path = '/uploads/thumbnail.jpg';
+
+	/**
+	 * Path to the next-gen version of the size.
+	 *
+	 * @var string
+	 */
+	private $next_gen_path = '/uploads/thumbnail.jpg.webp';
+
+	/**
+	 * Stubs the globals needed to reach the bail decision under test.
+	 *
+	 * @inheritDoc
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		Functions\when( '__' )->returnArg( 1 );
+		Functions\when( 'esc_html' )->returnArg( 1 );
+		Functions\when( 'do_action' )->justReturn( null );
+
+		// Short-circuit `imagify_before_optimize_size` with a WP_Error: this is the earliest
+		// point past the bail under test where we can stop the method deterministically,
+		// without needing to wire up the rest of the (unrelated) optimization flow. Every
+		// other filter is passed through unchanged.
+		Functions\when( 'apply_filters' )->alias(
+			function () {
+				$args = func_get_args();
+
+				if ( 'imagify_before_optimize_size' === $args[0] ) {
+					return new WP_Error( 'short_circuited_by_test', 'Short-circuited by test.' );
+				}
+
+				return $args[1] ?? null;
+			}
+		);
+	}
+
+	/**
+	 * Builds a process instance with mocked collaborators injected, bypassing the real
+	 * constructor (which requires a full WordPress environment, unavailable here).
+	 *
+	 * @param \Mockery\MockInterface $data       Mock for the DataInterface dependency.
+	 * @param \Mockery\MockInterface $filesystem Mock for the Imagify_Filesystem dependency.
+	 *
+	 * @return WP
+	 */
+	private function make_process( $data, $filesystem ): WP {
+		$process = ( new \ReflectionClass( WP::class ) )->newInstanceWithoutConstructor();
+
+		$this->setPropertyValue( 'data', $process, $data );
+		$this->setPropertyValue( 'filesystem', $process, $filesystem );
+
+		return $process;
+	}
+
+	/**
+	 * Tests the bail decision at the top of optimize_size() for a next-gen size whose data
+	 * says `success`.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param array $expected Expected results.
+	 */
+	public function testShouldReturnExpected( $config, $expected ): void {
+		$media = Mockery::mock();
+		$media->shouldReceive( 'is_valid' )->andReturn( true );
+		$media->shouldReceive( 'get_media_files' )->andReturn(
+			[
+				$this->thumb_size => [ 'path' => $this->original_path ],
+			]
+		);
+		$media->shouldReceive( 'get_allowed_mime_types' )->andReturn( [ 'image/jpeg' ] );
+
+		$data = Mockery::mock();
+		$data->shouldReceive( 'get_media' )->andReturn( $media );
+		$data->shouldReceive( 'get_size_data' )->with( $this->size, 'success' )->andReturn( true );
+
+		$filesystem = Mockery::mock();
+		$filesystem->shouldReceive( 'exists' )
+			->with( $this->next_gen_path )
+			->andReturn( $config['file_exists'] );
+
+		if ( $expected['bails_out'] ) {
+			// If it bails out, the rest of the method (and its collaborators) must never run.
+			$data->shouldNotReceive( 'get_size_data' )->with( $this->thumb_size, 'success' );
+			$data->shouldNotReceive( 'update_size_optimization_data' );
+		} else {
+			$data->shouldReceive( 'get_size_data' )->with( $this->thumb_size, 'success' )->andReturn( false );
+			$data->shouldReceive( 'update_size_optimization_data' )->once()->andReturnNull();
+
+			Functions\when( 'wp_check_filetype' )->justReturn(
+				[
+					'ext'  => 'jpg',
+					'type' => 'image/jpeg',
+				]
+			);
+
+			// Falling through reaches `new File( $path )`, whose constructor needs
+			// Imagify_Filesystem::get_instance(). The instance is never actually used on
+			// this path: it's short-circuited by the `imagify_before_optimize_size` filter
+			// before any of its methods would be called.
+			Mockery::mock( 'alias:Imagify_Filesystem' )
+				->shouldReceive( 'get_instance' )
+				->andReturn( Mockery::mock() );
+
+			// sanitize_optimization_level() unconditionally goes through Imagify_Options for
+			// a numeric level. Pass the value straight through: it's the level we already
+			// provided.
+			Mockery::mock( 'alias:Imagify_Options' )
+				->shouldReceive( 'get_instance->sanitize_and_validate' )
+				->andReturnUsing(
+					function ( $key, $value ) {
+						return $value;
+					}
+				);
+		}
+
+		$process = $this->make_process( $data, $filesystem );
+
+		$result = $process->optimize_size( $this->size, 0 );
+
+		if ( $expected['bails_out'] ) {
+			$this->assertInstanceOf( WP_Error::class, $result );
+			$this->assertSame( 'size_is_successfully_optimized', $result->get_error_code() );
+		} else {
+			// It fell through: the method reached the (short-circuited) optimization flow and
+			// returned the recorded optimization data, not the early bail's WP_Error.
+			$this->assertIsArray( $result );
+			$this->assertSame( 'error', $result['status'] );
+		}
+	}
+}

--- a/classes/Optimization/File.php
+++ b/classes/Optimization/File.php
@@ -940,7 +940,7 @@ class File {
 	 * magic bytes. The file's extension can't be trusted here, since it may be a temp
 	 * file downloaded with an unpredictable name (see download_url()).
 	 *
-	 * @since 2.2
+	 * @since 2.3.2
 	 *
 	 * @param string $file_path Absolute path to the file to check.
 	 * @param string $format    'webp' or 'avif'.
@@ -971,7 +971,7 @@ class File {
 	 * `mif1`/`msf1` (generic HEIF-family brands) while listing `avif` only among the compatible
 	 * brands, so both must be checked.
 	 *
-	 * @since 2.2
+	 * @since 2.3.2
 	 *
 	 * @param string $contents The file content (or at least its leading bytes).
 	 * @return bool

--- a/classes/Optimization/File.php
+++ b/classes/Optimization/File.php
@@ -628,15 +628,36 @@ class File {
 			return new \WP_Error( 'temp_file_not_found', $temp_file->get_error_message() );
 		}
 
-		if ( property_exists( $response, 'message' ) ) {
-			$args['convert'] = '';
-		}
-
-		$formats = [
+		$formats            = [
 			'webp',
 			'avif',
 		];
-		if ( in_array( $args['convert'], $formats, true ) ) {
+		$is_nextgen_request = in_array( $args['convert'], $formats, true );
+
+		if ( property_exists( $response, 'message' ) && ! $is_nextgen_request ) {
+			$args['convert'] = '';
+		}
+
+		if ( $is_nextgen_request && property_exists( $response, 'message' ) ) {
+			/*
+			 * The API can return a `message` alongside the source's own bytes instead of a
+			 * converted file (e.g. "Webp is less performant than original" or "already
+			 * compressed"). In that case the downloaded file is NOT the requested next-gen
+			 * format. Writing it to the next-gen path would create a corrupt file, and
+			 * writing it to `$this->path` would overwrite the original thumbnail. Verify the
+			 * actual bytes before doing either.
+			 */
+			if ( ! $this->is_file_format( $temp_file, $args['convert'] ) ) {
+				$this->filesystem->delete( $temp_file );
+
+				return new \WP_Error(
+					'no_next_gen_returned',
+					$response->message
+				);
+			}
+		}
+
+		if ( $is_nextgen_request ) {
 			$destination_path = $this->get_path_to_nextgen( $args['convert'] );
 			$this->path       = $destination_path;
 			$this->file_type  = null;
@@ -912,6 +933,41 @@ class File {
 	 */
 	public function is_avif() {
 		return preg_match( '@(?!^|/|\\\)\.avif$@i', $this->path );
+	}
+
+	/**
+	 * Tell if a file's actual content matches the given next-gen format, by reading its
+	 * magic bytes. The file's extension can't be trusted here, since it may be a temp
+	 * file downloaded with an unpredictable name (see download_url()).
+	 *
+	 * @since 2.2
+	 *
+	 * @param string $file_path Absolute path to the file to check.
+	 * @param string $format    'webp' or 'avif'.
+	 * @return bool
+	 */
+	protected function is_file_format( $file_path, $format ) {
+		$contents = $this->filesystem->get_contents( $file_path );
+
+		if ( ! is_string( $contents ) || strlen( $contents ) < 12 ) {
+			return false;
+		}
+
+		$header = substr( $contents, 0, 12 );
+
+		if ( 'webp' === $format ) {
+			// RIFF....WEBP.
+			return 'RIFF' === substr( $header, 0, 4 ) && 'WEBP' === substr( $header, 8, 4 );
+		}
+
+		if ( 'avif' === $format ) {
+			// ISO-BMFF box: bytes 4-7 are "ftyp", followed by a brand like "avif"/"avis".
+			$brand = substr( $header, 8, 4 );
+
+			return 'ftyp' === substr( $header, 4, 4 ) && ( 'avif' === $brand || 'avis' === $brand );
+		}
+
+		return false;
 	}
 
 	/**

--- a/classes/Optimization/File.php
+++ b/classes/Optimization/File.php
@@ -953,18 +953,50 @@ class File {
 			return false;
 		}
 
-		$header = substr( $contents, 0, 12 );
-
 		if ( 'webp' === $format ) {
 			// RIFF....WEBP.
-			return 'RIFF' === substr( $header, 0, 4 ) && 'WEBP' === substr( $header, 8, 4 );
+			return 'RIFF' === substr( $contents, 0, 4 ) && 'WEBP' === substr( $contents, 8, 4 );
 		}
 
 		if ( 'avif' === $format ) {
-			// ISO-BMFF box: bytes 4-7 are "ftyp", followed by a brand like "avif"/"avis".
-			$brand = substr( $header, 8, 4 );
+			return $this->is_avif_ftyp_box( $contents );
+		}
 
-			return 'ftyp' === substr( $header, 4, 4 ) && ( 'avif' === $brand || 'avis' === $brand );
+		return false;
+	}
+
+	/**
+	 * Tell if the given content starts with an AVIF `ftyp` box, i.e. its major brand or one of
+	 * its compatible brands is `avif`/`avis`. A file can legitimately declare a major brand of
+	 * `mif1`/`msf1` (generic HEIF-family brands) while listing `avif` only among the compatible
+	 * brands, so both must be checked.
+	 *
+	 * @since 2.2
+	 *
+	 * @param string $contents The file content (or at least its leading bytes).
+	 * @return bool
+	 */
+	private function is_avif_ftyp_box( $contents ) {
+		if ( 'ftyp' !== substr( $contents, 4, 4 ) ) {
+			return false;
+		}
+
+		$avif_brands = [ 'avif', 'avis' ];
+
+		if ( in_array( substr( $contents, 8, 4 ), $avif_brands, true ) ) {
+			// Major brand.
+			return true;
+		}
+
+		// Box size (big-endian uint32), bounding how far the compatible brands list extends.
+		$box_size = unpack( 'N', substr( $contents, 0, 4 ) )[1];
+		$box_size = min( $box_size, strlen( $contents ) );
+
+		// Compatible brands: 4-byte entries, starting right after the minor version, at offset 16.
+		for ( $offset = 16; $offset + 4 <= $box_size; $offset += 4 ) {
+			if ( in_array( substr( $contents, $offset, 4 ), $avif_brands, true ) ) {
+				return true;
+			}
 		}
 
 		return false;

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -505,26 +505,36 @@ abstract class AbstractProcess implements ProcessInterface {
 			);
 		}
 
-		if ( $this->get_data()->get_size_data( $size, 'success' ) ) { // Bail out.
-			// This size is already optimized with Imagify, and must not be optimized again.
-			if ( $next_gen ) {
-				return new WP_Error(
-					'size_is_successfully_optimized',
-					sprintf(
-					/* translators: %s is a size name. */
-						__( 'The Next-Gen format for the size %s already exists.', 'imagify' ),
-						'<code>' . esc_html( $thumb_size ) . '</code>'
-					)
-				);
-			} else {
-				return new WP_Error(
-					'size_is_successfully_optimized',
-					sprintf(
-					/* translators: %s is a size name. */
-						__( 'The size %s is already optimized by Imagify.', 'imagify' ),
-						'<code>' . esc_html( $thumb_size ) . '</code>'
-					)
-				);
+		if ( $this->get_data()->get_size_data( $size, 'success' ) ) {
+			/*
+			 * The data says this size is already optimized. For a next-gen size, this can be
+			 * stale: an API response carrying a `message` (see File::optimize()) could have
+			 * been recorded as `success` without any next-gen file ever being written. In that
+			 * case, don't bail out: fall through and let the file be (re)generated.
+			 */
+			$next_gen_file_is_missing = $next_gen && $this->is_next_gen_file_missing( $size, $sizes[ $thumb_size ]['path'] );
+
+			if ( ! $next_gen_file_is_missing ) { // Bail out.
+				// This size is already optimized with Imagify, and must not be optimized again.
+				if ( $next_gen ) {
+					return new WP_Error(
+						'size_is_successfully_optimized',
+						sprintf(
+						/* translators: %s is a size name. */
+							__( 'The Next-Gen format for the size %s already exists.', 'imagify' ),
+							'<code>' . esc_html( $thumb_size ) . '</code>'
+						)
+					);
+				} else {
+					return new WP_Error(
+						'size_is_successfully_optimized',
+						sprintf(
+						/* translators: %s is a size name. */
+							__( 'The size %s is already optimized by Imagify.', 'imagify' ),
+							'<code>' . esc_html( $thumb_size ) . '</code>'
+						)
+					);
+				}
 			}
 		}
 
@@ -1569,6 +1579,22 @@ abstract class AbstractProcess implements ProcessInterface {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Tell if the next-gen file for a size is missing from disk.
+	 *
+	 * @since 2.2
+	 *
+	 * @param string $size          The (next-gen) size name, e.g. "thumbnail@imagify-avif".
+	 * @param string $original_path Path to the non-next-gen version of that size.
+	 * @return bool
+	 */
+	protected function is_next_gen_file_missing( string $size, string $original_path ): bool {
+		$format        = strpos( $size, static::AVIF_SUFFIX ) ? 'avif' : 'webp';
+		$next_gen_path = imagify_path_to_nextgen( $original_path, $format );
+
+		return ! $next_gen_path || ! $this->filesystem->exists( $next_gen_path );
 	}
 
 	/**

--- a/classes/Optimization/Process/AbstractProcess.php
+++ b/classes/Optimization/Process/AbstractProcess.php
@@ -1584,7 +1584,7 @@ abstract class AbstractProcess implements ProcessInterface {
 	/**
 	 * Tell if the next-gen file for a size is missing from disk.
 	 *
-	 * @since 2.2
+	 * @since 2.3.2
 	 *
 	 * @param string $size          The (next-gen) size name, e.g. "thumbnail@imagify-avif".
 	 * @param string $original_path Path to the non-next-gen version of that size.


### PR DESCRIPTION
# Description

Fixes #816

When the **lossless** setting is enabled, Next-Gen files (AVIF, and WebP in the same conditions) were never generated for images the Imagify API considers already compressed — typically small images. Re-optimizing did not help: the media stayed permanently stuck without a Next-Gen version.

Worse, the same code path could move the API's returned bytes **over the user's original thumbnail**.

Both are fixed, and media already broken by this now self-heal on the next optimization pass.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

**Manual — performed against a real Imagify API key** on a Local WP install (PHP 8.4, backups enabled, `lossless = 1`, `optimization_format = avif`). These are the exact steps run, not a suggestion:

1. Set `lossless = 1` and `optimization_format = avif`; confirmed `imagify_nextgen_images_formats()` returned `['avif' => 'avif']`.
2. On **`develop`**, imported a small PNG (attachment 112) and let auto-optimization run.
3. Inspected `_imagify_data`: all three AVIF sizes recorded `success = true`.
4. Searched the uploads tree for `*.avif` for that attachment → **zero files on disk**. Phantom success reproduced. Other attachments on the same site did have `.avif` files, confirming AVIF generation works there generally.
5. Checked out **this branch**, imported the same source image (attachment 113), let it optimize.
6. Inspected `_imagify_data`: all three AVIF sizes now `success = false`, error recorded as `Avif is less performant than original`. No phantom success.
7. No-regression check: imported a 3456×2234 PNG on this branch (attachment 114) → **6/6 AVIF sizes succeeded and 6 `.avif` files were written to disk**, confirming the magic-byte check does not block genuine AVIF.
8. Restored the site's original Imagify settings.

**Result:** the phantom success is gone, the real reason is surfaced, and genuine AVIF conversion is unaffected.


### How to test

These steps were run and are reproducible as written. Note the expected outcome for a small image is **no `.avif` file** — that is correct, and the fix is about the recorded status, not about forcing a conversion the API declined.

1. Install and activate Imagify with a valid API key, backups enabled.
2. Settings → enable **lossless compression** and set the Next-Gen format to **AVIF**. Confirm `imagify_nextgen_images_formats()` returns `['avif' => 'avif']`.
3. On `develop`, upload a **small** image and let it optimize.
4. Inspect `_imagify_data` for that attachment: the `…@imagify-avif` sizes report `success = true`.
5. Search the uploads tree for `*.avif` for that attachment: **no files exist.** That mismatch is the bug — the plugin reports conversions that never happened.
6. Switch to this branch and upload the same image again.
7. Inspect `_imagify_data`: the AVIF sizes now report `success = false` with the error `Avif is less performant than original`. Still no `.avif` on disk, which is correct — the API declined because AVIF would be larger than the original.
8. **No-regression check:** upload a large image (e.g. 3456×2234) on this branch. AVIF sizes must report success **and** the matching `<file>.<ext>.avif` files must exist on disk. This proves the byte verification does not block genuine AVIF.
9. **PR #751 regression check:** with the format set to **WebP** and an image whose WebP would exceed the original, confirm no `.webp` is created and the original is written back as before.
10. Confirm the source image itself was not rewritten by the next-gen pass.
11. **Self-healing check:** on media already poisoned by this bug (data says success, no `.avif` on disk), run *Generate missing Next-Gen versions* — the size must be re-attempted rather than skipped.

### Affected Features & Quality Assurance Scope

- **Next-Gen generation (AVIF + WebP)** — the primary change. Both single-media optimization and bulk.
- **Lossless / optimization level 0** — the setting that surfaces the bug, though the fix is level-agnostic.
- **PR #751 behaviour** ("WebP is larger than the original") — explicitly preserved and now pinned by a test.
- **Generate missing Next-Gen versions** — benefits from the self-healing path.
- **Media library optimization data** — sizes that previously recorded a false `success` now record a proper error/`already_optimized` status.

## Technical description

### Documentation

**Root cause.** `File::optimize()` cleared `$args['convert']` whenever the API response carried a `message`:

```php
if ( property_exists( $response, 'message' ) ) {
    $args['convert'] = '';
}
```

That guard was added on 2023-11-13 (`93d69647`, PR #751) for the *"Webp is less performant than original"* case, where the API deliberately returns the original bytes and writing them back to the source is correct.

Four months later, on 2024-03-06, AVIF support (`5684433e`) added the conversion-destination branch immediately below it:

```php
if ( in_array( $args['convert'], $formats, true ) ) {
    $destination_path = $this->get_path_to_nextgen( $args['convert'] );
} else {
    $destination_path = $this->path;   // <- the source file
}
```

The older guard was never revisited. Clearing `convert` now silently reroutes the destination onto the **source file**, so no Next-Gen file is ever written and the downloaded bytes land on the original thumbnail.

**Why `lossless` is the trigger.** The setting pins the optimization level to `0` (`AbstractProcess::sanitize_optimization_level()`), and at level 0 a small image very often earns the API message *"WELL DONE. This image is already compressed, no further compression required"*. The defect itself is format-agnostic — there is no AVIF-specific branch anywhere on this path.

**Why it was sticky.** The response is not a `WP_Error`, so the size was stored as `status => 'success'` with no file on disk. `AbstractProcess::optimize()`'s recovery branch only fires for `already_optimized`, never `success`, so re-optimizing could never repair it — matching the reporter's "even reoptimize lossless won't generate it".

**The fix, in two parts.**

1. *Decide from the bytes, not the message.* `$is_nextgen_request` is captured **before** the guard, so the non-conversion path is preserved bit-for-bit. For a conversion request, the downloaded temp file is verified against the requested format via magic bytes (`RIFF….WEBP`; an ISO-BMFF `ftyp` box for AVIF, checking the major brand and then walking the compatible-brands list so a `mif1`/`msf1` major with `avif` compatible is still accepted). Matching bytes are written to the Next-Gen path; non-matching bytes return `WP_Error( 'no_next_gen_returned' )` and **nothing is written**. This is deliberately safe under both API behaviours — whether it returns a real AVIF or the untouched original, we never produce a corrupt `.avif` and never clobber the source.

   The `WP_Error` carries the **raw** API message, because `update_size_optimization_data()` does a `strpos()` on that raw English text to resolve the status to `already_optimized` rather than `error`.

2. *Self-healing.* `optimize_size()` no longer treats a Next-Gen size's `success` data as final when the file it points to is absent from disk; it falls through and regenerates. This is a read-path check, not a migration — no upgrade hook, no bulk data rewrite.

### New dependencies

None.

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

All mandatory items are ticked. The acceptance criteria were validated both by automated unit tests and by a live run against a real Imagify API key — see the numbered manual steps in *What was tested*, covering the reproduction of the phantom success on `develop`, the corrected behaviour on this branch, and the no-regression check that genuine AVIF conversion still writes files to disk.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
