### PR TITLE
Remove user_id property from Mixpanel events

### DIFF
--- a/Tests/Unit/classes/Tracking/Tracking/Test_GetDefaultEventProperties.php
+++ b/Tests/Unit/classes/Tracking/Tracking/Test_GetDefaultEventProperties.php
@@ -65,7 +65,6 @@ class Test_GetDefaultEventProperties extends TestCase {
 
 		$this->assertSame( $expected_hash, $props['license_owner'] );
 		$this->assertSame( 'wp_plugin', $props['context'] );
-		$this->assertSame( 5, $props['user_id'] );
 	}
 
 	/**
@@ -85,17 +84,16 @@ class Test_GetDefaultEventProperties extends TestCase {
 	}
 
 	/**
-	 * Tests that user_id comes from get_current_user_id().
+	 * Tests that no user_id property is sent.
 	 */
-	public function testUserIdFromGetCurrentUserId(): void {
+	public function testDoesNotSendUserId(): void {
 		Functions\when( 'get_imagify_user' )->justReturn( (object) [ 'email' => '' ] );
 		Functions\when( 'is_wp_error' )->justReturn( false );
-		Functions\when( 'get_current_user_id' )->justReturn( 42 );
 
 		$tracking = $this->create_tracking()['tracking'];
 		$props    = $this->call_get_default_event_properties( $tracking );
 
-		$this->assertSame( 42, $props['user_id'] );
+		$this->assertArrayNotHasKey( 'user_id', $props );
 	}
 
 	/**

--- a/classes/Tracking/BaseTracking.php
+++ b/classes/Tracking/BaseTracking.php
@@ -72,7 +72,6 @@ abstract class BaseTracking {
 		return [
 			'context'       => 'wp_plugin',
 			'license_owner' => $license_owner,
-			'user_id'       => (int) get_current_user_id(),
 		];
 	}
 


### PR DESCRIPTION
# Description

Removes the `user_id` property from every Mixpanel event.

The property held the local WordPress user ID, which is site-scoped and meaningless once aggregated across sites. User level metrics (MAU/DAU, retention, cohorts) already rely on the hashed `distinct_id` registered by `identify_user()`, so nothing depends on it.

No user facing change.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [x] Chore
- [ ] Release

## Detailed scenario

### What was tested

Automated: the Tracking unit test group (109 tests) passes. `Test_GetDefaultEventProperties` now asserts `user_id` is absent from the default event properties.

### How to test

1. Enable the tracking optin in Imagify settings.
2. Trigger a tracked event (save the settings, or optimize a media).
3. Inspect the Mixpanel payload: `context` and `license_owner` are present, `user_id` is gone.

### Affected Features & Quality Assurance Scope

Mixpanel tracking only. All events go through `BaseTracking::get_default_event_properties()`, so the whole tracking surface is touched, but only by the removal of one property.

## Technical description

### Documentation

`BaseTracking::get_default_event_properties()` builds the property array shared by every tracked event. The `user_id` entry was dropped; `context` and `license_owner` remain, and `identify_user()` still runs so the hashed `distinct_id` is unchanged.

### New dependencies

None.

### Risks

None. Removing a property cannot break event delivery. Mixpanel reports built on `user_id` would lose that breakdown, which is the intent.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
