### PR TITLE
test: mock HTTP requests in ImagifyUser integration tests

### DIFF
--- a/Tests/Integration/inc/classes/ImagifyUser/TestCase.php
+++ b/Tests/Integration/inc/classes/ImagifyUser/TestCase.php
@@ -4,12 +4,26 @@ namespace Imagify\Tests\Integration\inc\classes\ImagifyUser;
 
 use Imagify;
 use Imagify\Tests\Integration\TestCase as BaseTestCase;
+use WPMedia\PHPUnit\Integration\HttpRequestTrait;
 
 abstract class TestCase extends BaseTestCase {
+	use HttpRequestTrait;
+
+	/**
+	 * A syntactically valid API key. The Imagify API is mocked, so the key only
+	 * needs to be non-empty for the request to be attempted.
+	 *
+	 * @var string
+	 */
+	protected $validApiKey = 'imagify1234567890abcdefghijklmnopqrst';
+
 	protected $originalUserInstance;
 
 	public function set_up() {
 		parent::set_up();
+
+		// Block and mock any outbound HTTP request. Responses are declared per test via `$this->config['http']`.
+		$this->setup_http();
 
 		$this->originalUserInstance = $this->resetPropertyValue( 'user', Imagify::class );
 
@@ -18,15 +32,84 @@ abstract class TestCase extends BaseTestCase {
 	}
 
 	public function tear_down() {
-		parent::tear_down();
-
 		// Restore the user on the static property.
 		$this->setPropertyValue( 'user', Imagify::class, $this->originalUserInstance );
 
 		//Clean up the transients for API cache
 		delete_transient('imagify_user_cache');
 
+		// Fails the test if an HTTP request was not mocked, then removes the filter.
+		$this->tear_down_http();
 
+		parent::tear_down();
+	}
 
+	/**
+	 * Mocks the `users/me/` endpoint with a successful user account response.
+	 *
+	 * @param array $data Values overriding the default user account payload.
+	 *
+	 * @return void
+	 */
+	protected function mockUserAccount( array $data = [] ) {
+		$user = array_merge(
+			[
+				'id'                           => 14,
+				'email'                        => 'imagify@example.com',
+				'plan_id'                      => 1,
+				'plan_label'                   => 'free',
+				'account_type'                 => 'free',
+				'quota'                        => 1000,
+				'extra_quota'                  => 0,
+				'extra_quota_consumed'         => 0,
+				'consumed_current_month_quota' => 200,
+				'next_date_update'             => '2026-09-01',
+				'is_active'                    => true,
+				'is_monthly'                   => true,
+			],
+			$data
+		);
+
+		$this->mockUsersMeEndpoint( wp_json_encode( $user ), 200, 'OK' );
+	}
+
+	/**
+	 * Mocks the `users/me/` endpoint with the "Invalid token" error the API
+	 * returns when the API key is not valid.
+	 *
+	 * @return void
+	 */
+	protected function mockInvalidToken() {
+		$body = wp_json_encode(
+			[
+				'code'   => 'invalid_credentials',
+				'detail' => 'Invalid token.',
+			]
+		);
+
+		$this->mockUsersMeEndpoint( $body, 401, 'Unauthorized' );
+	}
+
+	/**
+	 * Registers the mocked HTTP response for the `users/me/` endpoint.
+	 *
+	 * @param string $body    Response body.
+	 * @param int    $code    HTTP status code.
+	 * @param string $message HTTP status message.
+	 *
+	 * @return void
+	 */
+	private function mockUsersMeEndpoint( $body, $code, $message ) {
+		$this->config['http'] = [
+			Imagify::API_ENDPOINT . 'users/me/' => [
+				'headers'  => [],
+				'body'     => $body,
+				'response' => [
+					'code'    => $code,
+					'message' => $message,
+				],
+				'cookies'  => [],
+			],
+		];
 	}
 }

--- a/Tests/Integration/inc/classes/ImagifyUser/getError.php
+++ b/Tests/Integration/inc/classes/ImagifyUser/getError.php
@@ -17,7 +17,8 @@ class Test_GetError extends TestCase {
 	 * Test \Imagify\User\User->get_error() should return false when succesfully fetched user account data.
 	 */
 	public function testShouldReturnFalseWhenFetchedUserData() {
-		update_imagify_option( 'api_key', $this->getApiCredential( 'IMAGIFY_TESTS_API_KEY' ) );
+		update_imagify_option( 'api_key', $this->validApiKey );
+		$this->mockUserAccount();
 
 		// Verify the static $user property is null.
 		$this->assertNull( $this->getNonPublicPropertyValue( 'user', Imagify::class ) );
@@ -36,6 +37,7 @@ class Test_GetError extends TestCase {
 	 */
 	public function testShouldReturnErrorWhenCouldNotFetchUserData() {
 		update_imagify_option( 'api_key', $this->invalidApiKey );
+		$this->mockInvalidToken();
 
 		// Verify the static $user property is null.
 		$this->assertNull( $this->getNonPublicPropertyValue( 'user', Imagify::class ) );

--- a/Tests/Integration/inc/classes/ImagifyUser/getPercentConsumedQuota.php
+++ b/Tests/Integration/inc/classes/ImagifyUser/getPercentConsumedQuota.php
@@ -32,6 +32,7 @@ class Test_GetPercentConsumedQuota extends TestCase {
 
 	public function testShouldReturnZeroWhenCouldNotFetchUserData() {
 		update_imagify_option( 'api_key', $this->invalidApiKey );
+		$this->mockInvalidToken();
 
 		// Verify the static $user property is null.
 		$this->assertNull( $this->getNonPublicPropertyValue( 'user', Imagify::class ) );
@@ -40,7 +41,13 @@ class Test_GetPercentConsumedQuota extends TestCase {
 	}
 
 	public function testShouldReturnQuotaWhenFetchedUserData() {
-		update_imagify_option( 'api_key', $this->getApiCredential( 'IMAGIFY_TESTS_API_KEY' ) );
+		update_imagify_option( 'api_key', $this->validApiKey );
+		$this->mockUserAccount(
+			[
+				'quota'                        => 1000,
+				'consumed_current_month_quota' => 500,
+			]
+		);
 
 		// Verify the static $user property is null.
 		$this->assertNull( $this->getNonPublicPropertyValue( 'user', Imagify::class ) );

--- a/Tests/Integration/inc/classes/ImagifyUser/isOverQuota.php
+++ b/Tests/Integration/inc/classes/ImagifyUser/isOverQuota.php
@@ -28,6 +28,7 @@ class Test_IsOverQuota extends TestCase {
 
 	public function testShouldReturnFalseWhenCouldNotFetchUserData() {
 		update_imagify_option( 'api_key', $this->invalidApiKey );
+		$this->mockInvalidToken();
 
 		// Verify the static $user property is null.
 		$this->assertNull( $this->getNonPublicPropertyValue( 'user', Imagify::class ) );
@@ -38,12 +39,14 @@ class Test_IsOverQuota extends TestCase {
 	}
 
 	public function testShouldReturnFalseWhenPaidAccount() {
-		update_imagify_option( 'api_key', $this->getApiCredential( 'IMAGIFY_TESTS_API_KEY' ) );
+		update_imagify_option( 'api_key', $this->validApiKey );
+		$this->mockUserAccount();
 
 		// Verify the static $user property is null.
 		$this->assertNull( $this->getNonPublicPropertyValue( 'user', Imagify::class ) );
 
 		$imagifyUser = new User();
+		$imagifyUser->init_user();
 		// Make our account a paid one.
 		$imagifyUser->plan_id = 2;
 		// Even if it is supposed to be over-quota.
@@ -56,7 +59,8 @@ class Test_IsOverQuota extends TestCase {
 	}
 
 	public function testShouldReturnFalseWhenFreeNotOverQuota() {
-		update_imagify_option( 'api_key', $this->getApiCredential( 'IMAGIFY_TESTS_API_KEY' ) );
+		update_imagify_option( 'api_key', $this->validApiKey );
+		$this->mockUserAccount();
 
 		// Verify the static $user property is null.
 		$this->assertNull( $this->getNonPublicPropertyValue( 'user', Imagify::class ) );
@@ -73,7 +77,8 @@ class Test_IsOverQuota extends TestCase {
 	}
 
 	public function testShouldReturnTrueWhenFreeOverQuota() {
-		update_imagify_option( 'api_key', $this->getApiCredential( 'IMAGIFY_TESTS_API_KEY' ) );
+		update_imagify_option( 'api_key', $this->validApiKey );
+		$this->mockUserAccount();
 
 		// Verify the static $user property is null.
 		$this->assertNull( $this->getNonPublicPropertyValue( 'user', Imagify::class ) );


### PR DESCRIPTION
# Description

The ImagifyUser integration tests were flaky and fragile, depending on a `IMAGIFY_TESTS_API_KEY` secret to make real HTTP requests to the Imagify API at `https://app.imagify.io/api/users/me/`. They now mock the HTTP layer using `wp-media/phpunit`'s `HttpRequestTrait`, eliminating network dependency and guaranteeing deterministic execution.

**Changes:**
- `TestCase.php`: uses `HttpRequestTrait`; sets up and tears down mocked HTTP; provides `mockUserAccount()` and `mockInvalidToken()` helpers; introduces non-secret `$validApiKey`.
- `getError.php`, `getPercentConsumedQuota.php`, `isOverQuota.php`: swap `getApiCredential('IMAGIFY_TESTS_API_KEY')` for mocked `$validApiKey` + appropriate mock helper.
- `isOverQuota.php`: fixed dead code by explicitly calling `init_user()` before the paid-account override so the paid-account branch is now genuinely exercised.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [x] Chore
- [ ] Release

## Detailed scenario

### What was tested

Ran the full ImagifyUser integration test suite inside wp-env (Docker) with WordPress 6.9.6, PHP 8.2.33:
```
vendor/bin/phpunit --configuration Tests/Integration/phpunit.xml.dist --testsuite integration --filter "ImagifyUser"
```
**Result:** `OK (8 tests, 21 assertions)` in 0.172s. Fast execution and the trait's unmocked-request block confirm zero real network traffic. Tests are deterministic and no longer require `IMAGIFY_TESTS_API_KEY`.

### How to test

1. Boot wp-env in the `tests-cli` container: `wp-env run tests-cli bash`
2. Run the filtered phpunit command above.
3. Confirm all 8 tests pass.
4. Note that tests pass even without `IMAGIFY_TESTS_API_KEY` set in the environment.
5. *Verification of mocking:* Comment out a `mockUserAccount()` or `mockInvalidToken()` call in any test and re-run; the trait will fail the test, proving requests are mocked and unmocked requests are blocked.

### Affected Features & Quality Assurance Scope

Test infrastructure only. No plugin runtime code is touched. No QA impact on optimization, admin flows, or user-facing behavior. The ImagifyUser integration tests are now faster and more reliable; all assertions remain unchanged.

## Technical description

### Documentation

The `wp-media/phpunit` package provides `HttpRequestTrait`, which mocks `wp_remote_request()` via the `pre_http_request` filter. Each test declares mocked responses by populating the `http` key in `$this->config` with URL → response mappings. The trait blocks (fails the test) on any unmocked request, guaranteeing network silence.

### New dependencies

None. `wp-media/phpunit` and `HttpRequestTrait` are already present in the repository.

### Risks

Low. Refactor is confined to the ImagifyUser integration test files under `Tests/Integration/inc/classes/ImagifyUser/`. No production code is touched. The trait's fail-on-unmocked-request behavior is a safety feature, not a risk.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

All boxes are ticked. All Code validation criteria apply: acceptance criteria validated by test run (8 passing, no errors), all lines triggered in phpunit execution. All Code style criteria apply: test helpers are self-documenting (`mockUserAccount`, `mockInvalidToken`); no user input (test-only); no added complexity; no user-facing messages (test infrastructure).

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
