### PR TITLE
Fix #1210: derive the bulk has-backup check from the true original for scaled uploads

### DIFF
--- a/Tests/Fixtures/classes/Bulk/WP/GetOriginalFilePathFromMetadataTest.php
+++ b/Tests/Fixtures/classes/Bulk/WP/GetOriginalFilePathFromMetadataTest.php
@@ -1,0 +1,84 @@
+<?php
+
+return [
+	'test_data' => [
+		// #1210 regression guard: a WP-scaled image must resolve to the original-derived path,
+		// not the scaled path stored in `_wp_attached_file`.
+		'shouldResolveOriginalPathForScaledImage' => [
+			'config'   => [
+				'file_path' => '/uploads/2024/01/image-scaled.jpg',
+				'metadata'  => [
+					'original_image' => 'image.jpg',
+				],
+			],
+			'expected' => [
+				'result' => '/uploads/2024/01/image.jpg',
+			],
+		],
+
+		// Non-scaled image: metadata has no `original_image`, path must be unchanged.
+		'shouldReturnFilePathUnchangedWhenNotScaled' => [
+			'config'   => [
+				'file_path' => '/uploads/2024/01/image.jpg',
+				'metadata'  => [
+					'width'  => 800,
+					'height' => 600,
+				],
+			],
+			'expected' => [
+				'result' => '/uploads/2024/01/image.jpg',
+			],
+		],
+
+		// Metadata is null (e.g. no `_wp_attachment_metadata` row) must not error and must fall
+		// back to the given file path unchanged.
+		'shouldReturnFilePathUnchangedWhenMetadataIsNull' => [
+			'config'   => [
+				'file_path' => '/uploads/2024/01/image.jpg',
+				'metadata'  => null,
+			],
+			'expected' => [
+				'result' => '/uploads/2024/01/image.jpg',
+			],
+		],
+
+		// Garbage/non-array metadata (e.g. unserialization failed and returned the raw string)
+		// must not error and must fall back to the given file path unchanged.
+		'shouldReturnFilePathUnchangedWhenMetadataIsGarbageString' => [
+			'config'   => [
+				'file_path' => '/uploads/2024/01/image.jpg',
+				'metadata'  => 'not-serialized-data',
+			],
+			'expected' => [
+				'result' => '/uploads/2024/01/image.jpg',
+			],
+		],
+
+		// `original_image` present but empty must fall back to the given file path unchanged.
+		'shouldReturnFilePathUnchangedWhenOriginalImageIsEmpty' => [
+			'config'   => [
+				'file_path' => '/uploads/2024/01/image.jpg',
+				'metadata'  => [
+					'original_image' => '',
+				],
+			],
+			'expected' => [
+				'result' => '/uploads/2024/01/image.jpg',
+			],
+		],
+
+		// `original_image` present but not a string (corrupted metadata) must fall back to the
+		// given file path unchanged, without triggering a PHP warning during concatenation.
+		'shouldReturnFilePathUnchangedWhenOriginalImageIsNotAString' => [
+			'config'   => [
+				'file_path' => '/uploads/2024/01/image.jpg',
+				'metadata'  => [
+					'original_image' => [ 'not', 'a', 'string' ],
+				],
+			],
+			'expected' => [
+				'result' => '/uploads/2024/01/image.jpg',
+			],
+		],
+	],
+];

