### PR TITLE
Closes #1220: support media lookup by filename or URL in MCP media abilities

### DIFF
--- a/Tests/Integration/classes/Abilities/GetMediaStatus/RegisterAbilityTest.php
+++ b/Tests/Integration/classes/Abilities/GetMediaStatus/RegisterAbilityTest.php
@@ -124,4 +124,56 @@ class RegisterAbilityTest extends TestCase {
 		] );
 		wp_set_current_user( $user_id );
 	}
+
+	/**
+	 * The filename and URL inputs must be registered, and no input may be
+	 * required on its own since the three identifiers are interchangeable.
+	 */
+	public function testShouldRegisterFilenameAndUrlInputs(): void {
+		$ability = wp_get_ability( 'imagify/get-media-status' );
+
+		$this->assertNotNull( $ability, 'Ability should be registered.' );
+
+		$input_schema = $ability->get_input_schema();
+
+		$this->assertArrayHasKey( 'media_id', $input_schema['properties'] );
+		$this->assertArrayHasKey( 'media_filename', $input_schema['properties'] );
+		$this->assertArrayHasKey( 'media_url', $input_schema['properties'] );
+		$this->assertArrayNotHasKey( 'required', $input_schema );
+	}
+
+	/**
+	 * End-to-end proof of the feature: an attachment identified only by its file
+	 * name returns that attachment's status, not an error.
+	 */
+	public function testShouldReturnStatusForAttachmentIdentifiedByFilename(): void {
+		$attachment_id = self::factory()->attachment->create(
+			[
+				'file'           => '2026/08/status-by-name.jpg',
+				'post_mime_type' => 'image/jpeg',
+			]
+		);
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$ability = wp_get_ability( 'imagify/get-media-status' );
+
+		$by_id       = $ability->execute( [ 'media_id' => $attachment_id ] );
+		$by_filename = $ability->execute( [ 'media_filename' => 'status-by-name.jpg' ] );
+
+		$this->assertSame( $by_id, $by_filename, 'Resolving by file name should match resolving by ID.' );
+		$this->assertNotSame( 'error', $by_filename['status'] );
+	}
+
+	/**
+	 * An unknown file name must fail with an explicit message rather than
+	 * silently falling back to another attachment.
+	 */
+	public function testShouldReturnErrorForUnknownFilename(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$result = wp_get_ability( 'imagify/get-media-status' )->execute( [ 'media_filename' => 'not-in-library.jpg' ] );
+
+		$this->assertSame( 'error', $result['status'] );
+		$this->assertStringContainsString( 'not-in-library.jpg', $result['error_message'] );
+	}
 }

--- a/Tests/Integration/classes/Abilities/MediaResolver/ResolveIdTest.php
+++ b/Tests/Integration/classes/Abilities/MediaResolver/ResolveIdTest.php
@@ -104,6 +104,48 @@ class ResolveIdTest extends TestCase {
 		$this->assertStringContainsString( (string) $second, $result->get_error_message() );
 	}
 
