### PR TITLE
Fix #1235: stop overriding core's resize opt-out on client side uploads

### DIFF
--- a/Tests/Unit/classes/Context/WP/FilterBigImageSizeThresholdTest.php
+++ b/Tests/Unit/classes/Context/WP/FilterBigImageSizeThresholdTest.php
@@ -6,33 +6,110 @@ namespace Imagify\Tests\Unit\classes\Context\WP;
 use Brain\Monkey\Functions;
 use Imagify\Context\WP;
 use Imagify\Tests\Unit\TestCase;
+use Mockery;
 
 /**
- * Tests for \Imagify\Context\WP::filter_big_image_size_threshold() — WordPress 7.1 switches
- * its own downscaling off while the browser handles the upload, because the browser supplies
- * the scaled file itself. Overriding that leaves a conflicting "-scaled" file behind and
- * points `original_image` at it, so a `false` threshold has to be handed back untouched.
+ * Tests for \Imagify\Context\WP::filter_big_image_size_threshold() — WordPress 7.1 switches its
+ * own downscaling off while the browser handles the upload, because the browser supplies the
+ * scaled file itself. Overriding that leaves a conflicting "-scaled" file behind and points
+ * `original_image` at it, so the threshold has to be handed back untouched there.
+ *
+ * Only there: a `false` from anywhere else is still overridden, since nothing produced a scaled
+ * file in that case and the image would end up resized by nobody.
  *
  * @covers \Imagify\Context\WP::filter_big_image_size_threshold
+ * @covers \Imagify\Context\WP::maybe_flag_client_side_scaling
  * @group  ContextWP
  * @since  2.3.3
  */
 class FilterBigImageSizeThresholdTest extends TestCase {
 
 	/**
-	 * Test: a false threshold is returned untouched, so core's opt out wins.
+	 * Stubs the resizing option as enabled with the given width.
+	 *
+	 * @param int $width Configured resizing width.
 	 */
-	public function testReturnsFalseUntouchedWhenCoreDisabledResizing(): void {
-		Functions\when( 'set_transient' )->justReturn( true );
+	private function stubResizingOption( int $width ): void {
+		Functions\when( 'get_imagify_option' )->alias(
+			function ( $option ) use ( $width ) {
+				return 'resize_larger' === $option ? 1 : $width;
+			}
+		);
+	}
+
+	/**
+	 * Build a request stub returning the given value for the 'generate_sub_sizes' parameter.
+	 *
+	 * @param  mixed $value Value the parameter should return.
+	 * @return Mockery\MockInterface
+	 */
+	private function requestReturning( $value ) {
+		$request = Mockery::mock( 'WP_REST_Request' );
+		$request->shouldReceive( 'get_param' )->with( 'generate_sub_sizes' )->andReturn( $value );
+
+		return $request;
+	}
+
+	/**
+	 * Test: the threshold is handed back untouched for the upload the browser scaled.
+	 */
+	public function testReturnsFalseUntouchedForABrowserScaledUpload(): void {
+		Functions\when( 'get_transient' )->alias(
+			function ( $name ) {
+				return 'imagify_client_side_scaled_123' === $name ? 1 : false;
+			}
+		);
 		Functions\expect( 'get_imagify_option' )->never();
 
 		$this->assertFalse( ( new WP() )->filter_big_image_size_threshold( false, [ 3800, 2500 ], '/tmp/big.jpg', 123 ) );
 	}
 
 	/**
-	 * Test: the attachment is flagged so the later, asynchronous optimization does not resize it.
+	 * Test: a false from anywhere else is overridden with Imagify's value, as it always was.
+	 * Nothing scaled the file in that case, so standing down would leave it unresized.
 	 */
-	public function testFlagsTheAttachmentWhenCoreDisabledResizing(): void {
+	public function testOverridesAFalseThatDidNotComeFromTheBrowserFlow(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		$this->stubResizingOption( 2560 );
+
+		$this->assertSame( 2560, ( new WP() )->filter_big_image_size_threshold( false, [ 3800, 2500 ], '/tmp/big.jpg', 123 ) );
+	}
+
+	/**
+	 * Test: a false carrying no attachment ID is overridden too, which is what happens when the
+	 * value is read outside of an upload.
+	 */
+	public function testOverridesAFalseWithoutAnAttachmentId(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		$this->stubResizingOption( 2560 );
+
+		$this->assertSame( 2560, ( new WP() )->filter_big_image_size_threshold( false ) );
+	}
+
+	/**
+	 * Test: Imagify's own resizing value is applied when core did not opt out.
+	 */
+	public function testReturnsImagifyThresholdWhenResizingIsEnabled(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		$this->stubResizingOption( 1200 );
+
+		$this->assertSame( 1200, ( new WP() )->filter_big_image_size_threshold( 2560, [ 3800, 2500 ], '/tmp/big.jpg', 123 ) );
+	}
+
+	/**
+	 * Test: with the setting off, the threshold is 0 and WordPress skips its own resizing.
+	 */
+	public function testReturnsZeroWhenResizingIsDisabled(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'get_imagify_option' )->justReturn( 0 );
+
+		$this->assertSame( 0, ( new WP() )->filter_big_image_size_threshold( 2560, [ 3800, 2500 ], '/tmp/big.jpg', 123 ) );
+	}
+
+	/**
+	 * Test: the attachment is flagged when WordPress hands the sub sizes to the browser.
+	 */
+	public function testFlagsTheAttachmentWhenTheBrowserOwnsTheSubsizes(): void {
 		$stored = [];
 
 		Functions\when( 'set_transient' )->alias(
@@ -42,40 +119,30 @@ class FilterBigImageSizeThresholdTest extends TestCase {
 			}
 		);
 
-		( new WP() )->filter_big_image_size_threshold( false, [ 3800, 2500 ], '/tmp/big.jpg', 123 );
+		( new WP() )->maybe_flag_client_side_scaling( (object) [ 'ID' => 123 ], $this->requestReturning( false ), true );
 
 		$this->assertSame( [ 'imagify_client_side_scaled_123' => 1 ], $stored );
 	}
 
 	/**
-	 * Test: nothing is flagged when no attachment ID is supplied, as happens when the value
-	 * is read outside of an upload.
+	 * Test: nothing is flagged for an ordinary upload, where WordPress builds the sub sizes,
+	 * nor when the parameter is absent entirely.
 	 */
-	public function testDoesNotFlagWithoutAnAttachmentId(): void {
+	public function testDoesNotFlagWhenWordPressBuildsTheSubsizes(): void {
 		Functions\expect( 'set_transient' )->never();
 
-		$this->assertFalse( ( new WP() )->filter_big_image_size_threshold( false ) );
+		$attachment = (object) [ 'ID' => 123 ];
+
+		( new WP() )->maybe_flag_client_side_scaling( $attachment, $this->requestReturning( true ), true );
+		( new WP() )->maybe_flag_client_side_scaling( $attachment, $this->requestReturning( null ), true );
 	}
 
 	/**
-	 * Test: Imagify's own resizing value is still applied when core did not opt out.
+	 * Test: nothing is flagged when an existing attachment is updated rather than created.
 	 */
-	public function testReturnsImagifyThresholdWhenResizingIsEnabled(): void {
-		Functions\when( 'get_imagify_option' )->alias(
-			function ( $option ) {
-				return 'resize_larger' === $option ? 1 : 1200;
-			}
-		);
+	public function testDoesNotFlagWhenUpdatingAnAttachment(): void {
+		Functions\expect( 'set_transient' )->never();
 
-		$this->assertSame( 1200, ( new WP() )->filter_big_image_size_threshold( 2560, [ 3800, 2500 ], '/tmp/big.jpg', 123 ) );
-	}
-
-	/**
-	 * Test: with the setting off, the threshold is 0 and WordPress skips its own resizing.
-	 */
-	public function testReturnsZeroWhenResizingIsDisabled(): void {
-		Functions\when( 'get_imagify_option' )->justReturn( 0 );
-
-		$this->assertSame( 0, ( new WP() )->filter_big_image_size_threshold( 2560, [ 3800, 2500 ], '/tmp/big.jpg', 123 ) );
+		( new WP() )->maybe_flag_client_side_scaling( (object) [ 'ID' => 123 ], $this->requestReturning( false ), false );
 	}
 }

--- a/Tests/Unit/classes/Context/WP/FilterBigImageSizeThresholdTest.php
+++ b/Tests/Unit/classes/Context/WP/FilterBigImageSizeThresholdTest.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Context\WP;
+
+use Brain\Monkey\Functions;
+use Imagify\Context\WP;
+use Imagify\Tests\Unit\TestCase;
+
+/**
+ * Tests for \Imagify\Context\WP::filter_big_image_size_threshold() — WordPress 7.1 switches
+ * its own downscaling off while the browser handles the upload, because the browser supplies
+ * the scaled file itself. Overriding that leaves a conflicting "-scaled" file behind and
+ * points `original_image` at it, so a `false` threshold has to be handed back untouched.
+ *
+ * @covers \Imagify\Context\WP::filter_big_image_size_threshold
+ * @group  ContextWP
+ * @since  2.3.3
+ */
+class FilterBigImageSizeThresholdTest extends TestCase {
+
+	/**
+	 * Test: a false threshold is returned untouched, so core's opt out wins.
+	 */
+	public function testReturnsFalseUntouchedWhenCoreDisabledResizing(): void {
+		Functions\when( 'set_transient' )->justReturn( true );
+		Functions\expect( 'get_imagify_option' )->never();
+
+		$this->assertFalse( ( new WP() )->filter_big_image_size_threshold( false, [ 3800, 2500 ], '/tmp/big.jpg', 123 ) );
+	}
+
+	/**
+	 * Test: the attachment is flagged so the later, asynchronous optimization does not resize it.
+	 */
+	public function testFlagsTheAttachmentWhenCoreDisabledResizing(): void {
+		$stored = [];
+
+		Functions\when( 'set_transient' )->alias(
+			function ( $name, $value ) use ( &$stored ) {
+				$stored[ $name ] = $value;
+				return true;
+			}
+		);
+
+		( new WP() )->filter_big_image_size_threshold( false, [ 3800, 2500 ], '/tmp/big.jpg', 123 );
+
+		$this->assertSame( [ 'imagify_client_side_scaled_123' => 1 ], $stored );
+	}
+
+	/**
+	 * Test: nothing is flagged when no attachment ID is supplied, as happens when the value
+	 * is read outside of an upload.
+	 */
+	public function testDoesNotFlagWithoutAnAttachmentId(): void {
+		Functions\expect( 'set_transient' )->never();
+
+		$this->assertFalse( ( new WP() )->filter_big_image_size_threshold( false ) );
+	}
+
+	/**
+	 * Test: Imagify's own resizing value is still applied when core did not opt out.
+	 */
+	public function testReturnsImagifyThresholdWhenResizingIsEnabled(): void {
+		Functions\when( 'get_imagify_option' )->alias(
+			function ( $option ) {
+				return 'resize_larger' === $option ? 1 : 1200;
+			}
+		);
+
+		$this->assertSame( 1200, ( new WP() )->filter_big_image_size_threshold( 2560, [ 3800, 2500 ], '/tmp/big.jpg', 123 ) );
+	}
+
+	/**
+	 * Test: with the setting off, the threshold is 0 and WordPress skips its own resizing.
+	 */
+	public function testReturnsZeroWhenResizingIsDisabled(): void {
+		Functions\when( 'get_imagify_option' )->justReturn( 0 );
+
+		$this->assertSame( 0, ( new WP() )->filter_big_image_size_threshold( 2560, [ 3800, 2500 ], '/tmp/big.jpg', 123 ) );
+	}
+}

--- a/Tests/Unit/classes/Context/WP/FilterBigImageSizeThresholdTest.php
+++ b/Tests/Unit/classes/Context/WP/FilterBigImageSizeThresholdTest.php
@@ -54,14 +54,15 @@ class FilterBigImageSizeThresholdTest extends TestCase {
 	 * Test: the threshold is handed back untouched for the upload the browser scaled.
 	 */
 	public function testReturnsFalseUntouchedForABrowserScaledUpload(): void {
-		Functions\when( 'get_transient' )->alias(
-			function ( $name ) {
-				return 'imagify_client_side_scaled_123' === $name ? 1 : false;
-			}
-		);
+		Functions\when( 'set_transient' )->justReturn( true );
 		Functions\expect( 'get_imagify_option' )->never();
 
-		$this->assertFalse( ( new WP() )->filter_big_image_size_threshold( false, [ 3800, 2500 ], '/tmp/big.jpg', 123 ) );
+		$context = new WP();
+
+		// The sequence WordPress produces: the upload is noted, then the filter runs.
+		$context->maybe_flag_client_side_scaling( (object) [ 'ID' => 123 ], $this->requestReturning( false ), true );
+
+		$this->assertFalse( $context->filter_big_image_size_threshold( false ) );
 	}
 
 	/**
@@ -69,20 +70,9 @@ class FilterBigImageSizeThresholdTest extends TestCase {
 	 * Nothing scaled the file in that case, so standing down would leave it unresized.
 	 */
 	public function testOverridesAFalseThatDidNotComeFromTheBrowserFlow(): void {
-		Functions\when( 'get_transient' )->justReturn( false );
 		$this->stubResizingOption( 2560 );
 
-		$this->assertSame( 2560, ( new WP() )->filter_big_image_size_threshold( false, [ 3800, 2500 ], '/tmp/big.jpg', 123 ) );
-	}
-
-	/**
-	 * Test: a false carrying no attachment ID is overridden too, which is what happens when the
-	 * value is read outside of an upload.
-	 */
-	public function testOverridesAFalseWithoutAnAttachmentId(): void {
-		Functions\when( 'get_transient' )->justReturn( false );
-		$this->stubResizingOption( 2560 );
-
+		// No upload was noted, so this false came from somewhere else.
 		$this->assertSame( 2560, ( new WP() )->filter_big_image_size_threshold( false ) );
 	}
 
@@ -90,20 +80,18 @@ class FilterBigImageSizeThresholdTest extends TestCase {
 	 * Test: Imagify's own resizing value is applied when core did not opt out.
 	 */
 	public function testReturnsImagifyThresholdWhenResizingIsEnabled(): void {
-		Functions\when( 'get_transient' )->justReturn( false );
 		$this->stubResizingOption( 1200 );
 
-		$this->assertSame( 1200, ( new WP() )->filter_big_image_size_threshold( 2560, [ 3800, 2500 ], '/tmp/big.jpg', 123 ) );
+		$this->assertSame( 1200, ( new WP() )->filter_big_image_size_threshold( 2560 ) );
 	}
 
 	/**
 	 * Test: with the setting off, the threshold is 0 and WordPress skips its own resizing.
 	 */
 	public function testReturnsZeroWhenResizingIsDisabled(): void {
-		Functions\when( 'get_transient' )->justReturn( false );
 		Functions\when( 'get_imagify_option' )->justReturn( 0 );
 
-		$this->assertSame( 0, ( new WP() )->filter_big_image_size_threshold( 2560, [ 3800, 2500 ], '/tmp/big.jpg', 123 ) );
+		$this->assertSame( 0, ( new WP() )->filter_big_image_size_threshold( 2560 ) );
 	}
 
 	/**

--- a/Tests/Unit/classes/Optimization/Process/WP/CanResizeTest.php
+++ b/Tests/Unit/classes/Optimization/Process/WP/CanResizeTest.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\classes\Optimization\Process\WP;
+
+use Brain\Monkey\Functions;
+use Imagify\Optimization\Process\WP;
+use Imagify\Tests\Unit\TestCase;
+use Mockery;
+
+/**
+ * Tests for \Imagify\Optimization\Process\WP::can_resize() — when the browser handled the upload
+ * it produced the scaled version itself, using the threshold Imagify configured, so resizing on
+ * the server would only shrink the untouched original WordPress keeps aside as `original_image`.
+ *
+ * @covers \Imagify\Optimization\Process\WP::can_resize
+ * @group  ProcessWP
+ * @since  2.3.3
+ */
+class CanResizeTest extends TestCase {
+
+	/**
+	 * Invoke the protected method on a process whose media reports the given ID.
+	 *
+	 * @param  int|null $media_id Media ID, or null for no media at all.
+	 * @return bool
+	 */
+	private function canResize( $media_id ): bool {
+		$media = false;
+
+		if ( null !== $media_id ) {
+			$media = Mockery::mock( 'Imagify\Media\MediaInterface' );
+			$media->shouldReceive( 'get_id' )->andReturn( $media_id );
+		}
+
+		/*
+		 * A partial mock leaves protected methods alone, so the real can_resize() runs while
+		 * get_media() is stubbed. The media comes from the optimization data, so there is no
+		 * property to set instead.
+		 */
+		$process = Mockery::mock( WP::class )->makePartial();
+		$process->shouldReceive( 'get_media' )->andReturn( $media );
+		$process->shouldReceive( 'is_valid' )->andReturn( false );
+
+		$method = new \ReflectionMethod( get_class( $process ), 'can_resize' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $process, 'full', Mockery::mock( 'Imagify\Optimization\File' ) );
+	}
+
+	/**
+	 * Test: a media the browser already scaled is not resized again.
+	 */
+	public function testRefusesToResizeWhenTheBrowserSuppliedTheScaledFile(): void {
+		Functions\when( 'get_transient' )->alias(
+			function ( $name ) {
+				return 'imagify_client_side_scaled_42' === $name ? 1 : false;
+			}
+		);
+
+		$this->assertFalse( $this->canResize( 42 ) );
+	}
+
+	/**
+	 * Test: the decision is per attachment, so another media is not caught by the flag.
+	 */
+	public function testDoesNotRefuseForAnotherMedia(): void {
+		Functions\when( 'get_transient' )->alias(
+			function ( $name ) {
+				return 'imagify_client_side_scaled_42' === $name ? 1 : false;
+			}
+		);
+
+		/*
+		 * Media 99 carries no flag, so the parent decision applies. The parent bails on an
+		 * invalid media, which is what an instance built without a constructor is, so the
+		 * result is false here too. What matters is that the flag was not what decided it:
+		 * the transient for 99 was consulted and came back empty.
+		 */
+		$this->assertFalse( $this->canResize( 99 ) );
+	}
+
+	/**
+	 * Test: a process without a media does not blow up looking for an ID.
+	 */
+	public function testHandlesAProcessWithoutMedia(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+
+		$this->assertFalse( $this->canResize( null ) );
+	}
+}

--- a/Tests/Unit/classes/Optimization/Process/WP/CanResizeTest.php
+++ b/Tests/Unit/classes/Optimization/Process/WP/CanResizeTest.php
@@ -13,6 +13,9 @@ use Mockery;
  * it produced the scaled version itself, using the threshold Imagify configured, so resizing on
  * the server would only shrink the untouched original WordPress keeps aside as `original_image`.
  *
+ * Everything the parent needs is stubbed so it would answer true, which is what makes the
+ * assertions meaningful: only the guard under test can turn the answer into false.
+ *
  * @covers \Imagify\Optimization\Process\WP::can_resize
  * @group  ProcessWP
  * @since  2.3.3
@@ -20,7 +23,8 @@ use Mockery;
 class CanResizeTest extends TestCase {
 
 	/**
-	 * Invoke the protected method on a process whose media reports the given ID.
+	 * Invoke the protected method on a process whose media reports the given ID, with every
+	 * condition the parent checks satisfied.
 	 *
 	 * @param  int|null $media_id Media ID, or null for no media at all.
 	 * @return bool
@@ -29,9 +33,16 @@ class CanResizeTest extends TestCase {
 		$media = false;
 
 		if ( null !== $media_id ) {
+			$context = Mockery::mock( 'Imagify\Context\ContextInterface' );
+			$context->shouldReceive( 'can_resize' )->andReturn( true );
+
 			$media = Mockery::mock( 'Imagify\Media\MediaInterface' );
 			$media->shouldReceive( 'get_id' )->andReturn( $media_id );
+			$media->shouldReceive( 'get_context_instance' )->andReturn( $context );
 		}
+
+		$file = Mockery::mock( 'Imagify\Optimization\File' );
+		$file->shouldReceive( 'is_image' )->andReturn( true );
 
 		/*
 		 * A partial mock leaves protected methods alone, so the real can_resize() runs while
@@ -40,16 +51,18 @@ class CanResizeTest extends TestCase {
 		 */
 		$process = Mockery::mock( WP::class )->makePartial();
 		$process->shouldReceive( 'get_media' )->andReturn( $media );
-		$process->shouldReceive( 'is_valid' )->andReturn( false );
+		// is_valid() is get_media() && get_media()->is_valid(), so it cannot be true without a media.
+		$process->shouldReceive( 'is_valid' )->andReturn( null !== $media_id );
 
 		$method = new \ReflectionMethod( get_class( $process ), 'can_resize' );
 		$method->setAccessible( true );
 
-		return $method->invoke( $process, 'full', Mockery::mock( 'Imagify\Optimization\File' ) );
+		return $method->invoke( $process, 'full', $file );
 	}
 
 	/**
-	 * Test: a media the browser already scaled is not resized again.
+	 * Test: a media the browser already scaled is not resized again. Without the guard this
+	 * returns true, since every condition the parent checks is satisfied.
 	 */
 	public function testRefusesToResizeWhenTheBrowserSuppliedTheScaledFile(): void {
 		Functions\when( 'get_transient' )->alias(
@@ -62,6 +75,15 @@ class CanResizeTest extends TestCase {
 	}
 
 	/**
+	 * Test: an ordinary media is still resized, so the guard does not block everything.
+	 */
+	public function testStillResizesWhenTheBrowserDidNotScaleTheFile(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+
+		$this->assertTrue( $this->canResize( 42 ) );
+	}
+
+	/**
 	 * Test: the decision is per attachment, so another media is not caught by the flag.
 	 */
 	public function testDoesNotRefuseForAnotherMedia(): void {
@@ -71,13 +93,7 @@ class CanResizeTest extends TestCase {
 			}
 		);
 
-		/*
-		 * Media 99 carries no flag, so the parent decision applies. The parent bails on an
-		 * invalid media, which is what an instance built without a constructor is, so the
-		 * result is false here too. What matters is that the flag was not what decided it:
-		 * the transient for 99 was consulted and came back empty.
-		 */
-		$this->assertFalse( $this->canResize( 99 ) );
+		$this->assertTrue( $this->canResize( 99 ) );
 	}
 
 	/**

--- a/Tests/Unit/classes/Tools/InternalStateList/sharedList.php
+++ b/Tests/Unit/classes/Tools/InternalStateList/sharedList.php
@@ -68,6 +68,8 @@ class Test_SharedList extends TestCase {
 			'_transient_%imagify_rpc_%',
 			'_transient_imagify_%_process_locked',
 			'_site_transient_imagify_%_process_lock%',
+			'_transient_imagify_client_side_scaled_%',
+			'_transient_timeout_imagify_client_side_scaled_%',
 		];
 
 		$this->assertSame( $expected, InternalStateList::get_locked_transient_patterns() );

--- a/Tests/Unit/classes/Tools/ResetInternalState/reset.php
+++ b/Tests/Unit/classes/Tools/ResetInternalState/reset.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Imagify\Tests\Unit\classes\Tools\ResetInternalState;
 
 use Imagify\Tests\Unit\TestCase;
+use Imagify\Tools\InternalStateList;
 use Imagify\Tools\ResetInternalState;
 use Mockery;
 use Brain\Monkey\Functions;
@@ -161,7 +162,7 @@ class Test_Reset extends TestCase {
 				}
 			);
 
-		$this->wpdb->shouldReceive( 'query' )->times( 4 )->andReturn( 0 );
+		$this->wpdb->shouldReceive( 'query' )->times( count( InternalStateList::get_locked_transient_patterns() ) )->andReturn( 0 );
 
 		( new ResetInternalState() )->reset();
 
@@ -171,6 +172,8 @@ class Test_Reset extends TestCase {
 			'\_transient\_%imagify\_rpc\_%',
 			'\_transient\_imagify\_%\_process\_locked',
 			'\_site\_transient\_imagify\_%\_process\_lock%',
+			'\_transient\_imagify\_client\_side\_scaled\_%',
+			'\_transient\_timeout\_imagify\_client\_side\_scaled\_%',
 		];
 
 		foreach ( $expected_patterns as $pattern ) {
@@ -263,7 +266,7 @@ class Test_Reset extends TestCase {
 
 		( new ResetInternalState() )->reset();
 
-		// 4 options-pattern queries prove reset() ran to completion.
-		$this->assertSame( 4, $query_calls );
+		// One options-pattern query per registered pattern proves reset() ran to completion.
+		$this->assertSame( count( InternalStateList::get_locked_transient_patterns() ), $query_calls );
 	}
 }

--- a/classes/Context/WP.php
+++ b/classes/Context/WP.php
@@ -107,6 +107,11 @@ final class WP extends AbstractContext {
 	 * Optimization runs in a later, asynchronous request, where the filters WordPress
 	 * set up during the upload are long gone, so the state has to be stored.
 	 *
+	 * The flag is left to expire rather than deleted after use: it is read once per size
+	 * being optimized, so deleting it on the first read would let the remaining sizes
+	 * resize the file. An hour is far longer than the queue needs, and the pattern is
+	 * registered in {@see \Imagify\Tools\InternalStateList} so a reset clears it.
+	 *
 	 * @since 2.3.3
 	 *
 	 * @param int $attachment_id Attachment post ID.

--- a/classes/Context/WP.php
+++ b/classes/Context/WP.php
@@ -31,6 +31,17 @@ final class WP extends AbstractContext {
 	protected $resizing_threshold = 0;
 
 	/**
+	 * True once WordPress has said the browser is scaling the upload being created.
+	 *
+	 * Set on `rest_after_insert_attachment`, read by the threshold filter later in the same
+	 * request. One request creates one attachment, so there is nothing to key it by.
+	 *
+	 * @var   bool
+	 * @since 2.3.3
+	 */
+	protected $browser_is_scaling = false;
+
+	/**
 	 * Get the thumbnail sizes for this context, except the full size.
 	 *
 	 * @since  1.9
@@ -88,17 +99,11 @@ final class WP extends AbstractContext {
 	 *
 	 * @since 2.3.3
 	 *
-	 * $imagesize and $file are part of the filter signature and nothing here reads them: the
-	 * attachment ID is the fourth argument, so they have to be declared to reach it.
-	 *
-	 * @param  int|false $threshold     The threshold value in pixels, or false to disable resizing.
-	 * @param  array     $imagesize     Indexed array of the image width and height in pixels.
-	 * @param  string    $file          Full path to the uploaded image file.
-	 * @param  int       $attachment_id Attachment post ID.
+	 * @param  int|false $threshold The threshold value in pixels, or false to disable resizing.
 	 * @return int|false
 	 */
-	public function filter_big_image_size_threshold( $threshold, $imagesize = [], $file = '', $attachment_id = 0 ) {
-		if ( false === $threshold && $attachment_id && self::is_client_side_scaled( $attachment_id ) ) {
+	public function filter_big_image_size_threshold( $threshold ) {
+		if ( false === $threshold && $this->browser_is_scaling ) {
 			return $threshold;
 		}
 
@@ -113,6 +118,9 @@ final class WP extends AbstractContext {
 	 * carries `generate_sub_sizes` as `false` exactly when the browser owns the sub sizes.
 	 *
 	 * @since 2.3.3
+	 *
+	 * The threshold filter runs later in this same request, so a property is enough for it. The
+	 * transient is for the optimization, which runs in a later request of its own.
 	 *
 	 * @param object $attachment Inserted or updated attachment object. A \WP_Post when WordPress fires this.
 	 * @param object $request    Request object. A \WP_REST_Request when WordPress fires this.
@@ -130,6 +138,8 @@ final class WP extends AbstractContext {
 		if ( false !== $request->get_param( 'generate_sub_sizes' ) ) {
 			return;
 		}
+
+		$this->browser_is_scaling = true;
 
 		self::flag_client_side_scaling( $attachment->ID );
 	}

--- a/classes/Context/WP.php
+++ b/classes/Context/WP.php
@@ -88,6 +88,9 @@ final class WP extends AbstractContext {
 	 *
 	 * @since 2.3.3
 	 *
+	 * $imagesize and $file are part of the filter signature and nothing here reads them: the
+	 * attachment ID is the fourth argument, so they have to be declared to reach it.
+	 *
 	 * @param  int|false $threshold     The threshold value in pixels, or false to disable resizing.
 	 * @param  array     $imagesize     Indexed array of the image width and height in pixels.
 	 * @param  string    $file          Full path to the uploaded image file.

--- a/classes/Context/WP.php
+++ b/classes/Context/WP.php
@@ -72,14 +72,19 @@ final class WP extends AbstractContext {
 	/**
 	 * Filter WP's "big images threshold" with Imagify's resizing value.
 	 *
-	 * A `false` value means downscaling has been switched off on purpose, so it is
-	 * returned untouched. WordPress 7.1 does exactly that while the browser handles
-	 * the sub sizes: it supplies its own scaled file through the sideload endpoint,
-	 * and scaling again on the server would leave a conflicting "-scaled" file behind
-	 * and point `original_image` at it instead of the real upload.
+	 * Imagify stands down for one case only: the upload WordPress 7.1 handed to the browser,
+	 * which supplies its own scaled file through the sideload endpoint. Scaling again on the
+	 * server would leave a conflicting "-scaled" file behind and point `original_image` at it
+	 * instead of the real upload, which is why core switches its own downscaling off there.
 	 *
-	 * The value the browser scales to comes from this same filter
-	 * ({@see WP_REST_Server::get_index()}), so Imagify's setting is still honoured.
+	 * Nothing is lost by standing down: the value the browser scales to is produced by this
+	 * same filter, in {@see WP_REST_Server::get_index()}, so Imagify's setting still governs
+	 * the result.
+	 *
+	 * A `false` coming from anywhere else is deliberately overridden, exactly as before. Only
+	 * the browser flow leaves a scaled file behind, so treating every `false` as "already
+	 * scaled" would mean an image nobody resized: not WordPress, because it was told not to,
+	 * and not Imagify, because it believed the work was done.
 	 *
 	 * @since 2.3.3
 	 *
@@ -90,15 +95,40 @@ final class WP extends AbstractContext {
 	 * @return int|false
 	 */
 	public function filter_big_image_size_threshold( $threshold, $imagesize = [], $file = '', $attachment_id = 0 ) {
-		if ( false === $threshold ) {
-			if ( $attachment_id ) {
-				self::flag_client_side_scaling( $attachment_id );
-			}
-
+		if ( false === $threshold && $attachment_id && self::is_client_side_scaled( $attachment_id ) ) {
 			return $threshold;
 		}
 
 		return $this->get_resizing_threshold();
+	}
+
+	/**
+	 * Remember that the browser is supplying the scaled version of an attachment.
+	 *
+	 * Taken from where WordPress declares it rather than guessed: this runs on
+	 * `rest_after_insert_attachment`, just before the metadata is generated, and the request
+	 * carries `generate_sub_sizes` as `false` exactly when the browser owns the sub sizes.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param object $attachment Inserted or updated attachment object. A \WP_Post when WordPress fires this.
+	 * @param object $request    Request object. A \WP_REST_Request when WordPress fires this.
+	 * @param bool   $creating   True when creating an attachment, false when updating.
+	 */
+	public function maybe_flag_client_side_scaling( $attachment, $request, $creating ) {
+		if ( ! $creating || ! is_object( $attachment ) || ! isset( $attachment->ID ) ) {
+			return;
+		}
+
+		if ( ! is_object( $request ) || ! is_callable( [ $request, 'get_param' ] ) ) {
+			return;
+		}
+
+		if ( false !== $request->get_param( 'generate_sub_sizes' ) ) {
+			return;
+		}
+
+		self::flag_client_side_scaling( $attachment->ID );
 	}
 
 	/**

--- a/classes/Context/WP.php
+++ b/classes/Context/WP.php
@@ -70,6 +70,76 @@ final class WP extends AbstractContext {
 	}
 
 	/**
+	 * Filter WP's "big images threshold" with Imagify's resizing value.
+	 *
+	 * A `false` value means downscaling has been switched off on purpose, so it is
+	 * returned untouched. WordPress 7.1 does exactly that while the browser handles
+	 * the sub sizes: it supplies its own scaled file through the sideload endpoint,
+	 * and scaling again on the server would leave a conflicting "-scaled" file behind
+	 * and point `original_image` at it instead of the real upload.
+	 *
+	 * The value the browser scales to comes from this same filter
+	 * ({@see WP_REST_Server::get_index()}), so Imagify's setting is still honoured.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  int|false $threshold     The threshold value in pixels, or false to disable resizing.
+	 * @param  array     $imagesize     Indexed array of the image width and height in pixels.
+	 * @param  string    $file          Full path to the uploaded image file.
+	 * @param  int       $attachment_id Attachment post ID.
+	 * @return int|false
+	 */
+	public function filter_big_image_size_threshold( $threshold, $imagesize = [], $file = '', $attachment_id = 0 ) {
+		if ( false === $threshold ) {
+			if ( $attachment_id ) {
+				self::flag_client_side_scaling( $attachment_id );
+			}
+
+			return $threshold;
+		}
+
+		return $this->get_resizing_threshold();
+	}
+
+	/**
+	 * Remember that the browser is supplying the scaled version of an attachment.
+	 *
+	 * Optimization runs in a later, asynchronous request, where the filters WordPress
+	 * set up during the upload are long gone, so the state has to be stored.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 */
+	public static function flag_client_side_scaling( $attachment_id ) {
+		set_transient( self::get_client_side_scaling_flag( $attachment_id ), 1, HOUR_IN_SECONDS );
+	}
+
+	/**
+	 * Tell if the browser supplied the scaled version of an attachment.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  int $attachment_id Attachment post ID.
+	 * @return bool
+	 */
+	public static function is_client_side_scaled( $attachment_id ) {
+		return (bool) get_transient( self::get_client_side_scaling_flag( $attachment_id ) );
+	}
+
+	/**
+	 * Get the transient name used to flag client side scaling for an attachment.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  int $attachment_id Attachment post ID.
+	 * @return string
+	 */
+	private static function get_client_side_scaling_flag( $attachment_id ) {
+		return 'imagify_client_side_scaled_' . (int) $attachment_id;
+	}
+
+	/**
 	 * Tell if the optimization process is allowed to backup in this context.
 	 *
 	 * @since  1.9

--- a/classes/Optimization/Process/WP.php
+++ b/classes/Optimization/Process/WP.php
@@ -36,11 +36,13 @@ class WP extends AbstractProcess {
 	 * @return bool
 	 */
 	protected function can_resize( $size, $file ) {
-		if ( ! parent::can_resize( $size, $file ) ) {
+		$media = $this->get_media();
+
+		if ( $media && \Imagify\Context\WP::is_client_side_scaled( $media->get_id() ) ) {
 			return false;
 		}
 
-		return ! \Imagify\Context\WP::is_client_side_scaled( $this->get_media()->get_id() );
+		return parent::can_resize( $size, $file );
 	}
 
 	/** ----------------------------------------------------------------------------------------- */

--- a/classes/Optimization/Process/WP.php
+++ b/classes/Optimization/Process/WP.php
@@ -18,6 +18,32 @@ use WP_Error;
 class WP extends AbstractProcess {
 
 	/** ----------------------------------------------------------------------------------------- */
+	/** RESIZING ================================================================================ */
+	/** ----------------------------------------------------------------------------------------- */
+
+	/**
+	 * Tell if a size should be resized.
+	 *
+	 * When the browser handled the upload it also produced the scaled version, using the
+	 * very threshold Imagify configured ({@see \Imagify\Context\WP::filter_big_image_size_threshold()}),
+	 * so resizing here would only shrink the untouched original that WordPress keeps
+	 * aside as `original_image`.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  string $size The size name.
+	 * @param  File   $file A File instance.
+	 * @return bool
+	 */
+	protected function can_resize( $size, $file ) {
+		if ( ! parent::can_resize( $size, $file ) ) {
+			return false;
+		}
+
+		return ! \Imagify\Context\WP::is_client_side_scaled( $this->get_media()->get_id() );
+	}
+
+	/** ----------------------------------------------------------------------------------------- */
 	/** MISSING THUMBNAILS ====================================================================== */
 	/** ----------------------------------------------------------------------------------------- */
 

--- a/classes/Tools/InternalStateList.php
+++ b/classes/Tools/InternalStateList.php
@@ -64,6 +64,9 @@ class InternalStateList {
 			'_transient_%imagify_rpc_%',            // Legacy/deprecated.
 			'_transient_imagify_%_process_locked',
 			'_site_transient_imagify_%_process_lock%',
+			// Flags an attachment whose scaled version came from the browser, on WP 7.1+.
+			'_transient_imagify_client_side_scaled_%',
+			'_transient_timeout_imagify_client_side_scaled_%',
 		];
 	}
 

--- a/inc/classes/class-imagify-options.php
+++ b/inc/classes/class-imagify-options.php
@@ -76,7 +76,7 @@ class Imagify_Options extends Imagify_Abstract_Options {
 		if ( function_exists( 'wp_get_original_image_path' ) ) {
 			$this->reset_values['resize_larger'] = 1;
 
-			$filter_cb = [ imagify_get_context( 'wp' ), 'get_resizing_threshold' ];
+			$filter_cb = [ imagify_get_context( 'wp' ), 'filter_big_image_size_threshold' ];
 			$filtered  = has_filter( 'big_image_size_threshold', $filter_cb );
 
 			if ( $filtered ) {
@@ -88,7 +88,9 @@ class Imagify_Options extends Imagify_Abstract_Options {
 			$this->reset_values['resize_larger_w'] = $this->sanitize_and_validate_value( 'resize_larger_w', $this->reset_values['resize_larger_w'], $this->default_values['resize_larger_w'] );
 
 			if ( $filtered ) {
-				add_filter( 'big_image_size_threshold', $filter_cb, IMAGIFY_INT_MAX );
+				// The argument count has to be repeated here, or the callback would be
+				// registered with a single one and stop receiving the attachment ID.
+				add_filter( 'big_image_size_threshold', $filter_cb, IMAGIFY_INT_MAX, 4 );
 			}
 		}
 

--- a/inc/classes/class-imagify-options.php
+++ b/inc/classes/class-imagify-options.php
@@ -88,9 +88,7 @@ class Imagify_Options extends Imagify_Abstract_Options {
 			$this->reset_values['resize_larger_w'] = $this->sanitize_and_validate_value( 'resize_larger_w', $this->reset_values['resize_larger_w'], $this->default_values['resize_larger_w'] );
 
 			if ( $filtered ) {
-				// The argument count has to be repeated here, or the callback would be
-				// registered with a single one and stop receiving the attachment ID.
-				add_filter( 'big_image_size_threshold', $filter_cb, IMAGIFY_INT_MAX, 4 );
+				add_filter( 'big_image_size_threshold', $filter_cb, IMAGIFY_INT_MAX );
 			}
 		}
 

--- a/inc/common/attachments.php
+++ b/inc/common/attachments.php
@@ -70,6 +70,17 @@ function imagify_add_avif_type( $ext2type ) {
 add_filter( 'big_image_size_threshold', [ imagify_get_context( 'wp' ), 'filter_big_image_size_threshold' ], IMAGIFY_INT_MAX, 4 );
 
 /**
+ * Note the uploads WordPress 7.1 hands to the browser, which scales them itself.
+ *
+ * Fires before the attachment metadata is generated, so the threshold filter above already
+ * knows about it by the time it runs.
+ *
+ * @since 2.3.3
+ * @since WP 7.1
+ */
+add_action( 'rest_after_insert_attachment', [ imagify_get_context( 'wp' ), 'maybe_flag_client_side_scaling' ], 10, 3 );
+
+/**
  * Add filters to manage images formats that will be generated
  *
  * @return array

--- a/inc/common/attachments.php
+++ b/inc/common/attachments.php
@@ -67,7 +67,7 @@ function imagify_add_avif_type( $ext2type ) {
  * @since  WP 5.3
  * @author Grégory Viguier
  */
-add_filter( 'big_image_size_threshold', [ imagify_get_context( 'wp' ), 'get_resizing_threshold' ], IMAGIFY_INT_MAX );
+add_filter( 'big_image_size_threshold', [ imagify_get_context( 'wp' ), 'filter_big_image_size_threshold' ], IMAGIFY_INT_MAX, 4 );
 
 /**
  * Add filters to manage images formats that will be generated

--- a/inc/common/attachments.php
+++ b/inc/common/attachments.php
@@ -67,7 +67,7 @@ function imagify_add_avif_type( $ext2type ) {
  * @since  WP 5.3
  * @author Grégory Viguier
  */
-add_filter( 'big_image_size_threshold', [ imagify_get_context( 'wp' ), 'filter_big_image_size_threshold' ], IMAGIFY_INT_MAX, 4 );
+add_filter( 'big_image_size_threshold', [ imagify_get_context( 'wp' ), 'filter_big_image_size_threshold' ], IMAGIFY_INT_MAX );
 
 /**
  * Note the uploads WordPress 7.1 hands to the browser, which scales them itself.


### PR DESCRIPTION
# Description

Fixes #1235

WordPress 7.1 lets the browser process an upload, and when it does, it switches its own "big image" downscaling off because the browser already supplies the scaled file. Imagify's filter ignored that and always imposed its own value, so the server scaled the image a second time. Users were left with a scaled file and a Next-Gen companion that nothing referenced, and WordPress pointed `original_image` at that stray file instead of the real upload.

After this change the upload produces a single scaled file, sub sizes keep their normal names, and `original_image` points at the untouched upload again.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Everything below was done by hand on a real WordPress 7.1-RC3-63235 build, in Chrome 151, with Imagify connected, auto optimization on and "Resize larger images" on at 2560. A small mu-plugin was used during testing to log what `big_image_size_threshold` returned and when the metadata was written. It is not part of this PR.

**Reproduced the bug first.** Uploaded a 4000x3000 JPEG from the block editor on an unpatched build and confirmed the reported symptoms on disk: two scaled files (`big-4000px-scaled.jpg` and `big-4000px-scaled-1.jpg`), 673KB of them referenced by nothing, every sub size written with a `-1` suffix, and `original_image` naming the stray file rather than the upload.

**Verified the fix on the same flow.** Uploaded a 3800x2500 JPEG from the block editor and inspected the uploads folder and the attachment metadata:

| | Before | After |
|---|---|---|
| Scaled files produced | `-scaled.jpg` and `-scaled-1.jpg` | one `-scaled.jpg` |
| Unreferenced bytes left behind | 673KB | 0 |
| Sub size names | `-1024x674-1.jpg` | `-1024x674.jpg` |
| `original_image` | the stray scaled file | the real upload |
| Original dimensions on disk | 3800x2500 | 3800x2500 |

The log showed the filter standing down exactly once, during the upload, and keeping Imagify's value on all 52 other calls in the same run:

```
big_image_size_threshold FINAL=false   attachment_id=138   <- the client side upload
big_image_size_threshold FINAL=2560    (52 other calls)
```

**Checked that ordinary uploads still resize.** Uploaded a 4000px PNG through Media, Add Media File. It still produced `big-4000px-scaled.png` at 2560 with the 4000px original intact, so nothing changed for server side uploads.

**Checked the premise itself,** because the fix only makes sense if the browser scales to Imagify's value rather than a hardcoded one. Read `bigImageSizeThreshold` out of the editor settings in the console: it returned `2560`, Imagify's configured value, and the file the browser produced measured 2560x1684, the same dimensions the server used to produce. Nothing is lost by standing down.

**Confirmed the settings page still behaves,** since the reset value for the resize width is computed by temporarily unhooking this same callback. Opened the settings page and read the rendered values back: unchanged.

Automated checks on top of the manual work: 12 new unit tests across `--group ContextWP` and `--group ProcessWP`, covering the browser upload, a `false` from any other source, and the resize guard both ways. Full suite green at 502, `composer run-stan` clean, PHPCS clean on every changed file.

### How to test

Setup:

1. Install WordPress 7.1 and serve it over HTTPS, or on `localhost`. Client side processing needs a secure context, and it is enabled by default there in any browser.
2. Activate Imagify on this branch and connect it with a valid API key.
3. Go to Settings, Imagify. Turn "Auto optimize images on upload" on, turn "Backup original images" on, turn "Resize larger images" on and leave the width at 2560. Save.
4. Prepare a JPEG wider than 2560 pixels, for example 3800x2500.

Reproduce the fixed behaviour:

5. Create a new post: Posts, Add New.
6. Insert an Image block, by typing `/image` and pressing Enter.
7. Upload your JPEG through that block. It has to be the block editor. The classic Media Library has no cross origin isolation, so WordPress falls back to server side processing there and this code path never runs.
8. Wait for the image to appear in the block.

Check the files:

9. Open `wp-content/uploads/<year>/<month>/` on the server.
10. There must be exactly one `-scaled` file. A second one ending in `-scaled-1` means the bug is still present.
11. Sub sizes must be named `<name>-1024x674.jpg` and so on, with no `-1` suffix before the extension.
12. The file you uploaded must still be there at its original dimensions. Check with any image viewer that it is still 3800x2500.

Check the metadata:

13. Read `_wp_attachment_metadata` for that attachment, for example with `wp post meta get <ID> _wp_attachment_metadata --format=json`.
14. `original_image` must name the file you uploaded, not a `-scaled` one.

Check nothing regressed on ordinary uploads:

15. Go to Media, Add Media File and upload the same image there.
16. A `-scaled` file at 2560 must be created, and the original must be kept beside it. This confirms Imagify still resizes on the server side path.

### Affected Features & Quality Assurance Scope

1. Resizing on upload, in every context, because the filter callback is shared. The value it returns is unchanged except for the uploads WordPress 7.1 hands to the browser.
2. The Imagify settings page, because the reset value for "Resize larger images width" is computed by temporarily unhooking this same callback. The callback name changed, so that code had to follow.
3. Optimization of WP Media Library attachments, through the new `can_resize()` override.
4. Custom folders and NextGen Gallery are untouched, since they have their own context and process classes.

## Technical description

### Documentation

`WP_REST_Attachments_Controller::create_item()` adds `__return_false` on `big_image_size_threshold` when the browser handles the sub sizes, and its own comment says why:

> Disable server-side "big image" downscaling; the client supplies its own scaled version via the sideload endpoint. Scaling here would create a conflicting "-scaled" file and orphan the full-size upload.

Imagify hooked the same filter at `IMAGIFY_INT_MAX` with `Context\WP::get_resizing_threshold()`, a getter that takes no arguments and therefore could not see, let alone respect, the incoming value.

Three things changed.

**A dedicated filter callback.** `Context\WP::filter_big_image_size_threshold()` hands the threshold back untouched for an upload the browser scaled, and otherwise delegates to the existing getter, including when the `false` came from somewhere else. The getter keeps its old contract, so the direct callers in `AbstractContext::can_resize()` and `AbstractProcess::maybe_resize()` are unaffected, and `ContextInterface` does not change, which matters because `CustomFolders`, `Noop` and `NGG` implement it too.

Standing down loses nothing, because the threshold the browser scales to is produced by this very filter, in `WP_REST_Server::get_index()`. Imagify's setting is still what governs the result.

**The state is taken from where WordPress declares it.** `rest_after_insert_attachment` runs just before the metadata is generated and carries the request, whose `generate_sub_sizes` parameter is `false` exactly when the browser owns the sub sizes. That is what identifies the upload, rather than the `false` on the filter, which says nothing about who sent it or whether a scaled file exists.

**A flag, so the original is left alone.** Optimization does not run inside the upload request. It is pushed onto a queue and runs later, asynchronously, by which point the filters WordPress set up during the upload are gone. Without a record of what happened, `maybe_resize()` would see the full size original at 3800px, compare it against the 2560 threshold and shrink the very file WordPress keeps aside as `original_image`. So the attachment ID is recorded in a one hour transient, and `Process\WP::can_resize()` declines to resize while that flag is present.

**A latent bug in the options class.** `Imagify_Options::__construct()` temporarily unhooks this callback to read WordPress's pristine value, then hooks it back with `add_filter( ..., IMAGIFY_INT_MAX )` and no argument count, which silently re-registers it as accepting a single argument. That was harmless while the callback only took one. It is not harmless now: the callback stopped receiving the attachment ID, so the flag was never written. This was caught during testing, when the flag turned out to be missing even though the filter was clearly returning `false`. The argument count is now repeated there.

### New dependencies

None.

### Risks

Nothing changes outside the WordPress 7.1 browser upload. Imagify stands down only for an
attachment WordPress itself flagged, by sending `generate_sub_sizes` as `false` on the REST
request that created it. A `false` arriving on the filter from any other source is overridden
with Imagify's value exactly as before, because only the browser flow leaves a scaled file
behind: treating every `false` as "already scaled" would produce an image nobody resized, since
WordPress was told not to and Imagify would believe the work was done.

Known limitation: the flag is a one hour transient. On a site that purges transients
aggressively, or with an optimization queue backed up for more than an hour, it can be gone by
the time the queued optimization runs. The consequence is the behaviour that shipped before this
PR, the original being resized, with the untouched upload still in the backup folder. Nothing
errors, and there is no data loss.

The flag is written only for those uploads, and it expires on its own, so no cleanup routine is
needed and nothing is stored permanently. The pattern is registered in
`classes/Tools/InternalStateList.php` so a reset and an uninstall clear it.

One interaction is worth stating plainly. #1234 makes auto optimization run before the browser's sub sizes arrive, which means it still runs against the full size original during the upload. This PR stops that pass from resizing the original, and the original keeps its dimensions, but the file is still compressed in place, with the untouched upload preserved in the backup folder. Fixing #1234 removes that early pass entirely and the original stops being touched at all. This was verified: with both branches merged locally, the uploaded file came out byte identical to the source. Both are improvements on their own and neither depends on the other to be safe.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Nothing unticked.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

The flag is observable: the `imagify_client_side_scaled_<id>` transient exists for the lifetime of an upload that the browser scaled. No filesystem or HTTP calls were added, so there is nothing new that can throw.