--- a/Tests/Unit/classes/Bulk/WP/GetOriginalFilePathFromMetadataTest.php
+++ b/Tests/Unit/classes/Bulk/WP/GetOriginalFilePathFromMetadataTest.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Bulk\WP;
+
+use Brain\Monkey\Functions;
+use Imagify\Bulk\WP;
+use Imagify\Tests\Unit\TestCase;
+
+/**
+ * Tests for the private \Imagify\Bulk\WP::get_original_file_path_from_metadata().
+ *
+ * Backups are always written at the path derived from the true original file
+ * (`wp_get_original_image_path()`), while the bulk queries derive `$file_path` from
+ * `_wp_attached_file`, which points to the WP-scaled copy when one exists. This helper mirrors
+ * the original-file derivation from already-batched `_wp_attachment_metadata`, so the bulk
+ * "has backup" checks stop looking for a backup file that never existed for scaled uploads.
+ *
+ * @covers \Imagify\Bulk\WP::get_original_file_path_from_metadata
+ * @group  Bulk
+ */
+class GetOriginalFilePathFromMetadataTest extends TestCase {
+
+	/**
+	 * Regression guard for #1210: a WP-scaled image must resolve its backup path from the
+	 * true original file, not from the scaled path stored in `_wp_attached_file`.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test config: `file_path` and `metadata`.
+	 * @param array $expected Expected `result`.
+	 */
+	public function testShouldReturnExpected( $config, $expected ): void {
+		Functions\when( 'trailingslashit' )->alias(
+			function ( $path ) {
+				return rtrim( $path, '/\\' ) . '/';
+			}
+		);
+
+		$wp = ( new \ReflectionClass( WP::class ) )->newInstanceWithoutConstructor();
+
+		$method = new \ReflectionMethod( WP::class, 'get_original_file_path_from_metadata' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $wp, $config['file_path'], $config['metadata'] );
+
+		$this->assertSame( $expected['result'], $result );
+	}
+}

--- a/classes/Bulk/WP.php
+++ b/classes/Bulk/WP.php
@@ -91,6 +91,8 @@ class WP extends AbstractBulk {
 				'optimization_levels' => '_imagify_optimization_level',
 				// Get attachments status.
 				'statuses'            => '_imagify_status',
+				// Get attachments metadata, to detect a WP-scaled original.
+				'metadata'            => '_wp_attachment_metadata',
 			],
 			$ids
 		);
@@ -156,7 +158,8 @@ class WP extends AbstractBulk {
 				continue;
 			}
 
-			$attachment_backup_path        = get_imagify_attachment_backup_path( $file_path );
+			$original_path                 = $this->get_original_file_path_from_metadata( $file_path, isset( $metas['metadata'][ $id ] ) ? $metas['metadata'][ $id ] : null );
+			$attachment_backup_path        = get_imagify_attachment_backup_path( $original_path );
 			$attachment_status             = isset( $metas['statuses'][ $id ] ) ? $metas['statuses'][ $id ] : false;
 			$attachment_optimization_level = isset( $metas['optimization_levels'][ $id ] ) ? $metas['optimization_levels'][ $id ] : false;
 

--- a/classes/Bulk/WP.php
+++ b/classes/Bulk/WP.php
@@ -221,6 +221,8 @@ class WP extends AbstractBulk {
 			[
 				// Get attachments filename.
 				'filenames' => '_wp_attached_file',
+				// Get attachments metadata, to detect a WP-scaled original.
+				'metadata'  => '_wp_attachment_metadata',
 			],
 			$ids
 		);
@@ -239,7 +241,8 @@ class WP extends AbstractBulk {
 				continue;
 			}
 