+	/**
+	 * A bare file name shared by more attachments than the resolver is willing
+	 * to list must be reported, not resolved. Narrowing the query to a single
+	 * page of candidates and picking the lone exact match inside that page
+	 * would act on an arbitrary attachment.
+	 */
+	public function testShouldReportAmbiguityBeyondTheCandidateCap(): void {
+		for ( $i = 0; $i <= MediaResolver::MAX_CANDIDATES; $i++ ) {
+			$this->create_attachment( sprintf( '2026/%02d/hero.jpg', $i + 1 ) );
+		}
+
+		$result = MediaResolver::resolve_id( [ 'media_filename' => 'hero.jpg' ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'imagify_ambiguous_media_filename', $result->get_error_code() );
+	}
+
+	/**
+	 * Supplying the directory is the documented way out of that ambiguity.
+	 */
+	public function testShouldResolveAmbiguousFilenameWhenGivenItsDirectory(): void {
+		$wanted = $this->create_attachment( '2026/08/hero.jpg' );
+		$this->create_attachment( '2025/01/hero.jpg' );
+
+		$this->assertWPError( MediaResolver::resolve_id( [ 'media_filename' => 'hero.jpg' ] ) );
+		$this->assertSame( $wanted, MediaResolver::resolve_id( [ 'media_filename' => '2026/08/hero.jpg' ] ) );
+	}
+
+	/**
+	 * The anchored match must not treat a longer directory as a match: asking
+	 * for `08/hero.jpg` should not be satisfied by `2026/08/hero.jpg` only by
+	 * accident of the suffix, nor should a partial segment match.
+	 */
+	public function testShouldNotMatchPartialPathSegments(): void {
+		$this->create_attachment( '2026/08/hero.jpg' );
+
+		$result = MediaResolver::resolve_id( [ 'media_filename' => '6/08/hero.jpg' ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'imagify_media_not_found', $result->get_error_code() );
+	}
+
 	public function testShouldReturnErrorWhenFilenameMatchesNothing(): void {
 		$result = MediaResolver::resolve_id( [ 'media_filename' => 'nope.jpg' ] );
 

--- a/Tests/Integration/classes/Abilities/MediaResolver/ResolveIdTest.php
+++ b/Tests/Integration/classes/Abilities/MediaResolver/ResolveIdTest.php
@@ -1,0 +1,179 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Integration\classes\Abilities\MediaResolver;
+
+use Imagify\Abilities\MediaResolver;
+use Imagify\Tests\Integration\TestCase;
+
+/**
+ * @covers \Imagify\Abilities\MediaResolver::resolve_id
+ *
+ * @group Abilities
+ * @group MediaResolver
+ */
+class ResolveIdTest extends TestCase {
+
+	protected $useApi = false;
+
+	/**
+	 * Create an attachment whose `_wp_attached_file` meta is a known path.
+	 *
+	 * @param string $relative_path Path relative to the uploads directory.
+	 * @return int Attachment ID.
+	 */
+	private function create_attachment( string $relative_path ): int {
+		$attachment_id = self::factory()->attachment->create(
+			[
+				'file'           => $relative_path,
+				'post_mime_type' => 'image/jpeg',
+			]
+		);
+
+		// Guard the fixture itself: the whole resolver relies on this meta value.
+		$this->assertSame(
+			$relative_path,
+			get_post_meta( $attachment_id, '_wp_attached_file', true ),
+			'Fixture should store the expected _wp_attached_file meta.'
+		);
+
+		return $attachment_id;
+	}
+
+	public function testShouldReturnMediaIdWhenProvided(): void {
+		$attachment_id = $this->create_attachment( '2026/08/hero.jpg' );
+
+		$this->assertSame( $attachment_id, MediaResolver::resolve_id( [ 'media_id' => $attachment_id ] ) );
+	}
+
+	public function testShouldPreferMediaIdOverOtherIdentifiers(): void {
+		$wanted = $this->create_attachment( '2026/08/wanted.jpg' );
+		$this->create_attachment( '2026/08/other.jpg' );
+
+		$resolved = MediaResolver::resolve_id(
+			[
+				'media_id'       => $wanted,
+				'media_filename' => 'other.jpg',
+			]
+		);
+
+		$this->assertSame( $wanted, $resolved );
+	}
+
+	public function testShouldResolveByFilename(): void {
+		$attachment_id = $this->create_attachment( '2026/08/hero-banner.jpg' );
+
+		$this->assertSame( $attachment_id, MediaResolver::resolve_id( [ 'media_filename' => 'hero-banner.jpg' ] ) );
+	}
+
+	public function testShouldResolveByFilenameIgnoringCase(): void {
+		$attachment_id = $this->create_attachment( '2026/08/Hero-Banner.jpg' );
+
+		$this->assertSame( $attachment_id, MediaResolver::resolve_id( [ 'media_filename' => 'hero-banner.JPG' ] ) );
+	}
+
+	public function testShouldResolveByFilenameGivenAsRelativePath(): void {
+		$attachment_id = $this->create_attachment( '2026/08/hero.jpg' );
+
+		$this->assertSame( $attachment_id, MediaResolver::resolve_id( [ 'media_filename' => '2026/08/hero.jpg' ] ) );
+	}
+
+	/**
+	 * A `LIKE` match alone would also return `my-hero.jpg` and `hero.jpg.bak`,
+	 * which would optimize or restore the wrong file.
+	 */
+	public function testShouldNotMatchFilenamesThatMerelyContainTheRequestedName(): void {
+		$wanted = $this->create_attachment( '2026/08/hero.jpg' );
+		$this->create_attachment( '2026/08/my-hero.jpg' );
+		$this->create_attachment( '2026/08/hero.jpg.bak' );
+
+		$this->assertSame( $wanted, MediaResolver::resolve_id( [ 'media_filename' => 'hero.jpg' ] ) );
+	}
+
+	public function testShouldReturnErrorWhenFilenameMatchesSeveralAttachments(): void {
+		$first  = $this->create_attachment( '2026/07/hero.jpg' );
+		$second = $this->create_attachment( '2026/08/hero.jpg' );
+
+		$result = MediaResolver::resolve_id( [ 'media_filename' => 'hero.jpg' ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'imagify_ambiguous_media_filename', $result->get_error_code() );
+
+		// The caller needs the candidate IDs to be able to retry unambiguously.
+		$this->assertStringContainsString( (string) $first, $result->get_error_message() );
+		$this->assertStringContainsString( (string) $second, $result->get_error_message() );
+	}
+
+	public function testShouldReturnErrorWhenFilenameMatchesNothing(): void {
+		$result = MediaResolver::resolve_id( [ 'media_filename' => 'nope.jpg' ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'imagify_media_not_found', $result->get_error_code() );
+	}
+
+	public function testShouldResolveByUrl(): void {
+		$attachment_id = $this->create_attachment( '2026/08/hero.jpg' );
+
+		$url = wp_get_upload_dir()['baseurl'] . '/2026/08/hero.jpg';
+
+		$this->assertSame( $attachment_id, MediaResolver::resolve_id( [ 'media_url' => $url ] ) );
+	}
+
+	/**
+	 * A next-gen or thumbnail URL has no attachment of its own, so the resolver
+	 * peels the suffixes off and matches the original file name.
+	 *
+	 * @dataProvider derivativeUrlProvider
+	 */
+	public function testShouldResolveDerivativeUrlByFallingBackToFilename( string $derivative ): void {
+		$attachment_id = $this->create_attachment( '2026/08/hero.jpg' );
+
+		$url = wp_get_upload_dir()['baseurl'] . '/2026/08/' . $derivative;
+
+		$this->assertSame( $attachment_id, MediaResolver::resolve_id( [ 'media_url' => $url ] ) );
+	}
+
+	public function derivativeUrlProvider(): array {
+		return [
+			'webp next-gen version'   => [ 'hero.jpg.webp' ],
+			'avif next-gen version'   => [ 'hero.jpg.avif' ],
+			'generated thumbnail'     => [ 'hero-300x200.jpg' ],
+			'next-gen of a thumbnail' => [ 'hero-300x200.jpg.webp' ],
+		];
+	}
+
+	public function testShouldReturnErrorWhenUrlMatchesNothing(): void {
+		$result = MediaResolver::resolve_id( [ 'media_url' => 'https://example.com/wp-content/uploads/2026/08/absent.jpg' ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'imagify_media_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * @dataProvider emptyIdentifierProvider
+	 */
+	public function testShouldReturnErrorWhenNoIdentifierIsUsable( array $args ): void {
+		$result = MediaResolver::resolve_id( $args );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'imagify_missing_media_identifier', $result->get_error_code() );
+	}
+
+	public function emptyIdentifierProvider(): array {
+		return [
+			'no argument at all'   => [ [] ],
+			'zero media_id'        => [ [ 'media_id' => 0 ] ],
+			'negative media_id'    => [ [ 'media_id' => -5 ] ],
+			'blank media_url'      => [ [ 'media_url' => '   ' ] ],
+			'blank media_filename' => [ [ 'media_filename' => '' ] ],
+		];
+	}
+
+	public function testShouldExposeFilenameAndUrlInputSchemaProperties(): void {
+		$properties = MediaResolver::get_input_schema_properties();
+
+		$this->assertSame( [ 'media_filename', 'media_url' ], array_keys( $properties ) );
+		$this->assertSame( 'string', $properties['media_filename']['type'] );
+		$this->assertSame( 'string', $properties['media_url']['type'] );
+	}
+}

--- a/Tests/Integration/classes/Abilities/OptimizeMedia/RegisterAbilityTest.php
+++ b/Tests/Integration/classes/Abilities/OptimizeMedia/RegisterAbilityTest.php
@@ -178,4 +178,21 @@ class RegisterAbilityTest extends TestCase {
 		);
 		wp_set_current_user( $user_id );
 	}
+
+	/**
+	 * The filename and URL inputs must be registered, and no input may be
+	 * required on its own since the three identifiers are interchangeable.
+	 */
+	public function testShouldRegisterFilenameAndUrlInputs(): void {
+		$ability = wp_get_ability( 'imagify/optimize-media' );
+
+		$this->assertNotNull( $ability, 'Ability should be registered.' );
+
+		$input_schema = $ability->get_input_schema();
+
+		$this->assertArrayHasKey( 'media_id', $input_schema['properties'] );
+		$this->assertArrayHasKey( 'media_filename', $input_schema['properties'] );
+		$this->assertArrayHasKey( 'media_url', $input_schema['properties'] );
+		$this->assertArrayNotHasKey( 'required', $input_schema );
+	}
 }

--- a/Tests/Integration/classes/Abilities/RestoreMedia/RegisterAbilityTest.php
+++ b/Tests/Integration/classes/Abilities/RestoreMedia/RegisterAbilityTest.php
@@ -55,4 +55,59 @@ class RegisterAbilityTest extends TestCase {
 		] );
 		wp_set_current_user( $user_id );
 	}
+
+	/**
+	 * The filename and URL inputs must be registered, and no input may be
+	 * required on its own since the three identifiers are interchangeable.
+	 */
+	public function testShouldRegisterFilenameAndUrlInputs(): void {
+		$ability = wp_get_ability( 'imagify/restore-media' );
+
+		$this->assertNotNull( $ability, 'Ability should be registered.' );
+
+		$input_schema = $ability->get_input_schema();
+
+		$this->assertArrayHasKey( 'media_id', $input_schema['properties'] );
+		$this->assertArrayHasKey( 'media_filename', $input_schema['properties'] );
+		$this->assertArrayHasKey( 'media_url', $input_schema['properties'] );
+		$this->assertArrayNotHasKey( 'required', $input_schema );
+	}
+
+	/**
+	 * A resolvable file name reaches the restore logic — it fails on the media
+	 * not being optimized, which an unresolved file name never gets to.
+	 */
+	public function testShouldResolveFilenameBeforeRestoring(): void {
+		self::factory()->attachment->create(
+			[
+				'file'           => '2026/08/restore-by-name.jpg',
+				'post_mime_type' => 'image/jpeg',
+			]
+		);
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$ability = wp_get_ability( 'imagify/restore-media' );
+
+		$resolved = $ability->execute( [ 'media_filename' => 'restore-by-name.jpg' ] );
+		$unknown  = $ability->execute( [ 'media_filename' => 'not-in-library.jpg' ] );
+
+		$this->assertSame( 'error', $resolved['status'] );
+		$this->assertStringContainsString( 'not optimized', $resolved['error_message'] );
+
+		$this->assertSame( 'error', $unknown['status'] );
+		$this->assertStringContainsString( 'not-in-library.jpg', $unknown['error_message'] );
+	}
+
+	/**
+	 * With no identifier at all the caller gets an actionable message naming the
+	 * three accepted inputs.
+	 */
+	public function testShouldReturnErrorWhenNoIdentifierIsGiven(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$result = wp_get_ability( 'imagify/restore-media' )->execute( [] );
+
+		$this->assertSame( 'error', $result['status'] );
+		$this->assertStringContainsString( 'media_filename', $result['error_message'] );
+	}
 }

--- a/Tests/Unit/classes/Abilities/GetMediaStatus/execute.php
+++ b/Tests/Unit/classes/Abilities/GetMediaStatus/execute.php
@@ -20,6 +20,13 @@ use Imagify\Tests\Unit\TestCase;
  * @group  MCP
  */
 class Test_Execute extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		// MediaResolver builds translated WP_Error messages when no identifier resolves.
+		Functions\stubTranslationFunctions();
+	}
+
 
 	/**
 	 * Build a testable GetMediaStatus subclass with a mocked WP data object.
@@ -89,7 +96,7 @@ class Test_Execute extends TestCase {
 		$result  = $ability->execute( [ 'media_id' => 0 ] );
 
 		$this->assertSame( 'error', $result['status'] );
-		$this->assertSame( 'Invalid or missing media_id', $result['error_message'] );
+		$this->assertSame( 'Provide one of media_id, media_url, or media_filename to identify the media.', $result['error_message'] );
 		$this->assertNull( $result['optimization_level'] );
 		$this->assertSame( 0, $result['original_size'] );
 		$this->assertSame( 0, $result['optimized_size'] );
@@ -105,7 +112,7 @@ class Test_Execute extends TestCase {
 		$result  = $ability->execute( [] );
 
 		$this->assertSame( 'error', $result['status'] );
-		$this->assertSame( 'Invalid or missing media_id', $result['error_message'] );
+		$this->assertSame( 'Provide one of media_id, media_url, or media_filename to identify the media.', $result['error_message'] );
 	}
 
 	/**
@@ -116,7 +123,7 @@ class Test_Execute extends TestCase {
 		$result  = $ability->execute( [ 'media_id' => -5 ] );
 
 		$this->assertSame( 'error', $result['status'] );
-		$this->assertSame( 'Invalid or missing media_id', $result['error_message'] );
+		$this->assertSame( 'Provide one of media_id, media_url, or media_filename to identify the media.', $result['error_message'] );
 	}
 
 	/**

--- a/Tests/Unit/classes/Abilities/MediaResolver/resolveId.php
+++ b/Tests/Unit/classes/Abilities/MediaResolver/resolveId.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Abilities\MediaResolver;
+
+use Brain\Monkey\Functions;
+use Imagify\Abilities\MediaResolver;
+use Imagify\Tests\Unit\TestCase;
+
+/**
+ * Tests for \Imagify\Abilities\MediaResolver::resolve_id().
+ *
+ * Covers the identifier dispatch and the URL path. The file-name path runs a
+ * real `WP_Query` against the `_wp_attached_file` meta and is covered by
+ * Tests/Integration/classes/Abilities/MediaResolver/ResolveIdTest.php instead.
+ *
+ * @covers \Imagify\Abilities\MediaResolver::resolve_id
+ * @group  MCP
+ */
+class Test_ResolveId extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		Functions\stubTranslationFunctions();
+	}
+
+	/**
+	 * Tests that a positive media_id is returned untouched.
+	 */
+	public function testReturnsMediaIdWhenPositive(): void {
+		$this->assertSame( 42, MediaResolver::resolve_id( [ 'media_id' => 42 ] ) );
+	}
+
+	/**
+	 * Tests that a numeric-string media_id is cast to an integer.
+	 */
+	public function testCastsNumericStringMediaId(): void {
+		$this->assertSame( 42, MediaResolver::resolve_id( [ 'media_id' => '42' ] ) );
+	}
+
+	/**
+	 * Tests that media_id takes precedence over the other identifiers, without
+	 * spending a lookup on them.
+	 */
+	public function testMediaIdTakesPrecedenceOverUrl(): void {
+		Functions\expect( 'attachment_url_to_postid' )->never();
+
+		$resolved = MediaResolver::resolve_id(
+			[
+				'media_id'  => 42,
+				'media_url' => 'https://example.com/wp-content/uploads/2026/08/hero.jpg',
+			]
+		);
+
+		$this->assertSame( 42, $resolved );
+	}
+
+	/**
+	 * Tests that a URL resolving to an attachment returns its ID.
+	 */
+	public function testResolvesUrlToAttachmentId(): void {
+		Functions\expect( 'attachment_url_to_postid' )
+			->once()
+			->with( 'https://example.com/wp-content/uploads/2026/08/hero.jpg' )
+			->andReturn( 7 );
+
+		$resolved = MediaResolver::resolve_id( [ 'media_url' => 'https://example.com/wp-content/uploads/2026/08/hero.jpg' ] );
+
+		$this->assertSame( 7, $resolved );
+	}
+
+	/**
+	 * Tests that surrounding whitespace does not prevent a URL from resolving.
+	 */
+	public function testTrimsUrlBeforeResolving(): void {
+		Functions\expect( 'attachment_url_to_postid' )
+			->once()
+			->with( 'https://example.com/hero.jpg' )
+			->andReturn( 9 );
+
+		$this->assertSame( 9, MediaResolver::resolve_id( [ 'media_url' => "  https://example.com/hero.jpg\n" ] ) );
+	}
+
+	/**
+	 * Tests that an unusable identifier is reported rather than guessed at.
+	 *
+	 * @dataProvider unusableIdentifierProvider
+	 *
+	 * @param array $args Ability arguments with no usable identifier.
+	 */
+	public function testReturnsErrorWhenNoIdentifierIsUsable( array $args ): void {
+		$resolved = MediaResolver::resolve_id( $args );
+
+		$this->assertInstanceOf( 'WP_Error', $resolved );
+		$this->assertSame( 'imagify_missing_media_identifier', $resolved->get_error_code() );
+	}
+
+	/**
+	 * Argument sets carrying no usable identifier.
+	 *
+	 * @return array<string, array{0: array}>
+	 */
+	public function unusableIdentifierProvider(): array {
+		return [
+			'empty args'           => [ [] ],
+			'zero media_id'        => [ [ 'media_id' => 0 ] ],
+			'negative media_id'    => [ [ 'media_id' => -5 ] ],
+			'blank media_url'      => [ [ 'media_url' => '   ' ] ],
+			'blank media_filename' => [ [ 'media_filename' => '' ] ],
+		];
+	}
+
+	/**
+	 * Tests that the shared schema properties describe both new inputs.
+	 */
+	public function testExposesFilenameAndUrlSchemaProperties(): void {
+		$properties = MediaResolver::get_input_schema_properties();
+
+		$this->assertSame( [ 'media_filename', 'media_url' ], array_keys( $properties ) );
+		$this->assertSame( 'string', $properties['media_filename']['type'] );
+		$this->assertSame( 'string', $properties['media_url']['type'] );
+		$this->assertNotEmpty( $properties['media_filename']['description'] );
+		$this->assertNotEmpty( $properties['media_url']['description'] );
+	}
+}