-			$attachment_backup_path = get_imagify_attachment_backup_path( $file_path );
+			$original_path          = $this->get_original_file_path_from_metadata( $file_path, isset( $metas['metadata'][ $id ] ) ? $metas['metadata'][ $id ] : null );
+			$attachment_backup_path = get_imagify_attachment_backup_path( $original_path );
 
 			if ( ! $this->filesystem->exists( $attachment_backup_path ) ) {
 				// No backup, cannot restore.
@@ -348,6 +351,8 @@ class WP extends AbstractBulk {
 			[
 				// Get attachments filename.
 				'filenames' => '_wp_attached_file',
+				// Get attachments metadata, to detect a WP-scaled original.
+				'metadata'  => '_wp_attachment_metadata',
 			],
 			$ids
 		);
@@ -384,7 +389,8 @@ class WP extends AbstractBulk {
 				continue;
 			}
 
-			$backup_path = get_imagify_attachment_backup_path( $file_path );
+			$original_path = $this->get_original_file_path_from_metadata( $file_path, isset( $metas['metadata'][ $id ] ) ? $metas['metadata'][ $id ] : null );
+			$backup_path   = get_imagify_attachment_backup_path( $original_path );
 
 			if ( ! $this->filesystem->exists( $backup_path ) ) {
 				// No backup, no WebP.
@@ -396,6 +402,33 @@ class WP extends AbstractBulk {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Get the original (pre-scaling) file path from batched `_wp_attachment_metadata`.
+	 *
+	 * When WordPress scales down an image on upload, `_wp_attached_file` (and therefore
+	 * `$file_path`) points to the scaled copy, but Imagify backups are always stored at the
+	 * path derived from the true original file (see `Imagify\Media\WP::get_raw_backup_path()`,
+	 * which relies on `wp_get_original_image_path()`). This mirrors that derivation from data
+	 * already fetched in a single batched query, instead of instantiating a media object (and
+	 * firing its own uncached meta reads) for every attachment in the loop.
+	 *
+	 * @since 2.4
+	 *
+	 * @param string $file_path Path derived from `_wp_attached_file`.
+	 * @param mixed  $metadata  The unserialized `_wp_attachment_metadata` value for this attachment,
+	 *                          or null/garbage if it couldn't be fetched or decoded.
+	 *
+	 * @return string The original-derived file path, or $file_path unchanged when there is no
+	 *                scaled original to account for.
+	 */
+	private function get_original_file_path_from_metadata( $file_path, $metadata ) {
+		if ( ! is_array( $metadata ) || empty( $metadata['original_image'] ) || ! is_string( $metadata['original_image'] ) ) {
+			return $file_path;
+		}
+
+		return trailingslashit( dirname( $file_path ) ) . $metadata['original_image'];
 	}
 
 	/**


### PR DESCRIPTION
# Description

Fixes #1210

Images that WordPress scaled on upload (anything above `big_image_size_threshold`, 2560px by default) were wrongly treated as having **no backup file** by the bulk pre-filters. As a result:

- **Generate Missing Next-Gen Versions** silently skipped them — the reported symptom in #1210 and #549.
- **Re-running bulk optimization at a different level** silently skipped them too.
- The **restore list** was affected by the same derivation.

Restoring the backup file could never help, because the code was looking for a backup that had never existed under that name. This is why the issue read as "intermittent" for four years: it is fully deterministic per image, but it varies with the image's dimensions rather than with the attempt.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [x] Sub-task of #549
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

**Automated** — 6 new unit tests following the project's fixture pattern (`Tests/Fixtures/…` consumed via `@dataProvider configTestData`), covering the extracted path-resolution helper:

1. Scaled image (metadata carries `original_image`) → resolves to the original-derived path (the #1210 regression guard)
2. Non-scaled image → path returned unchanged
3. `null` metadata → falls back to the attached-file path
4. Garbage (non-array) metadata → safe fallback, no warning
5. Empty `original_image` → safe fallback
6. Non-string `original_image` (array) → safe fallback

**Manual — performed on a real site.** Local WP install, PHP 8.4, real Imagify API key, backups enabled, `big_image_size_threshold` = 2560. Identical DB state on both branches; only the branch changed between runs. These are the exact steps run:

1. Imported a 3456×2234 PNG (attachment **110**) — WordPress scaled it, so `_wp_attached_file` points at `pr1210-big-scaled.png` and the metadata carries `original_image`. Imported a small PNG (attachment **111**) as the non-scaled control.
2. Let both optimize with Next-Gen **disabled**, so they became "optimized, no next-gen version".
3. Confirmed the path divergence directly: the bulk pre-filter looks for `pr1210-big-scaled.png` in the backup directory, while `Media\WP::get_raw_backup_path()` points at `pr1210-big.png`.
4. Found that **both** backup files existed, so the bug did **not** fire — see the caveat below. Removed only `backup/…/pr1210-big-scaled.png`, leaving the true original backup `pr1210-big.png` in place.
5. On **`develop`**, called `Imagify\Bulk\WP::get_optimized_media_ids_without_format()` via WP-CLI, querying a format no media had yet so the backup check was the only possible exclusion → attachment 110 landed in the **`no_backup` bucket and was excluded**, despite a valid backup being present. Control 111 was selected. **Bug reproduced.**
6. Checked out **this branch** and re-ran the identical query against the same data → attachment 110 **selected**, `no_backup` empty, control 111 unchanged. **Fixed.**
7. **Negative check:** removed the original backup too, so the media genuinely had none, and re-ran on this branch → 110 correctly returned to the `no_backup` bucket. The fix does not paper over genuinely missing backups.
8. Restored both backup files and the site's original settings.

| Attachment | `develop` | This PR |
|---|---|---|
| **110** — scaled, valid original backup present | `no_backup`, **excluded** | **selected** ✅ |
| **111** — non-scaled control | selected | selected (unchanged) |
| **110** — no backup at all | — | still `no_backup` ✅ |

**Important caveat for QA — the bug is masked in the default flow.** `Imagify\Optimization\File::backup()` does not only back up the original: when `$backup_source` is set it *also* copies the `-scaled` variant into the backup directory. So after a normal optimization both `image.png` and `image-scaled.png` exist there, the pre-filter finds the `-scaled` file it wrongly looks for, and nothing appears broken — verified empirically at step 4 above.

The bug therefore only fires when the `-scaled` backup is **absent while the original is present**, which happens when: a user deletes and then restores a backup by hand (they restore *the* backup — the original — not both, **which is exactly the #549 / #1210 report and why "restoring the backup doesn't help"**); or the backup was taken without a `$backup_source`, such as the temporary backup at `AbstractProcess.php:423`, which skips the `-scaled` branch entirely; or the `-scaled` file did not exist at backup time.

This makes the real-world blast radius narrower than the issue text implies, and reviewers should weigh that when prioritising. The underlying divergence is still a genuine defect and the fix is still correct.


### How to test

**Step 4 is essential — without it the bug will not reproduce.** See the caveat in *What was tested*.

1. Set up a site with Imagify and a valid API key, backups enabled.
2. Upload an image **wider or taller than 2560px** (so WordPress creates a `-scaled` copy) and one **below** that threshold, with Next-Gen creation **disabled**. Let both optimize.
3. Confirm the path divergence: `_wp_attached_file` for the large image points at `<Y>/<m>/image-scaled.jpg`, while `Media\WP::get_raw_backup_path()` points at `…/backup/<Y>/<m>/image.jpg`.
4. Look in `uploads/backup/<Y>/<m>/` — you will find **both** `image.jpg` and `image-scaled.jpg`, because `File::backup()` also copies the scaled variant. **Delete only `image-scaled.jpg`**, leaving `image.jpg`. This reproduces the state a user reaches after deleting and restoring a backup by hand, which is the reported scenario.
5. Enable Next-Gen creation, then click **Generate Missing Next-Gen Versions**.
   - *Before this PR:* only the small image is processed; the large one is skipped as having no backup, despite `image.jpg` being present.
   - *After this PR:* both are processed.
6. Regression check for the optimize pre-filter: change the optimization level and re-run bulk optimization. The scaled image must be re-optimized rather than silently skipped.
7. Regression check for non-scaled images: confirm images below the threshold behave exactly as before.
8. Negative check: delete `image.jpg` from the backup directory too, so the media genuinely has no backup, and re-run. It must still be reported as having no backup — this PR must not paper over genuinely missing backups.

Steps 1-8 can also be driven headlessly by calling `Imagify\Bulk\WP::get_optimized_media_ids_without_format()` directly via WP-CLI and inspecting the returned `ids` and `errors['no_backup']`, which is how the results in *What was tested* were produced. Querying a format no media has yet isolates the backup check as the only possible exclusion.

### Affected Features & Quality Assurance Scope

- **Generate Missing Next-Gen Versions** (bulk) — the primary fix.
- **Bulk optimization / re-optimization at a different level** — second affected pre-filter, `get_unoptimized_media_ids()`.
- **Bulk restore list** — third affected pre-filter, `get_optimized_media_ids()`.
- **Media Library (WP context) only.** Custom folders and NextGEN Gallery are *not* affected: they derive the backup path from the file's own stored path and have no scaled variant. Their bulk classes are untouched.
- Sites whose images are all below `big_image_size_threshold` see no behavioural change at all.

## Technical description

### Documentation

**Root cause.** Backups are always written at a path derived from the **original** file:

- `classes/Optimization/Process/AbstractProcess.php:423`, `:702`, `:1294` all pass `$media->get_raw_backup_path()`
- `classes/Media/WP.php:185-190` — `get_raw_backup_path()` = `get_imagify_attachment_backup_path( $this->get_raw_original_path() )`
- `classes/Media/WP.php:89-91` — `get_raw_original_path()` prefers `wp_get_original_image_path()`, i.e. the **unscaled** original

The bulk pre-filters in `classes/Bulk/WP.php` instead derived it from `_wp_attached_file`, and `get_imagify_attachment_backup_path()` (`inc/functions/attachments.php:214-224`) is a pure `preg_replace` of the uploads basedir — so it faithfully preserves whatever filename it is handed, including the `-scaled` suffix.

WordPress core makes those two disagree for scaled uploads:

- `wp-admin/includes/image.php:210` — `_wp_image_meta_replace_original()` calls `update_attached_file()` with the **scaled** file
- `wp-admin/includes/image.php:223` — stores the original basename in `$image_meta['original_image']`
- `wp-includes/post.php:8468-8472` — `wp_get_original_image_path()` rebuilds the original path from `original_image`

Net effect for a scaled upload: bulk checked `…/backup/<Y>/<m>/image-scaled.jpg`, while the backup actually lives at `…/backup/<Y>/<m>/image.jpg`.

**The fix.** `_wp_attachment_metadata` is added to the three already-batched `Imagify_DB::get_metas()` calls, and a small private helper reconstructs the original filename from its `original_image` entry — mirroring `wp_get_original_image_path()` without instantiating a media object per attachment. Images with no `original_image` entry resolve to exactly the same path as before, so non-scaled media are bit-for-bit unaffected.

The helper guards untrusted database content: non-array metadata, a missing, empty or non-string `original_image` all fall back to the attached-file path without emitting a warning.

**Why not simply call `has_backup()` per media.** That would be the obvious one-liner, but these pre-filters run on a settings-page request over a result set capped at 10 000 IDs (`inc/functions/attachments.php:388`). Instantiating one `Imagify\Media\WP` per attachment would fire up to 10 000 uncached meta reads on a page load. Adding one key to an existing batched query costs nothing.

### New dependencies

None.

### Risks

- **CDN-backed media are out of reach of this fix.** `classes/Media/WP.php:85-87` short-circuits `get_raw_original_path()` to the CDN's own path, which the batched-metadata approach cannot reproduce. Such media may still be misclassified. Called out explicitly rather than silently unhandled.
- **`original_image` is treated as a basename**, matching core's `wp_basename( $original_file )` at `wp-admin/includes/image.php:223`. The helper joins it to `dirname( $file_path )`. Malformed metadata containing a path separator would produce a nonsensical path, but that path is only ever passed to a file-existence check, so the failure mode is a false "no backup" — the current behaviour for those media anyway.
- **Scope is wider than the ticket.** #1210 describes only the Next-Gen tool, but the same derivation bug sits in the optimize and restore pre-filters, so all three are fixed together. Reviewers should weigh the optimize pre-filter change (`get_unoptimized_media_ids()`) on its own merits — it was not in the original report and was found while verifying the fix.
- No test exercises the three call sites end to end; see *What was tested*.

### Merge-order note for #1203

PR #1203 (`Refs #1011`) also edits `classes/Bulk/WP.php` — it adds a second `NOT LIKE` predicate to the SQL in `get_optimized_media_ids_without_format()`. This PR changes the `get_metas()` calls and the file-existence loops **below** those queries, so the hunks are distinct and should merge cleanly, but **a rebase is expected rather than optional**.

The two changes are semantically orthogonal and neither weakens the other: #1203 *removes* permanently-refused media from the selection, this PR *adds back* wrongly-excluded scaled media.

#1203 also creates `Tests/Integration/classes/Bulk/WP/GetOptimizedMediaIdsWithoutFormatTest.php`. This PR deliberately avoids that path and places its tests under `Tests/Unit/classes/Bulk/WP/`, so the two test suites do not collide.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

All mandatory items are ticked. The acceptance criteria were validated by unit tests, by tracing the mechanism against WordPress core, and by a live run on a real keyed install — the bug was reproduced on `develop` and confirmed fixed on this branch against identical data, with a negative check proving genuinely missing backups are still reported. See the numbered manual steps in *What was tested*.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