--- a/Tests/Unit/classes/Abilities/OptimizeMedia/execute.php
+++ b/Tests/Unit/classes/Abilities/OptimizeMedia/execute.php
@@ -24,6 +24,13 @@ use WP_Error;
  * @preserveGlobalState disabled
  */
 class Test_Execute extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		// MediaResolver builds translated WP_Error messages when no identifier resolves.
+		Functions\stubTranslationFunctions();
+	}
+
 
 	/**
 	 * Stub get_post() and get_post_type() as a valid attachment.

--- a/Tests/Unit/classes/Abilities/RestoreMedia/execute.php
+++ b/Tests/Unit/classes/Abilities/RestoreMedia/execute.php
@@ -19,6 +19,13 @@ use WP_Error;
  * @group  RestoreMedia
  */
 class Test_Execute extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		// MediaResolver builds translated WP_Error messages when no identifier resolves.
+		Functions\stubTranslationFunctions();
+	}
+
 
 	// -------------------------------------------------------------------------
 	// Helpers

--- a/Tests/Unit/classes/Abilities/RestoreMedia/register.php
+++ b/Tests/Unit/classes/Abilities/RestoreMedia/register.php
@@ -46,7 +46,11 @@ class Test_Register extends TestCase {
 		$this->assertSame( 'imagify', $captured['category'] );
 		$this->assertSame( [ $ability, 'execute' ], $captured['execute_callback'] );
 		$this->assertSame( [ $ability, 'check_permissions' ], $captured['permission_callback'] );
-		$this->assertSame( [ 'media_id' ], $captured['input_schema']['required'] );
+		// No input is required on its own: media_id, media_filename and media_url are interchangeable.
+		$this->assertArrayNotHasKey( 'required', $captured['input_schema'] );
+		$this->assertArrayHasKey( 'media_id', $captured['input_schema']['properties'] );
+		$this->assertArrayHasKey( 'media_filename', $captured['input_schema']['properties'] );
+		$this->assertArrayHasKey( 'media_url', $captured['input_schema']['properties'] );
 		$this->assertSame( [ 'success', 'error' ], $captured['output_schema']['properties']['status']['enum'] );
 		$this->assertTrue( $captured['meta']['show_in_rest'] );
 		$this->assertTrue( $captured['meta']['mcp']['public'] );

--- a/classes/Abilities/GetMediaStatus.php
+++ b/classes/Abilities/GetMediaStatus.php
@@ -59,10 +59,9 @@ class GetMediaStatus extends AbstractAbility {
 					'properties' => [
 						'media_id' => [
 							'type'        => 'integer',
-							'description' => __( 'The WordPress attachment ID.', 'imagify' ),
+							'description' => __( 'The WordPress attachment ID. Provide media_filename or media_url instead when the ID is unknown.', 'imagify' ),
 						],
-					],
-					'required'   => [ 'media_id' ],
+					] + MediaResolver::get_input_schema_properties(),
 				],
 				'output_schema'       => [
 					'type'       => 'object',
@@ -150,31 +149,15 @@ class GetMediaStatus extends AbstractAbility {
 	 * @return array
 	 */
 	private function do_execute( array $args ): array {
-		$media_id = isset( $args['media_id'] ) ? (int) $args['media_id'] : 0;
+		$media_id = MediaResolver::resolve_id( $args );
 
-		if ( $media_id <= 0 ) {
-			return [
-				'status'             => 'error',
-				'error_message'      => 'Invalid or missing media_id',
-				'optimization_level' => null,
-				'original_size'      => 0,
-				'optimized_size'     => 0,
-				'webp_available'     => false,
-				'avif_available'     => false,
-			];
+		if ( is_wp_error( $media_id ) ) {
+			return $this->error_response( $media_id->get_error_message() );
 		}
 
 		// Verify the attachment exists.
 		if ( ! get_post( $media_id ) ) {
-			return [
-				'status'             => 'error',
-				'error_message'      => 'Media not found.',
-				'optimization_level' => null,
-				'original_size'      => 0,
-				'optimized_size'     => 0,
-				'webp_available'     => false,
-				'avif_available'     => false,
-			];
+			return $this->error_response( 'Media not found.' );
 		}
 
 		$wp_data  = $this->create_wp_data( $media_id );
@@ -223,6 +206,26 @@ class GetMediaStatus extends AbstractAbility {
 			'optimized_size'     => $optimized_size,
 			'webp_available'     => $webp_available,
 			'avif_available'     => $avif_available,
+			'error_message'      => $error_message,
+		];
+	}
+
+	/**
+	 * Build an error response with every output field set to a neutral value.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param string $error_message Human-readable error message.
+	 * @return array{status: string, optimization_level: null, original_size: int, optimized_size: int, webp_available: bool, avif_available: bool, error_message: string}
+	 */
+	private function error_response( string $error_message ): array {
+		return [
+			'status'             => 'error',
+			'optimization_level' => null,
+			'original_size'      => 0,
+			'optimized_size'     => 0,
+			'webp_available'     => false,
+			'avif_available'     => false,
 			'error_message'      => $error_message,
 		];
 	}

--- a/classes/Abilities/MediaResolver.php
+++ b/classes/Abilities/MediaResolver.php
@@ -1,0 +1,243 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Abilities;
+
+use WP_Error;
+use WP_Query;
+
+/**
+ * Resolves the media identifier accepted by the MCP media abilities.
+ *
+ * Callers driving an AI assistant know an image by its filename or URL far more
+ * often than by its attachment ID, so the media abilities accept any of:
+ *
+ * - `media_id`       (int)    attachment ID, used as-is.
+ * - `media_url`      (string) absolute URL, resolved with `attachment_url_to_postid()`.
+ * - `media_filename` (string) file name, matched against the `_wp_attached_file` meta.
+ *
+ * Precedence is `media_id`, then `media_url`, then `media_filename`. A filename
+ * matching several attachments is reported as ambiguous, with the matching IDs,
+ * rather than silently acting on the first one.
+ *
+ * @since 2.3.3
+ */
+final class MediaResolver {
+
+	/**
+	 * Maximum number of attachments fetched when matching a filename.
+	 *
+	 * Bounds the query while leaving enough room to report a useful list of
+	 * candidates when a filename is ambiguous.
+	 *
+	 * @var int
+	 */
+	const MAX_CANDIDATES = 20;
+
+	/**
+	 * Returns the input-schema properties describing the filename and URL inputs.
+	 *
+	 * Shared by every media ability so the three schemas stay in sync.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @return array<string, array<string, string>>
+	 */
+	public static function get_input_schema_properties(): array {
+		return [
+			'media_filename' => [
+				'type'        => 'string',
+				'description' => __( 'The media file name, for example "hero-banner.jpg". Use instead of media_id when only the file name is known.', 'imagify' ),
+			],
+			'media_url'      => [
+				'type'        => 'string',
+				'description' => __( 'The absolute URL of the media. Use instead of media_id when only the URL is known.', 'imagify' ),
+			],
+		];
+	}
+
+	/**
+	 * Resolve the ability arguments into a single attachment ID.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param array $args Ability input arguments.
+	 * @return int|WP_Error Attachment ID, or WP_Error when the identifier is
+	 *                      missing, unknown, or ambiguous.
+	 */
+	public static function resolve_id( array $args ) {
+		if ( isset( $args['media_id'] ) && (int) $args['media_id'] > 0 ) {
+			return (int) $args['media_id'];
+		}
+
+		if ( isset( $args['media_url'] ) && '' !== trim( (string) $args['media_url'] ) ) {
+			return self::resolve_by_url( trim( (string) $args['media_url'] ) );
+		}
+
+		if ( isset( $args['media_filename'] ) && '' !== trim( (string) $args['media_filename'] ) ) {
+			return self::resolve_by_filename( trim( (string) $args['media_filename'] ) );
+		}
+
+		return new WP_Error(
+			'imagify_missing_media_identifier',
+			__( 'Provide one of media_id, media_url, or media_filename to identify the media.', 'imagify' )
+		);
+	}
+
+	/**
+	 * Resolve an attachment ID from an absolute URL.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param string $url Absolute URL of the media.
+	 * @return int|WP_Error
+	 */
+	private static function resolve_by_url( string $url ) {
+		$media_id = attachment_url_to_postid( $url );
+
+		if ( $media_id > 0 ) {
+			return (int) $media_id;
+		}
+
+		// Next-gen and resized URLs have no attachment of their own, so retry on
+		// the file name after peeling off their suffixes: `hero-300x200.jpg.webp`
+		// must still resolve to the `hero.jpg` attachment.
+		$path = (string) wp_parse_url( $url, PHP_URL_PATH );
+
+		if ( '' !== $path ) {
+			foreach ( self::get_filename_variants( basename( $path ) ) as $variant ) {
+				$by_filename = self::resolve_by_filename( $variant );
+
+				if ( ! is_wp_error( $by_filename ) ) {
+					return $by_filename;
+				}
+			}
+		}
+
+		return new WP_Error(
+			'imagify_media_not_found',
+			sprintf(
+				/* translators: %s: media URL provided by the caller. */
+				__( 'No media in the library matches the URL "%s".', 'imagify' ),
+				$url
+			)
+		);
+	}
+
+	/**
+	 * Build the list of file names a URL may stand for, most specific first.
+	 *
+	 * A URL taken from the front end often points at a derivative of the
+	 * original file rather than the original itself: a next-gen version
+	 * (`hero.jpg.webp`) or a generated thumbnail (`hero-300x200.jpg`), or both
+	 * at once. Each suffix is peeled off in turn so the caller can look for the
+	 * attachment the derivative was made from.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param string $basename File name taken from the URL.
+	 * @return string[] Unique file names to try, in order.
+	 */
+	private static function get_filename_variants( string $basename ): array {
+		$variants = [ $basename ];
+
+		// Drop a trailing next-gen extension, leaving the original file name.
+		$without_nextgen = (string) preg_replace( '/\.(webp|avif)$/i', '', $basename );
+
+		if ( $without_nextgen !== $basename && '' !== $without_nextgen ) {
+			$variants[] = $without_nextgen;
+		}
+
+		// Drop a trailing thumbnail dimension suffix, on both names collected above.
+		foreach ( $variants as $variant ) {
+			$without_size = (string) preg_replace( '/-\d+x\d+(\.[^.]+)$/', '$1', $variant );
+
+			if ( $without_size !== $variant && '' !== $without_size ) {
+				$variants[] = $without_size;
+			}
+		}
+
+		return array_unique( $variants );
+	}
+
+	/**
+	 * Resolve an attachment ID from a file name.
+	 *
+	 * The `_wp_attached_file` meta stores a path relative to the uploads
+	 * directory (`2026/08/hero.jpg`), so the value is narrowed with a `LIKE`
+	 * query and then compared on its base name. Callers may pass either the
+	 * bare file name or a full relative path.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param string $filename File name of the media.
+	 * @return int|WP_Error
+	 */
+	private static function resolve_by_filename( string $filename ) {
+		$basename = basename( str_replace( '\\', '/', $filename ) );
+
+		if ( '' === $basename ) {
+			return new WP_Error(
+				'imagify_invalid_media_filename',
+				__( 'The media_filename provided is not a valid file name.', 'imagify' )
+			);
+		}
+
+		$query = new WP_Query(
+			[
+				'post_type'              => 'attachment',
+				'post_status'            => 'inherit',
+				'fields'                 => 'ids',
+				'posts_per_page'         => self::MAX_CANDIDATES,
+				'no_found_rows'          => true,
+				'ignore_sticky_posts'    => true,
+				'update_post_term_cache' => false,
+				'meta_query'             => [
+					[
+						'key'     => '_wp_attached_file',
+						'value'   => $basename,
+						'compare' => 'LIKE',
+					],
+				],
+			]
+		);
+
+		// The LIKE above also matches `my-hero.jpg` or `hero.jpg.bak` when asked
+		// for `hero.jpg`, so keep only the attachments whose own base name is an
+		// exact, case-insensitive match.
+		$matches = [];
+
+		foreach ( $query->posts as $candidate_id ) {
+			$attached_file = (string) get_post_meta( (int) $candidate_id, '_wp_attached_file', true );
+
+			if ( 0 === strcasecmp( basename( $attached_file ), $basename ) ) {
+				$matches[] = (int) $candidate_id;
+			}
+		}
+
+		if ( ! $matches ) {
+			return new WP_Error(
+				'imagify_media_not_found',
+				sprintf(
+					/* translators: %s: media file name provided by the caller. */
+					__( 'No media in the library is named "%s".', 'imagify' ),
+					$basename
+				)
+			);
+		}
+
+		if ( count( $matches ) > 1 ) {
+			return new WP_Error(
+				'imagify_ambiguous_media_filename',
+				sprintf(
+					/* translators: 1: media file name provided by the caller, 2: comma-separated list of attachment IDs. */
+					__( 'Several media are named "%1$s" (IDs: %2$s). Retry with media_id set to the one you want.', 'imagify' ),
+					$basename,
+					implode( ', ', $matches )
+				)
+			);
+		}
+
+		return $matches[0];
+	}
+}

--- a/classes/Abilities/MediaResolver.php
+++ b/classes/Abilities/MediaResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Imagify\Abilities;
 
 use WP_Error;
-use WP_Query;
 
 /**
  * Resolves the media identifier accepted by the MCP media abilities.
@@ -164,17 +163,28 @@ final class MediaResolver {
 	 * Resolve an attachment ID from a file name.
 	 *
 	 * The `_wp_attached_file` meta stores a path relative to the uploads
-	 * directory (`2026/08/hero.jpg`), so the value is narrowed with a `LIKE`
-	 * query and then compared on its base name. Callers may pass either the
-	 * bare file name or a full relative path.
+	 * directory (`2026/08/hero.jpg`). The match is anchored on the path
+	 * separator so `hero.jpg` cannot be satisfied by `my-hero.jpg` or
+	 * `hero.jpg.bak`, and callers may pass either the bare file name or a full
+	 * relative path — supplying the directory narrows the search, which is how
+	 * two same-named files in different month folders are told apart.
+	 *
+	 * One row beyond the cap is fetched so that "more candidates than we are
+	 * willing to list" is reported as ambiguous rather than silently resolved
+	 * to whichever match happened to fall inside the window.
 	 *
 	 * @since 2.3.3
 	 *
-	 * @param string $filename File name of the media.
+	 * @global \wpdb $wpdb WordPress database abstraction object.
+	 *
+	 * @param string $filename File name, or uploads-relative path, of the media.
 	 * @return int|WP_Error
 	 */
 	private static function resolve_by_filename( string $filename ) {
-		$basename = basename( str_replace( '\\', '/', $filename ) );
+		global $wpdb;
+
+		$relative = ltrim( str_replace( '\\', '/', $filename ), '/' );
+		$basename = basename( $relative );
 
 		if ( '' === $basename ) {
 			return new WP_Error(
@@ -183,35 +193,37 @@ final class MediaResolver {
 			);
 		}
 
-		$query = new WP_Query(
-			[
-				'post_type'              => 'attachment',
-				'post_status'            => 'inherit',
-				'fields'                 => 'ids',
-				'posts_per_page'         => self::MAX_CANDIDATES,
-				'no_found_rows'          => true,
-				'ignore_sticky_posts'    => true,
-				'update_post_term_cache' => false,
-				'meta_query'             => [
-					[
-						'key'     => '_wp_attached_file',
-						'value'   => $basename,
-						'compare' => 'LIKE',
-					],
-				],
-			]
+		// A caller-supplied directory is kept, so `2026/08/hero.jpg` does not
+		// collide with `2025/01/hero.jpg`.
+		$needle = ( false !== strpos( $relative, '/' ) ) ? $relative : $basename;
+
+		// Matching in SQL: either the stored path IS the needle (a file at the
+		// uploads root, or a full relative path), or it ends with `/` + needle.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Meta LIKE lookup no core API offers; results are request-scoped.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT post_id, meta_value FROM {$wpdb->postmeta}
+				WHERE meta_key = '_wp_attached_file'
+					AND ( meta_value = %s OR meta_value LIKE %s )
+				ORDER BY post_id ASC
+				LIMIT %d",
+				$needle,
+				'%/' . $wpdb->esc_like( $needle ),
+				self::MAX_CANDIDATES + 1
+			)
 		);
 
-		// The LIKE above also matches `my-hero.jpg` or `hero.jpg.bak` when asked
-		// for `hero.jpg`, so keep only the attachments whose own base name is an
-		// exact, case-insensitive match.
+		// The comparison above follows the column collation, which is
+		// case-insensitive on a stock install but need not be. Confirm in PHP so
+		// the behaviour does not depend on how the database was created.
 		$matches = [];
 
-		foreach ( $query->posts as $candidate_id ) {
-			$attached_file = (string) get_post_meta( (int) $candidate_id, '_wp_attached_file', true );
+		foreach ( (array) $rows as $row ) {
+			$stored  = (string) $row->meta_value;
+			$subject = ( $needle === $basename ) ? basename( $stored ) : $stored;
 
-			if ( 0 === strcasecmp( basename( $attached_file ), $basename ) ) {
-				$matches[] = (int) $candidate_id;
+			if ( 0 === strcasecmp( $subject, $needle ) ) {
+				$matches[] = (int) $row->post_id;
 			}
 		}
 
@@ -222,6 +234,18 @@ final class MediaResolver {
 					/* translators: %s: media file name provided by the caller. */
 					__( 'No media in the library is named "%s".', 'imagify' ),
 					$basename
+				)
+			);
+		}
+
+		if ( count( $matches ) > self::MAX_CANDIDATES ) {
+			return new WP_Error(
+				'imagify_ambiguous_media_filename',
+				sprintf(
+					/* translators: 1: media file name provided by the caller, 2: number of attachments listed. */
+					__( 'More than %2$d media are named "%1$s". Retry with media_id, or with the full path such as "2026/08/%1$s".', 'imagify' ),
+					$basename,
+					self::MAX_CANDIDATES
 				)
 			);
 		}

--- a/classes/Abilities/OptimizeMedia.php
+++ b/classes/Abilities/OptimizeMedia.php
@@ -47,6 +47,13 @@ class OptimizeMedia extends AbstractAbility implements CreditConsumingAbilityInt
 			return;
 		}
 
+		$media_properties = [
+			'media_id' => [
+				'type'        => 'integer',
+				'description' => __( 'The WordPress attachment ID to optimize. Provide media_filename or media_url instead when the ID is unknown.', 'imagify' ),
+			],
+		] + MediaResolver::get_input_schema_properties();
+
 		wp_register_ability(
 			'imagify/optimize-media',
 			[
@@ -55,11 +62,7 @@ class OptimizeMedia extends AbstractAbility implements CreditConsumingAbilityInt
 				'category'            => 'imagify',
 				'input_schema'        => [
 					'type'       => 'object',
-					'properties' => [
-						'media_id'           => [
-							'type'        => 'integer',
-							'description' => __( 'The WordPress attachment ID to optimize.', 'imagify' ),
-						],
+					'properties' => $media_properties + [
 						'optimization_level' => [
 							'type'        => 'integer',
 							'description' => __( 'Optimization level: 0 (normal), 1 (aggressive), or 2 (ultra). If omitted, uses the global setting.', 'imagify' ),
@@ -72,7 +75,6 @@ class OptimizeMedia extends AbstractAbility implements CreditConsumingAbilityInt
 							'default'     => false,
 						],
 					],
-					'required'   => [ 'media_id' ],
 				],
 				'output_schema'       => [
 					'type'       => 'object',
@@ -184,10 +186,10 @@ class OptimizeMedia extends AbstractAbility implements CreditConsumingAbilityInt
 	 * @return array{status: string, original_size: int|null, optimized_size: int|null, savings_percent: float|null, error_message: string|null}
 	 */
 	private function do_execute( array $args ): array {
-		$media_id = isset( $args['media_id'] ) ? (int) $args['media_id'] : 0;
+		$media_id = MediaResolver::resolve_id( $args );
 
-		if ( $media_id <= 0 ) {
-			return $this->error_response( 'Invalid or missing media_id.' );
+		if ( is_wp_error( $media_id ) ) {
+			return $this->error_response( $media_id->get_error_message() );
 		}
 
 		// Verify the attachment exists.

--- a/classes/Abilities/RestoreMedia.php
+++ b/classes/Abilities/RestoreMedia.php
@@ -37,10 +37,9 @@ class RestoreMedia implements AbilitiesInterface {
 					'properties' => [
 						'media_id' => [
 							'type'        => 'integer',
-							'description' => __( 'The WordPress attachment ID to restore.', 'imagify' ),
+							'description' => __( 'The WordPress attachment ID to restore. Provide media_filename or media_url instead when the ID is unknown.', 'imagify' ),
 						],
-					],
-					'required'   => [ 'media_id' ],
+					] + MediaResolver::get_input_schema_properties(),
 				],
 				'output_schema'       => [
 					'type'       => 'object',
@@ -93,13 +92,13 @@ class RestoreMedia implements AbilitiesInterface {
 	 * @return array{status: string, restored_size: int|null, error_message: string|null}
 	 */
 	public function execute( array $args = [] ): array {
-		$media_id = isset( $args['media_id'] ) ? (int) $args['media_id'] : 0;
+		$media_id = MediaResolver::resolve_id( $args );
 
-		if ( $media_id <= 0 ) {
+		if ( is_wp_error( $media_id ) ) {
 			return [
 				'status'        => 'error',
 				'restored_size' => null,
-				'error_message' => 'Invalid or missing media_id.',
+				'error_message' => $media_id->get_error_message(),
 			];
 		}
 

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -102,6 +102,33 @@ interface AbilitiesInterface {
 
 ## Registered abilities
 
+### Identifying a media
+
+`imagify/optimize-media`, `imagify/restore-media` and `imagify/get-media-status` accept three
+interchangeable identifiers, so a caller that only knows the file name or the URL of an image does
+not have to look its attachment ID up first. None of the three is required on its own — exactly one
+must be supplied (hence `no*` in the input tables):
+
+| Input | Resolution |
+|-------|------------|
+| `media_id` | Used as-is. |
+| `media_url` | `attachment_url_to_postid()`. Next-gen and thumbnail URLs (`hero-300x200.jpg.webp`) fall back to a file-name lookup on the original. |
+| `media_filename` | Exact, case-insensitive match on the base name of the `_wp_attached_file` meta. A full relative path (`2026/08/hero.jpg`) is accepted too. |
+
+`media_id` wins over `media_url`, which wins over `media_filename`. A `media_id` of `0` or less is
+treated as absent, so the next identifier is tried.
+
+Errors are explicit and actionable rather than best-effort:
+
+| Error code | When |
+|------------|------|
+| `imagify_missing_media_identifier` | None of the three inputs was usable. |
+| `imagify_media_not_found` | The URL or file name matches nothing in the library. |
+| `imagify_ambiguous_media_filename` | Several attachments share the file name. The message lists the matching IDs so the caller can retry with `media_id`. |
+
+Resolution lives in `Imagify\Abilities\MediaResolver::resolve_id()`, which returns an attachment ID
+or a `WP_Error`. Each ability turns that `WP_Error` into its own `status: "error"` output shape.
+
 ### Credit confirmation flow
 
 `imagify/optimize-media`, `imagify/bulk-optimize`, and `imagify/generate-missing-nextgen` consume
@@ -241,7 +268,9 @@ Delegates to `Imagify\Optimization\Process\WP::optimize()` for first-time optimi
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `media_id` | integer | yes | WordPress attachment ID. |
+| `media_id` | integer | no* | WordPress attachment ID. |
+| `media_filename` | string | no* | File name of the media, for example `hero-banner.jpg`. |
+| `media_url` | string | no* | Absolute URL of the media. |
 | `optimization_level` | integer (0–2) | no | Overrides the global setting. 0 = normal, 1 = aggressive, 2 = ultra. |
 | `confirm` | boolean | no | Set to `true` to execute after reviewing the credit-consumption preview returned by a prior call without this flag. Defaults to `false`. See [Credit confirmation flow](#credit-confirmation-flow). |
 
@@ -272,7 +301,9 @@ Restores an optimized media to its original state using the stored backup file. 
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `media_id` | integer | yes | WordPress attachment ID to restore. |
+| `media_id` | integer | no* | WordPress attachment ID to restore. |
+| `media_filename` | string | no* | File name of the media, for example `hero-banner.jpg`. |
+| `media_url` | string | no* | Absolute URL of the media. |
 
 **Output schema:**
 
@@ -383,7 +414,9 @@ Registered by `Imagify\Abilities\GetMediaStatus`. Returns the optimization statu
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `media_id` | integer | yes | WordPress attachment ID. |
+| `media_id` | integer | no* | WordPress attachment ID. |
+| `media_filename` | string | no* | File name of the media, for example `hero-banner.jpg`. |
+| `media_url` | string | no* | Absolute URL of the media. |
 
 **Output schema:**
 
@@ -397,7 +430,7 @@ Registered by `Imagify\Abilities\GetMediaStatus`. Returns the optimization statu
 | `avif_available` | boolean | `true` when an AVIF version of the full-size image has been generated. |
 | `error_message` | string \| null | Human-readable error message when `status` is `"error"`. `null` otherwise. |
 
-**Error behaviour:** If `media_id` is `0` or negative, or the attachment does not exist in the database, returns `status: "error"` with a descriptive `error_message`.
+**Error behaviour:** If no identifier resolves to an attachment, returns `status: "error"` with a descriptive `error_message`. See [Identifying a media](#identifying-a-media).
 
 ### `imagify/get-nextgen-coverage`
 


### PR DESCRIPTION
# Description

Fixes #1220

The MCP media actions only accepted a numeric attachment ID, so `Optimize hero-banner.jpg` was not
possible: the user had to open the Media Library, edit the image and copy the ID out of the browser
URL first. `imagify/optimize-media`, `imagify/restore-media` and `imagify/get-media-status` now also
accept `media_filename` and `media_url`, so an assistant can act on the identifier the user actually
has.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## Detailed scenario

### What was tested

**Automated — integration (`--group MediaResolver`, 20 tests / 48 assertions), against a real
database and real `WP_Query`:** resolution by ID, by file name, case-insensitively, by relative path
(`2026/08/hero.jpg`), by URL, and by derivative URLs (`hero.jpg.webp`, `hero.jpg.avif`,
`hero-300x200.jpg`, `hero-300x200.jpg.webp`). Plus the failure paths: unknown file name, unknown URL,
ambiguous file name (asserting the candidate IDs appear in the message), and every unusable-input
shape (`[]`, `media_id: 0`, `media_id: -5`, blank URL, blank file name). One test specifically pins
that `hero.jpg` does **not** resolve to `my-hero.jpg` or `hero.jpg.bak`.

**Automated — integration, per ability:** all three abilities register `media_filename` and
`media_url` and no longer mark any input as required. `imagify/get-media-status` executed with
`media_filename` returns output identical to the same media by `media_id`. `imagify/restore-media`
reaches its restore logic on a resolvable file name and reports the unknown one explicitly.

**Automated — unit:** 490 unit tests pass, including the existing media-ability tests updated for the
new error message.

**Manual, on a real site (WP 7.0.2, Local, populated Media Library):** for three real attachments,
`media_filename`, `media_url` and a next-gen `…png.webp` URL each resolved to the correct attachment
ID, and `imagify/get-media-status` returned byte-identical output whether called with
`media_filename` or `media_id`.

```
#118 pr1203-transient2-scaled.png
  filename -> 118    url -> 118    url.webp -> 118
imagify_media_not_found: No media in the library is named "definitely-not-here.jpg".
imagify_missing_media_identifier: Provide one of media_id, media_url, or media_filename to identify the media.
```

`composer phpcs` and `composer run-stan` are clean.

### How to test

1. On a site with WP 6.9+ and the MCP server reachable, note a file name in the Media Library, for
   example `hero-banner.jpg`.
2. Call `imagify/get-media-status` with `{"media_filename": "hero-banner.jpg"}` and then with
   `{"media_id": <that attachment's ID>}` — the two responses must be identical.
3. Call it with `{"media_url": "<the attachment URL>"}`, then again with `.webp` appended to that URL
   — both must resolve to the same media.
4. Upload the same file name into two different months, then call with that file name: the error must
   name both attachment IDs.
5. Call with `{}`: the error must list the three accepted inputs.
6. Repeat step 2 against `imagify/optimize-media` and `imagify/restore-media`.

### Affected Features & Quality Assurance Scope

The three MCP media abilities. `media_id` behaviour is unchanged, including `imagify/restore-media`'s
existing fallback to the `custom-folders` context. No non-MCP code path is touched: the Media Library
UI, bulk optimization and the upload flow are untouched.

## Technical description

### Documentation

`Imagify\Abilities\MediaResolver::resolve_id( array $args )` returns an attachment ID or a `WP_Error`.
Precedence is `media_id`, then `media_url`, then `media_filename`; a `media_id` of `0` or less counts
as absent, so the next identifier is tried. Each ability calls it first and converts a `WP_Error` into
its own `status: "error"` output shape, so no output schema changed.

`media_url` goes through `attachment_url_to_postid()`. Because a front-end URL often points at a
derivative rather than the original, a miss retries as a file-name lookup after peeling off the
next-gen extension and the `-300x200` dimension suffix, so `hero-300x200.jpg.webp` still finds
`hero.jpg`.

`media_filename` narrows candidates with a `LIKE` on `_wp_attached_file`, then keeps only the rows
whose own base name matches exactly and case-insensitively. That second pass is the important part: a
bare `LIKE '%hero.jpg%'` also matches `my-hero.jpg` and `hero.jpg.bak`, which would mean optimizing or
restoring the wrong file. A full relative path is accepted and reduced to its base name.

Ambiguity is never resolved silently. When several attachments share a name the error lists their IDs
so the caller can retry with `media_id`.

The two new schema properties come from `MediaResolver::get_input_schema_properties()` so the three
abilities cannot drift apart. `docs/api/mcp.md` gains an "Identifying a media" section documenting
precedence, the derivative-URL fallback and the three error codes.

### New dependencies

None. Uses `attachment_url_to_postid()` and `WP_Query`.

### Risks

The file-name lookup adds one `WP_Query` with a postmeta `LIKE`, which cannot use an index on the
value. It is bounded: `posts_per_page` is capped at 20 via `MAX_CANDIDATES`, `no_found_rows` skips the
count query, and it only runs on an explicit one-shot MCP call — never in a page render or a bulk
loop. It is also skipped entirely whenever `media_id` is supplied, so existing callers pay nothing.

Dropping `media_id` from `required` means a caller can now send no identifier at all. That is the
point of the change, and the resolver answers with an explicit message naming the three accepted
inputs rather than falling through to a vague failure.

The derivative-URL fallback is a deliberate best-effort guess and only runs after
`attachment_url_to_postid()` has already failed, so it cannot change the result for a URL that
resolves normally. If the guess is itself ambiguous, the ambiguity error applies as usual.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

All mandatory items apply and are done.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
