### PR TITLE
Fix #1234: optimize once the client side sub sizes have arrived

### DIFF
--- a/Tests/Integration/inc/classes/AutoOptimization/ClientSideUploadSequenceTest.php
+++ b/Tests/Integration/inc/classes/AutoOptimization/ClientSideUploadSequenceTest.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Imagify\Tests\Integration\inc\classes\AutoOptimization;
+
+use Imagify_Auto_Optimization;
+use Imagify\Tests\Integration\TestCase;
+use WP_REST_Request;
+
+/**
+ * Fires the real WordPress hook chain for a WP 7.1 client side upload and checks when auto
+ * optimization runs, and what it can see when it does.
+ *
+ * The unit tests call the methods directly, which proves they behave as written but not that
+ * the sequence WordPress actually produces lands where it should. This drives the genuine
+ * chain instead: `wp_generate_attachment_metadata` for the create phase, then the same filter
+ * for the finalize phase, then `wp_update_attachment_metadata`, which writes the post meta and
+ * therefore fires `added_post_meta` / `updated_post_meta`.
+ *
+ * Two things matter and neither can be checked from a unit test:
+ *   - nothing is optimized on the create phase, when no sub size exists yet,
+ *   - the optimization that does run happens after the metadata is stored, so the sizes it
+ *     reads are the complete set rather than the value that was about to be replaced.
+ *
+ * @covers \Imagify_Auto_Optimization::maybe_store_generate_step
+ * @covers \Imagify_Auto_Optimization::store_ids_to_optimize
+ * @covers \Imagify_Auto_Optimization::do_auto_optimization_after_meta_update
+ * @group  AutoOptimization
+ */
+class Test_ClientSideUploadSequence extends TestCase {
+	/**
+	 * This suite needs no Imagify API credentials.
+	 *
+	 * @var bool
+	 */
+	protected $useApi = false; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+
+	/**
+	 * Files written to disk by the test.
+	 *
+	 * @var array
+	 */
+	private $created_files = [];
+
+	/**
+	 * Auto optimization runs recorded during the test.
+	 *
+	 * @var array
+	 */
+	private $runs = [];
+
+	/**
+	 * Original value of the auto_optimize option.
+	 *
+	 * @var mixed
+	 */
+	private $original_auto_optimize;
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->original_auto_optimize = get_imagify_option( 'auto_optimize' );
+		update_imagify_option( 'auto_optimize', 1 );
+
+		$this->runs = [];
+
+		/*
+		 * Record every optimization the sequence triggers, along with the sizes readable from
+		 * the stored metadata at that moment. What is under test is when the decision is taken
+		 * and what it can see: the optimization itself only reaches a queue that nothing
+		 * dispatches during the tests.
+		 */
+		add_action(
+			'imagify_before_auto_optimization',
+			[ $this, 'record_run' ],
+			5,
+			2
+		);
+
+		/*
+		 * The plugin registers these on boot. Calling init() again is idempotent, since the
+		 * callbacks and priorities are identical, and it keeps the test honest if the hooks
+		 * were not registered for any reason. remove_hooks() is deliberately not called on
+		 * tear down: it would leave auto optimization switched off for every later test.
+		 */
+		Imagify_Auto_Optimization::get_instance()->init();
+	}
+
+	/**
+	 * Cleans up the test environment after each test.
+	 */
+	public function tear_down() {
+		remove_action( 'imagify_before_auto_optimization', [ $this, 'record_run' ], 5 );
+
+		update_imagify_option( 'auto_optimize', $this->original_auto_optimize );
+
+		foreach ( $this->created_files as $file ) {
+			if ( file_exists( $file ) ) {
+				wp_delete_file( $file );
+			}
+		}
+
+		$this->created_files = [];
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Records an auto optimization run and what the stored metadata holds at that point.
+	 *
+	 * @param int  $attachment_id Attachment ID.
+	 * @param bool $is_new_upload Whether Imagify treats this as a new upload.
+	 */
+	public function record_run( $attachment_id, $is_new_upload ) {
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+
+		$this->runs[] = [
+			'is_new_upload' => $is_new_upload,
+			'sizes'         => is_array( $metadata ) && ! empty( $metadata['sizes'] ) ? array_keys( $metadata['sizes'] ) : [],
+		];
+	}
+
+	/**
+	 * Creates an attachment with a real file behind it, as the upload would.
+	 *
+	 * @return int
+	 */
+	private function create_attachment() {
+		$uploads   = wp_upload_dir();
+		$filename  = 'imagify-client-side-' . uniqid() . '.jpg';
+		$file_path = trailingslashit( $uploads['basedir'] ) . $filename;
+
+		wp_mkdir_p( dirname( $file_path ) );
+		file_put_contents( $file_path, 'not-a-real-jpeg' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+		$this->created_files[] = $file_path;
+
+		$attachment_id = $this->factory()->attachment->create_object(
+			[
+				'file'           => $filename,
+				'post_mime_type' => 'image/jpeg',
+				'post_status'    => 'inherit',
+			]
+		);
+
+		update_post_meta( $attachment_id, '_wp_attached_file', $filename );
+
+		return $attachment_id;
+	}
+
+	/**
+	 * Builds the REST request WordPress hands to `rest_after_insert_attachment` when the
+	 * browser is going to send the sub sizes itself.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function client_side_request() {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_param( 'generate_sub_sizes', false );
+
+		return $request;
+	}
+
+	/**
+	 * Runs the create phase: WordPress stores metadata that carries no sub size yet.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 */
+	private function run_create_phase( $attachment_id ) {
+		$metadata = [
+			'file'   => get_post_meta( $attachment_id, '_wp_attached_file', true ),
+			'width'  => 3800,
+			'height' => 2500,
+			'sizes'  => [],
+		];
+
+		/** This filter is documented in wp-admin/includes/image.php */
+		$metadata = apply_filters( 'wp_generate_attachment_metadata', $metadata, $attachment_id, 'create' );
+
+		wp_update_attachment_metadata( $attachment_id, $metadata );
+	}
+
+	/**
+	 * Runs the finalize phase: every sideloaded sub size is stored in one go.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 */
+	private function run_finalize_phase( $attachment_id ) {
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+
+		$metadata['sizes'] = [
+			'thumbnail'    => [ 'file' => 'thumb.jpg' ],
+			'medium'       => [ 'file' => 'medium.jpg' ],
+			'medium_large' => [ 'file' => 'medium_large.jpg' ],
+			'large'        => [ 'file' => 'large.jpg' ],
+		];
+
+		/** This filter is documented in wp-admin/includes/image.php */
+		$metadata = apply_filters( 'wp_generate_attachment_metadata', $metadata, $attachment_id, 'update' );
+
+		wp_update_attachment_metadata( $attachment_id, $metadata );
+	}
+
+	/**
+	 * Test: the create phase optimizes nothing, and the finalize phase optimizes once, as a new
+	 * upload, with every sub size readable from the stored metadata.
+	 */
+	public function testOptimizesOnceTheSubsizesAreStored() {
+		$attachment_id = $this->create_attachment();
+
+		Imagify_Auto_Optimization::get_instance()->flag_awaiting_client_side_subsizes(
+			get_post( $attachment_id ),
+			$this->client_side_request(),
+			true
+		);
+
+		$this->run_create_phase( $attachment_id );
+
+		$this->assertSame( [], $this->runs, 'Nothing should be optimized while the browser still owes its sub sizes.' );
+
+		$this->run_finalize_phase( $attachment_id );
+
+		$this->assertCount( 1, $this->runs, 'The media should be optimized exactly once.' );
+		$this->assertTrue( $this->runs[0]['is_new_upload'], 'The finalize pass is still the new upload.' );
+		$this->assertSame(
+			[ 'thumbnail', 'medium', 'medium_large', 'large' ],
+			$this->runs[0]['sizes'],
+			'The optimization must run after the metadata is stored, so every sub size is visible.'
+		);
+	}
+
+	/**
+	 * Test: an ordinary upload, where WordPress builds the sub sizes itself, is optimized on
+	 * the create phase exactly as before, so the deferral is limited to the client side flow.
+	 */
+	public function testOptimizesImmediatelyOnAnOrdinaryUpload() {
+		$attachment_id = $this->create_attachment();
+
+		// No flag: WordPress is building the sub sizes itself.
+		$metadata = [
+			'file'   => get_post_meta( $attachment_id, '_wp_attached_file', true ),
+			'width'  => 1200,
+			'height' => 900,
+			'sizes'  => [
+				'thumbnail' => [ 'file' => 'thumb.jpg' ],
+				'medium'    => [ 'file' => 'medium.jpg' ],
+			],
+		];
+
+		/** This filter is documented in wp-admin/includes/image.php */
+		$metadata = apply_filters( 'wp_generate_attachment_metadata', $metadata, $attachment_id, 'create' );
+
+		wp_update_attachment_metadata( $attachment_id, $metadata );
+
+		$this->assertCount( 1, $this->runs, 'An ordinary upload should still be optimized once, on the create phase.' );
+		$this->assertTrue( $this->runs[0]['is_new_upload'] );
+	}
+
+	/**
+	 * Test: the flag is not left behind once the sub sizes have arrived.
+	 */
+	public function testClearsTheFlagOnceTheSubsizesArrive() {
+		$attachment_id = $this->create_attachment();
+		$auto          = Imagify_Auto_Optimization::get_instance();
+
+		$auto->flag_awaiting_client_side_subsizes( get_post( $attachment_id ), $this->client_side_request(), true );
+
+		$this->assertTrue( $auto->is_awaiting_client_side_subsizes( $attachment_id ) );
+
+		$this->run_create_phase( $attachment_id );
+
+		$this->assertTrue( $auto->is_awaiting_client_side_subsizes( $attachment_id ), 'The flag survives the create phase.' );
+
+		$this->run_finalize_phase( $attachment_id );
+
+		$this->assertFalse( $auto->is_awaiting_client_side_subsizes( $attachment_id ), 'The flag is cleared once the sub sizes are in.' );
+	}
+}

--- a/Tests/Integration/inc/classes/AutoOptimization/ClientSideUploadSequenceTest.php
+++ b/Tests/Integration/inc/classes/AutoOptimization/ClientSideUploadSequenceTest.php
@@ -151,6 +151,23 @@ class Test_ClientSideUploadSequence extends TestCase {
 	}
 
 	/**
+	 * Builds one entry of the metadata `sizes` array, as WordPress stores it.
+	 *
+	 * @param  string $file   File name.
+	 * @param  int    $width  Width in pixels.
+	 * @param  int    $height Height in pixels.
+	 * @return array
+	 */
+	private function size_data( $file, $width, $height ) {
+		return [
+			'file'      => $file,
+			'width'     => $width,
+			'height'    => $height,
+			'mime-type' => 'image/jpeg',
+		];
+	}
+
+	/**
 	 * Builds the REST request WordPress hands to `rest_after_insert_attachment` when the
 	 * browser is going to send the sub sizes itself.
 	 *
@@ -191,10 +208,10 @@ class Test_ClientSideUploadSequence extends TestCase {
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 
 		$metadata['sizes'] = [
-			'thumbnail'    => [ 'file' => 'thumb.jpg' ],
-			'medium'       => [ 'file' => 'medium.jpg' ],
-			'medium_large' => [ 'file' => 'medium_large.jpg' ],
-			'large'        => [ 'file' => 'large.jpg' ],
+			'thumbnail'    => $this->size_data( 'thumb.jpg', 150, 150 ),
+			'medium'       => $this->size_data( 'medium.jpg', 300, 197 ),
+			'medium_large' => $this->size_data( 'medium_large.jpg', 768, 505 ),
+			'large'        => $this->size_data( 'large.jpg', 1024, 674 ),
 		];
 
 		/** This filter is documented in wp-admin/includes/image.php */
@@ -244,8 +261,8 @@ class Test_ClientSideUploadSequence extends TestCase {
 			'width'  => 1200,
 			'height' => 900,
 			'sizes'  => [
-				'thumbnail' => [ 'file' => 'thumb.jpg' ],
-				'medium'    => [ 'file' => 'medium.jpg' ],
+				'thumbnail' => $this->size_data( 'thumb.jpg', 150, 150 ),
+				'medium'    => $this->size_data( 'medium.jpg', 300, 225 ),
 			],
 		];
 

--- a/Tests/Unit/classes/Tools/InternalStateList/sharedList.php
+++ b/Tests/Unit/classes/Tools/InternalStateList/sharedList.php
@@ -68,6 +68,8 @@ class Test_SharedList extends TestCase {
 			'_transient_%imagify_rpc_%',
 			'_transient_imagify_%_process_locked',
 			'_site_transient_imagify_%_process_lock%',
+			'_transient_imagify_awaiting_subsizes_%',
+			'_transient_timeout_imagify_awaiting_subsizes_%',
 		];
 
 		$this->assertSame( $expected, InternalStateList::get_locked_transient_patterns() );

--- a/Tests/Unit/classes/Tools/ResetInternalState/reset.php
+++ b/Tests/Unit/classes/Tools/ResetInternalState/reset.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Imagify\Tests\Unit\classes\Tools\ResetInternalState;
 
 use Imagify\Tests\Unit\TestCase;
+use Imagify\Tools\InternalStateList;
 use Imagify\Tools\ResetInternalState;
 use Mockery;
 use Brain\Monkey\Functions;
@@ -161,7 +162,7 @@ class Test_Reset extends TestCase {
 				}
 			);
 
-		$this->wpdb->shouldReceive( 'query' )->times( 4 )->andReturn( 0 );
+		$this->wpdb->shouldReceive( 'query' )->times( count( InternalStateList::get_locked_transient_patterns() ) )->andReturn( 0 );
 
 		( new ResetInternalState() )->reset();
 
@@ -171,6 +172,8 @@ class Test_Reset extends TestCase {
 			'\_transient\_%imagify\_rpc\_%',
 			'\_transient\_imagify\_%\_process\_locked',
 			'\_site\_transient\_imagify\_%\_process\_lock%',
+			'\_transient\_imagify\_awaiting\_subsizes\_%',
+			'\_transient\_timeout\_imagify\_awaiting\_subsizes\_%',
 		];
 
 		foreach ( $expected_patterns as $pattern ) {
@@ -263,7 +266,7 @@ class Test_Reset extends TestCase {
 
 		( new ResetInternalState() )->reset();
 
-		// 4 options-pattern queries prove reset() ran to completion.
-		$this->assertSame( 4, $query_calls );
+		// One options-pattern query per registered pattern proves reset() ran to completion.
+		$this->assertSame( count( InternalStateList::get_locked_transient_patterns() ), $query_calls );
 	}
 }

--- a/Tests/Unit/inc/classes/AutoOptimization/MaybeStoreGenerateStepTest.php
+++ b/Tests/Unit/inc/classes/AutoOptimization/MaybeStoreGenerateStepTest.php
@@ -105,6 +105,8 @@ class MaybeStoreGenerateStepTest extends TestCase {
 	 * Test: the attachment is flagged when WordPress hands the sub sizes over to the browser.
 	 */
 	public function testFlagsTheAttachmentWhenTheBrowserHandlesTheSubsizes(): void {
+		$this->stubDependencies();
+
 		$stored = [];
 
 		Functions\when( 'set_transient' )->alias(
@@ -124,6 +126,7 @@ class MaybeStoreGenerateStepTest extends TestCase {
 	 * nor when the parameter is absent entirely.
 	 */
 	public function testDoesNotFlagWhenWordPressBuildsTheSubsizes(): void {
+		$this->stubDependencies();
 		Functions\expect( 'set_transient' )->never();
 
 		$attachment = (object) [ 'ID' => 42 ];
@@ -133,9 +136,20 @@ class MaybeStoreGenerateStepTest extends TestCase {
 	}
 
 	/**
+	 * Test: an attachment Imagify cannot optimize is not flagged, since nothing would read it.
+	 */
+	public function testDoesNotFlagAnUnsupportedMimeType(): void {
+		Functions\when( 'imagify_is_attachment_mime_type_supported' )->justReturn( false );
+		Functions\expect( 'set_transient' )->never();
+
+		( new Imagify_Auto_Optimization() )->flag_awaiting_client_side_subsizes( (object) [ 'ID' => 42 ], $this->requestReturning( false ), true );
+	}
+
+	/**
 	 * Test: nothing is flagged when an existing attachment is being updated rather than created.
 	 */
 	public function testDoesNotFlagWhenUpdatingAnAttachment(): void {
+		$this->stubDependencies();
 		Functions\expect( 'set_transient' )->never();
 
 		( new Imagify_Auto_Optimization() )->flag_awaiting_client_side_subsizes( (object) [ 'ID' => 42 ], $this->requestReturning( false ), false );

--- a/Tests/Unit/inc/classes/AutoOptimization/MaybeStoreGenerateStepTest.php
+++ b/Tests/Unit/inc/classes/AutoOptimization/MaybeStoreGenerateStepTest.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\inc\classes\AutoOptimization;
+
+use Brain\Monkey\Functions;
+use Imagify_Auto_Optimization;
+use Imagify\Tests\Unit\TestCase;
+use Mockery;
+
+/**
+ * Tests for \Imagify_Auto_Optimization::maybe_store_generate_step() — WordPress 7.1 can let the
+ * browser process an upload, in which case the attachment is created with no sub sizes and each
+ * one is sent afterwards. Optimizing when the attachment is created would only ever cover the
+ * full size, so the "generate" step has to wait for the request that brings the sub sizes in.
+ *
+ * @covers \Imagify_Auto_Optimization::maybe_store_generate_step
+ * @covers \Imagify_Auto_Optimization::flag_awaiting_client_side_subsizes
+ * @group  AutoOptimization
+ * @since  2.3.3
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class MaybeStoreGenerateStepTest extends TestCase {
+
+	/**
+	 * Stubs everything maybe_store_generate_step() needs beyond the transient calls.
+	 */
+	private function stubDependencies(): void {
+		Functions\when( 'imagify_is_attachment_mime_type_supported' )->justReturn( true );
+	}
+
+	/**
+	 * Test: on an ordinary upload the generate step is stored, as it always was.
+	 */
+	public function testStoresTheGenerateStepOnAnOrdinaryUpload(): void {
+		$this->stubDependencies();
+		Functions\when( 'get_transient' )->justReturn( false );
+
+		$auto_optimization = new Imagify_Auto_Optimization();
+		$metadata          = [ 'file' => 'image.jpg' ];
+
+		$this->assertSame( $metadata, $auto_optimization->maybe_store_generate_step( $metadata, 42, 'create' ) );
+		$this->assertTrue( $auto_optimization->has_step( 42, 'generate' ) );
+	}
+
+	/**
+	 * Test: while the browser still owes its sub sizes, the create phase stores nothing, so
+	 * no optimization is launched against the full size alone.
+	 */
+	public function testSkipsTheGenerateStepWhileAwaitingClientSideSubsizes(): void {
+		$this->stubDependencies();
+		Functions\when( 'get_transient' )->justReturn( 1 );
+
+		$auto_optimization = new Imagify_Auto_Optimization();
+		$metadata          = [ 'file' => 'image.jpg' ];
+
+		$this->assertSame( $metadata, $auto_optimization->maybe_store_generate_step( $metadata, 42, 'create' ) );
+		$this->assertFalse( $auto_optimization->has_step( 42, 'generate' ) );
+		$this->assertFalse( $auto_optimization->has_step( 42, 'upload' ) );
+	}
+
+	/**
+	 * Test: the request that brings the sub sizes in restores the upload step, so the media is
+	 * treated as the new upload it still is, and clears the flag.
+	 */
+	public function testRestoresTheUploadStepWhenTheSubsizesArrive(): void {
+		$this->stubDependencies();
+		Functions\when( 'get_transient' )->justReturn( 1 );
+
+		$deleted = [];
+
+		Functions\when( 'delete_transient' )->alias(
+			function ( $name ) use ( &$deleted ) {
+				$deleted[] = $name;
+				return true;
+			}
+		);
+
+		$auto_optimization = new Imagify_Auto_Optimization();
+		$metadata          = [ 'file' => 'image.jpg' ];
+
+		$auto_optimization->maybe_store_generate_step( $metadata, 42, 'update' );
+
+		$this->assertTrue( $auto_optimization->has_step( 42, 'generate' ) );
+		$this->assertTrue( $auto_optimization->has_step( 42, 'upload' ) );
+		$this->assertSame( [ 'imagify_awaiting_subsizes_42' ], $deleted );
+	}
+
+	/**
+	 * Build a request stub returning the given value for the 'generate_sub_sizes' parameter.
+	 *
+	 * @param  mixed $value Value the parameter should return.
+	 * @return Mockery\MockInterface
+	 */
+	private function requestReturning( $value ) {
+		$request = Mockery::mock( 'WP_REST_Request' );
+		$request->shouldReceive( 'get_param' )->with( 'generate_sub_sizes' )->andReturn( $value );
+
+		return $request;
+	}
+
+	/**
+	 * Test: the attachment is flagged when WordPress hands the sub sizes over to the browser.
+	 */
+	public function testFlagsTheAttachmentWhenTheBrowserHandlesTheSubsizes(): void {
+		$stored = [];
+
+		Functions\when( 'set_transient' )->alias(
+			function ( $name, $value ) use ( &$stored ) {
+				$stored[ $name ] = $value;
+				return true;
+			}
+		);
+
+		( new Imagify_Auto_Optimization() )->flag_awaiting_client_side_subsizes( (object) [ 'ID' => 42 ], $this->requestReturning( false ), true );
+
+		$this->assertSame( [ 'imagify_awaiting_subsizes_42' => 1 ], $stored );
+	}
+
+	/**
+	 * Test: nothing is flagged for an ordinary upload, where WordPress builds the sub sizes,
+	 * nor when the parameter is absent entirely.
+	 */
+	public function testDoesNotFlagWhenWordPressBuildsTheSubsizes(): void {
+		Functions\expect( 'set_transient' )->never();
+
+		$attachment = (object) [ 'ID' => 42 ];
+
+		( new Imagify_Auto_Optimization() )->flag_awaiting_client_side_subsizes( $attachment, $this->requestReturning( true ), true );
+		( new Imagify_Auto_Optimization() )->flag_awaiting_client_side_subsizes( $attachment, $this->requestReturning( null ), true );
+	}
+
+	/**
+	 * Test: nothing is flagged when an existing attachment is being updated rather than created.
+	 */
+	public function testDoesNotFlagWhenUpdatingAnAttachment(): void {
+		Functions\expect( 'set_transient' )->never();
+
+		( new Imagify_Auto_Optimization() )->flag_awaiting_client_side_subsizes( (object) [ 'ID' => 42 ], $this->requestReturning( false ), false );
+	}
+}

--- a/Tests/Unit/inc/classes/AutoOptimization/StoreIdsToOptimizeTest.php
+++ b/Tests/Unit/inc/classes/AutoOptimization/StoreIdsToOptimizeTest.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Unit\inc\classes\AutoOptimization;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use Imagify_Auto_Optimization;
+use Imagify\Tests\Unit\TestCase;
+
+/**
+ * Tests for \Imagify_Auto_Optimization::store_ids_to_optimize() — on a client side upload the
+ * sub sizes are all stored in one write, and the sizes to optimize are read from the stored
+ * metadata. Launching from inside the filter would read the value that is about to be replaced
+ * and see no sub sizes at all, so that pass waits for the write instead.
+ *
+ * @covers \Imagify_Auto_Optimization::store_ids_to_optimize
+ * @group  AutoOptimization
+ * @since  2.3.3
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class StoreIdsToOptimizeTest extends TestCase {
+
+	/**
+	 * Stubs what both methods need beyond the transient calls.
+	 */
+	private function stubDependencies(): void {
+		Functions\when( 'imagify_is_attachment_mime_type_supported' )->justReturn( true );
+		Functions\when( 'get_imagify_option' )->justReturn( 1 );
+		Functions\when( 'delete_transient' )->justReturn( true );
+	}
+
+	/**
+	 * Test: an ordinary upload launches straight away, as it always did.
+	 */
+	public function testLaunchesImmediatelyOnAnOrdinaryUpload(): void {
+		$this->stubDependencies();
+		Functions\when( 'get_transient' )->justReturn( false );
+
+		$auto_optimization = new Imagify_Auto_Optimization();
+		$metadata          = [ 'file' => 'image.jpg' ];
+
+		$auto_optimization->set_step( 42, 'upload' );
+		$auto_optimization->maybe_store_generate_step( $metadata, 42, 'create' );
+
+		Actions\expectDone( 'imagify_after_auto_optimization_init' )->once()->with( 42, true );
+
+		$auto_optimization->store_ids_to_optimize( $metadata, 42 );
+	}
+
+	/**
+	 * Test: the pass that brings the client side sub sizes in does not launch from the filter,
+	 * because the metadata it would read has not been written yet.
+	 */
+	public function testDefersWhenTheClientSideSubsizesJustArrived(): void {
+		$this->stubDependencies();
+		Functions\when( 'get_transient' )->justReturn( 1 );
+
+		$auto_optimization = new Imagify_Auto_Optimization();
+		$metadata          = [ 'file' => 'image.jpg' ];
+
+		// The finalize request: this restores the upload step and marks the pass as deferred.
+		$auto_optimization->maybe_store_generate_step( $metadata, 42, 'update' );
+
+		Actions\expectDone( 'imagify_after_auto_optimization_init' )->never();
+
+		$this->assertSame( $metadata, $auto_optimization->store_ids_to_optimize( $metadata, 42 ) );
+
+		// The step is left in place for do_auto_optimization_after_meta_update() to pick up.
+		$this->assertTrue( $auto_optimization->has_step( 42, 'update' ) );
+		$this->assertTrue( $auto_optimization->has_step( 42, 'upload' ) );
+	}
+
+	/**
+	 * Test: deferring happens once. A later metadata write for the same attachment, with the
+	 * flag gone, launches normally rather than being skipped again.
+	 */
+	public function testDeferringAppliesOnlyToThatPass(): void {
+		$this->stubDependencies();
+		Functions\when( 'get_transient' )->justReturn( 1 );
+
+		$auto_optimization = new Imagify_Auto_Optimization();
+		$metadata          = [ 'file' => 'image.jpg' ];
+
+		$auto_optimization->maybe_store_generate_step( $metadata, 42, 'update' );
+		$auto_optimization->store_ids_to_optimize( $metadata, 42 );
+
+		Actions\expectDone( 'imagify_after_auto_optimization_init' )->once();
+
+		$auto_optimization->store_ids_to_optimize( $metadata, 42 );
+	}
+}

--- a/classes/Tools/InternalStateList.php
+++ b/classes/Tools/InternalStateList.php
@@ -64,6 +64,9 @@ class InternalStateList {
 			'_transient_%imagify_rpc_%',            // Legacy/deprecated.
 			'_transient_imagify_%_process_locked',
 			'_site_transient_imagify_%_process_lock%',
+			// Flags an attachment whose sub sizes the browser is still to send, on WP 7.1+.
+			'_transient_imagify_awaiting_subsizes_%',
+			'_transient_timeout_imagify_awaiting_subsizes_%',
 		];
 	}
 

--- a/inc/classes/class-imagify-auto-optimization.php
+++ b/inc/classes/class-imagify-auto-optimization.php
@@ -99,6 +99,12 @@ class Imagify_Auto_Optimization extends Imagify_Auto_Optimization_Deprecated {
 		 * upload of WP 7.1 needs: it stores every sub size at once, so reading them before the
 		 * write would only ever see the full size. Harmless the rest of the time, since an
 		 * optimization that already ran has cleared its steps by then.
+		 *
+		 * The trade-off is that these two hooks now fire for every post meta write on the site
+		 * rather than only on old WordPress versions. The callback returns on anything that is
+		 * not '_wp_attachment_metadata', which is the first thing it checks, so the cost is one
+		 * string comparison. Carrying the state on the attachment instead would mean an extra
+		 * read on every upload, for a narrower guarantee.
 		 */
 		add_action( 'updated_post_meta', [ $this, 'do_auto_optimization_after_meta_update' ], $priority, 4 );
 		add_action( 'added_post_meta', [ $this, 'do_auto_optimization_after_meta_update' ], $priority, 4 );
@@ -190,6 +196,11 @@ class Imagify_Auto_Optimization extends Imagify_Auto_Optimization_Deprecated {
 			return;
 		}
 
+		if ( ! imagify_is_attachment_mime_type_supported( $attachment->ID ) ) {
+			// Nothing would ever read the flag for this attachment.
+			return;
+		}
+
 		set_transient( $this->get_awaiting_subsizes_transient_name( $attachment->ID ), 1, HOUR_IN_SECONDS );
 	}
 
@@ -202,7 +213,8 @@ class Imagify_Auto_Optimization extends Imagify_Auto_Optimization_Deprecated {
 	 * @param  array  $metadata      An array of attachment meta data.
 	 * @param  int    $attachment_id Current attachment ID.
 	 * @param  string $context       Can be 'create' when the metadata was initially created for a
-	 *                               new attachment, or 'update' when it was updated. Null before WP 7.1.
+	 *                               new attachment, or 'update' when it was updated. Passed by WordPress
+	 *                               since 5.3, so only null if something else applies the filter.
 	 * @return array
 	 */
 	public function maybe_store_generate_step( $metadata, $attachment_id, $context = null ) {

--- a/inc/classes/class-imagify-auto-optimization.php
+++ b/inc/classes/class-imagify-auto-optimization.php
@@ -39,6 +39,14 @@ class Imagify_Auto_Optimization extends Imagify_Auto_Optimization_Deprecated {
 	private $is_wp_53;
 
 	/**
+	 * Attachment IDs whose optimization must wait for the metadata to be stored.
+	 *
+	 * @var   array
+	 * @since 2.3.3
+	 */
+	private $deferred = [];
+
+	/**
 	 * The ID of the attachment that failed to be uploaded.
 	 *
 	 * @var   int
@@ -75,7 +83,8 @@ class Imagify_Auto_Optimization extends Imagify_Auto_Optimization_Deprecated {
 
 		// Automatic optimization tunel.
 		add_action( 'add_attachment', [ $this, 'store_upload_ids' ], $priority );
-		add_filter( 'wp_generate_attachment_metadata', [ $this, 'maybe_store_generate_step' ], $priority, 2 );
+		add_action( 'rest_after_insert_attachment', [ $this, 'flag_awaiting_client_side_subsizes' ], $priority, 3 );
+		add_filter( 'wp_generate_attachment_metadata', [ $this, 'maybe_store_generate_step' ], $priority, 3 );
 		add_filter( 'wp_update_attachment_metadata', [ $this, 'store_ids_to_optimize' ], $priority, 2 );
 
 		if ( $this->is_wp_53 ) {
@@ -83,10 +92,16 @@ class Imagify_Auto_Optimization extends Imagify_Auto_Optimization_Deprecated {
 			add_action( 'imagify_after_auto_optimization_init', [ $this, 'do_auto_optimization' ], $priority, 2 );
 			// Upload failure recovering.
 			add_action( 'wp_ajax_media-create-image-subsizes', [ $this, 'prevent_auto_optimization_when_recovering_from_upload_failure' ], -5 ); // Before WP’s hook (priority 1).
-		} else {
-			add_action( 'updated_post_meta', [ $this, 'do_auto_optimization_after_meta_update' ], $priority, 4 );
-			add_action( 'added_post_meta', [ $this, 'do_auto_optimization_after_meta_update' ], $priority, 4 );
 		}
+
+		/**
+		 * Also used on WP 5.3+ to optimize once the metadata is stored, which the client side
+		 * upload of WP 7.1 needs: it stores every sub size at once, so reading them before the
+		 * write would only ever see the full size. Harmless the rest of the time, since an
+		 * optimization that already ran has cleared its steps by then.
+		 */
+		add_action( 'updated_post_meta', [ $this, 'do_auto_optimization_after_meta_update' ], $priority, 4 );
+		add_action( 'added_post_meta', [ $this, 'do_auto_optimization_after_meta_update' ], $priority, 4 );
 
 		add_action( 'deleted_post_meta', [ $this, 'unset_optimization' ], $priority, 3 );
 
@@ -105,6 +120,7 @@ class Imagify_Auto_Optimization extends Imagify_Auto_Optimization_Deprecated {
 
 		// Automatic optimization tunel.
 		remove_action( 'add_attachment', [ $this, 'store_upload_ids' ], $priority );
+		remove_action( 'rest_after_insert_attachment', [ $this, 'flag_awaiting_client_side_subsizes' ], $priority );
 		remove_filter( 'wp_generate_attachment_metadata', [ $this, 'maybe_store_generate_step' ], $priority );
 		remove_filter( 'wp_update_attachment_metadata', [ $this, 'store_ids_to_optimize' ], $priority );
 
@@ -113,10 +129,10 @@ class Imagify_Auto_Optimization extends Imagify_Auto_Optimization_Deprecated {
 			remove_action( 'imagify_after_auto_optimization_init', [ $this, 'do_auto_optimization' ], $priority );
 			// Upload failure recovering.
 			remove_action( 'wp_ajax_media-create-image-subsizes', [ $this, 'prevent_auto_optimization_when_recovering_from_upload_failure' ], -5 );
-		} else {
-			remove_action( 'updated_post_meta', [ $this, 'do_auto_optimization_after_meta_update' ], $priority );
-			remove_action( 'added_post_meta', [ $this, 'do_auto_optimization_after_meta_update' ], $priority );
 		}
+
+		remove_action( 'updated_post_meta', [ $this, 'do_auto_optimization_after_meta_update' ], $priority );
+		remove_action( 'added_post_meta', [ $this, 'do_auto_optimization_after_meta_update' ], $priority );
 
 		remove_action( 'deleted_post_meta', [ $this, 'unset_optimization' ], $priority );
 
@@ -145,15 +161,51 @@ class Imagify_Auto_Optimization extends Imagify_Auto_Optimization_Deprecated {
 	}
 
 	/**
+	 * Remember that the browser will send the sub sizes of an attachment separately.
+	 *
+	 * WordPress 7.1 can let the browser process an upload. The attachment is then created
+	 * with no sub sizes at all, each one is sent afterwards through the sideload endpoint,
+	 * and a last request finalizes the metadata. Optimizing when the attachment is created
+	 * would only ever cover the full size.
+	 *
+	 * This runs before the metadata is first generated, and the flag is stored because the
+	 * sub sizes arrive in later requests.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param object $attachment Inserted or updated attachment object. A \WP_Post when WordPress fires this.
+	 * @param object $request    Request object. A \WP_REST_Request when WordPress fires this.
+	 * @param bool   $creating   True when creating an attachment, false when updating.
+	 */
+	public function flag_awaiting_client_side_subsizes( $attachment, $request, $creating ) {
+		if ( ! $creating || ! is_object( $attachment ) || ! isset( $attachment->ID ) ) {
+			return;
+		}
+
+		if ( ! is_object( $request ) || ! is_callable( [ $request, 'get_param' ] ) ) {
+			return;
+		}
+
+		if ( false !== $request->get_param( 'generate_sub_sizes' ) ) {
+			return;
+		}
+
+		set_transient( $this->get_awaiting_subsizes_transient_name( $attachment->ID ), 1, HOUR_IN_SECONDS );
+	}
+
+	/**
 	 * Store the "generate step" when wp_generate_attachment_metadata() is used.
 	 *
 	 * @since 1.9.10
+	 * @since 2.3.3 Added the $context parameter.
 	 *
-	 * @param  array $metadata      An array of attachment meta data.
-	 * @param  int   $attachment_id Current attachment ID.
+	 * @param  array  $metadata      An array of attachment meta data.
+	 * @param  int    $attachment_id Current attachment ID.
+	 * @param  string $context       Can be 'create' when the metadata was initially created for a
+	 *                               new attachment, or 'update' when it was updated. Null before WP 7.1.
 	 * @return array
 	 */
-	public function maybe_store_generate_step( $metadata, $attachment_id ) {
+	public function maybe_store_generate_step( $metadata, $attachment_id, $context = null ) {
 		if ( self::is_optimization_prevented( $attachment_id ) ) {
 			return $metadata;
 		}
@@ -163,9 +215,68 @@ class Imagify_Auto_Optimization extends Imagify_Auto_Optimization_Deprecated {
 			return $metadata;
 		}
 
+		if ( $this->is_awaiting_client_side_subsizes( $attachment_id ) ) {
+			if ( 'create' === $context ) {
+				/**
+				 * The browser has not sent its sub sizes yet. Optimizing now would cover the
+				 * full size only, and leave every thumbnail untouched.
+				 */
+				return $metadata;
+			}
+
+			/**
+			 * The sub sizes are in. The upload step was set in the request that created the
+			 * attachment and did not outlive it, so set it again: as far as Imagify is
+			 * concerned this still is a brand new upload.
+			 */
+			$this->clear_awaiting_client_side_subsizes( $attachment_id );
+			$this->set_step( $attachment_id, 'upload' );
+
+			/**
+			 * The sub sizes are all stored in one go, right after this, so the optimization
+			 * has to wait for that write. Reading them now would only see the full size.
+			 */
+			$this->deferred[ $attachment_id ] = 1;
+		}
+
 		$this->set_step( $attachment_id, 'generate' );
 
 		return $metadata;
+	}
+
+	/**
+	 * Tell if the browser is still to send the sub sizes of an attachment.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  int $attachment_id Current attachment ID.
+	 * @return bool
+	 */
+	public function is_awaiting_client_side_subsizes( $attachment_id ) {
+		return (bool) get_transient( $this->get_awaiting_subsizes_transient_name( $attachment_id ) );
+	}
+
+	/**
+	 * Forget that the browser was to send the sub sizes of an attachment.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param int $attachment_id Current attachment ID.
+	 */
+	public function clear_awaiting_client_side_subsizes( $attachment_id ) {
+		delete_transient( $this->get_awaiting_subsizes_transient_name( $attachment_id ) );
+	}
+
+	/**
+	 * Get the transient name used to await the sub sizes of an attachment.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  int $attachment_id Current attachment ID.
+	 * @return string
+	 */
+	private function get_awaiting_subsizes_transient_name( $attachment_id ) {
+		return 'imagify_awaiting_subsizes_' . (int) $attachment_id;
 	}
 
 	/**
@@ -283,6 +394,16 @@ class Imagify_Auto_Optimization extends Imagify_Auto_Optimization_Deprecated {
 
 		// Ready for the next step.
 		$this->set_step( $attachment_id, 'update' );
+
+		if ( ! empty( $this->deferred[ $attachment_id ] ) ) {
+			/**
+			 * The metadata is not stored yet, so the sizes to optimize cannot be read.
+			 * $this->do_auto_optimization_after_meta_update() takes over once it is.
+			 */
+			unset( $this->deferred[ $attachment_id ] );
+
+			return $metadata;
+		}
 
 		/**
 		 * Triggered after a media auto-optimization init.


### PR DESCRIPTION
# Description

Fixes #1234

WordPress 7.1 can hand an upload over to the browser. The attachment is then created with no sub sizes at all, each one is sent afterwards through a new sideload endpoint, and a last request stores the complete metadata in one go.

Auto optimization ran on that first, empty metadata. Only the full size was ever optimized, every thumbnail was left untouched, and the media still reported success. Users saw "Optimize 6 missing thumbnails" on the media, or worse, on smaller images, "WELL DONE. This media file is already optimized, no further optimization is required." with no way to recover. Next-Gen images had the same gap, so the front end served WebP for the main image and untouched JPEG for every thumbnail.

Uploads made from the block editor now get every size optimized, in a single pass.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Everything below was done by hand on a real WordPress 7.1-RC3-63235 build, in Chrome 151, with Imagify connected and auto optimization on. A small mu-plugin was used during testing to log when the metadata was generated and when auto optimization fired, and to read the optimization data back. It is not part of this PR.

**Reproduced the bug first.** Uploaded a 4000x3000 JPEG from the block editor on an unpatched build. The optimization data came back with `full` and `full@imagify-webp` only, while the media had six sub sizes on disk, and the media row offered "Optimize 6 missing thumbnails". Repeated with an image below 2560px: four sub sizes unoptimized, and the row read "WELL DONE. This media file is already optimized, no further optimization is required." with no recovery link at all. The log showed auto optimization firing twice, once on the empty metadata and once at the end.

**Verified the fix on the same flow.** Uploaded a 3800x2500 JPEG from the block editor and read the optimization data back:

| | Before | After |
|---|---|---|
| Sizes optimized | `full` only | `full` and all 6 sub sizes |
| Next-Gen versions | `full` only | all 7 |
| Times auto optimization fired | 2 | 1 |
| Media Library detail | "Optimize 6 missing thumbnails" | "Thumbnails Optimized: 7" |
| Overall saving reported | 41% on one file | 52.58% across the set |

The log showed the create phase no longer triggering anything, and the finalize pass seeing every size:

```
gen_meta id=145 context='create' sizes=0                      <- nothing triggered
gen_meta id=145 context='update' sizes=6
>>> AUTO_OPT id=145 is_new_upload=true sizes_present=thumbnail,medium,medium_large,large,1536x1536,2048x2048
```

**Confirmed it in the interface, not only in the data.** Opened "View Details" on the media in the Media Library list view: "Thumbnails Optimized: 7", "Next-Gen generated: Yes", overall saving 52.58%, and no "Optimize N missing thumbnails" link.

**Checked that ordinary uploads still work,** which matters most here because the hook registration changed for every WordPress version. Uploaded through Media, Add Media File: auto optimization fired exactly once, as a new upload, with all sizes already present, and the media ended with all 5 sizes and all 5 Next-Gen versions optimized. No second pass.

**Re-ran the whole upload test after the last code change.** The final commit tightened the input guards on the new hook, so the manual upload test was repeated against it rather than assumed: all 7 sizes plus all 7 Next-Gen versions optimized, one pass, flag cleared, 50.17% saving.

Automated checks on top of the manual work: 6 new unit tests (`composer test-unit -- --group AutoOptimization`, 8 including the 2 that already covered this class), full suite green at 490, `composer run-stan` clean, PHPCS clean on both changed files.

### How to test

Setup:

1. Install WordPress 7.1 and serve it over HTTPS, or on `localhost`. Client side processing needs a secure context, and it is enabled by default there in any browser.
2. Activate Imagify on this branch and connect it with a valid API key.
3. Go to Settings, Imagify. Turn "Auto optimize images on upload" on and turn "Backup original images" on. Save.
4. Prepare two JPEGs: one wider than 2560 pixels, and one narrower, for example 1200x900.

Test the main case:

5. Create a new post: Posts, Add New.
6. Insert an Image block, by typing `/image` and pressing Enter.
7. Upload the wide JPEG through that block. It has to be the block editor. The classic Media Library has no cross origin isolation, so WordPress falls back to server side processing there and this code path never runs.
8. Wait for the image to appear in the block, then give the optimization about 15 seconds to finish.

Check the result:

9. Go to Media, Library and switch to list view.
10. Find the media and click "View Details" in its Imagify column.
11. "Thumbnails Optimized" must match the number of sub sizes the media has, so 6 for a wide image on a default install.
12. There must be no "Optimize N missing thumbnails" link. That link appearing means the bug is still present.
13. "Next-Gen generated" must say Yes.

Test the case that used to be worse:

14. Repeat steps 5 to 8 with the 1200x900 JPEG.
15. Its row must not read "WELL DONE. This media file is already optimized, no further optimization is required.". That message with unoptimized thumbnails, and no recovery link, was the original symptom on small images.
16. Click "View Details" and confirm "Thumbnails Optimized" matches its sub size count, so 4 on a default install.

Check nothing regressed on ordinary uploads:

17. Go to Media, Add Media File and upload the wide JPEG there.
18. Wait for the optimization, then open "View Details". Every size must be optimized, exactly as before this change.
19. Confirm the media was optimized once, not twice, for example by checking that the reported original file size matches the file you uploaded rather than an already compressed version.

### Affected Features & Quality Assurance Scope

1. Auto optimization on upload, in every context, since the hooks changed for all of them. Ordinary uploads keep their existing path, and the deferred path only applies to attachments WordPress flagged as browser processed.
2. Next-Gen generation on upload, which inherits the fix because it is part of the same pass.
3. The Media Library Imagify column, including the "Optimize N missing thumbnails" action and the optimization statistics.
4. Upload failure recovery through `media-create-image-subsizes`, which shares this class.
5. Bulk optimization, custom folders and manual optimization do not go through this path and are untouched.

## Technical description

### Documentation

Two separate problems had to be solved.

**The trigger fired too early.** `WP_REST_Attachments_Controller::create_item()` generates and stores metadata with no sub sizes, then the browser sideloads them one by one, then `finalize_item()` stores the complete set. Imagify keyed its "generate" step off the first of those, and `store_ids_to_optimize()` launched from there.

There is no public way to ask WordPress whether the browser is handling an upload, so the state is taken from where WordPress itself declares it: `rest_after_insert_attachment` fires just before the metadata is generated and carries the request, whose `generate_sub_sizes` parameter is `false` exactly when the browser owns the sub sizes. That gets recorded in a one hour transient, because the sub sizes arrive in later requests.

While that flag is set, the `create` phase stores no step at all, so nothing is optimized. When the finalize request comes through with the `update` context, the flag is cleared and the "upload" step is restored. That step was set on `add_attachment`, in the request that created the attachment, and is held in memory only, so it did not outlive it. Restoring it is what makes the media count as a new upload instead of falling into the "already optimized?" branch, which would either re-optimize the full size for a second credit or bail out and leave the media untouched.

**The size list was read too early.** Fixing the timing alone was not enough, and this is the part worth reviewing closely. `optimize()` resolves the sizes to work on when it queues the job, and it reads them from the stored metadata. During `wp_update_attachment_metadata` the new value has not been written yet, so on the finalize pass it still saw zero sub sizes and queued the full size alone. This was found during testing: the trigger was firing at the right moment, as a new upload, and the thumbnails were still not optimized.

Ordinary uploads never hit this because WordPress writes metadata progressively as it builds sub sizes, so by the last call the rows are already there. The client side flow writes everything once, at the end.

So for this path the optimization is deferred: `store_ids_to_optimize()` sets its "update" step and returns without firing, and `do_auto_optimization_after_meta_update()`, hooked on `added_post_meta` and `updated_post_meta`, picks it up once `_wp_attachment_metadata` is actually stored. That method already existed for WordPress versions below 5.3, and already guards on the "update" step, so it is now registered for every version. It cannot double fire: `do_auto_optimization()` clears the steps as its first action, so after an immediate run the meta hooks find nothing to do.

### New dependencies

None.

### Risks

The `added_post_meta` and `updated_post_meta` hooks are now registered on WordPress 5.3 and above, where previously they were not. They are guarded by the "update" step, which only `store_ids_to_optimize()` sets and which `do_auto_optimization()` clears before doing anything, so an ordinary upload cannot be optimized twice. This was verified on a real upload: one pass, one set of results.

If the browser never sends its sub sizes, because the tab was closed mid upload, the flag expires after an hour and the media stays unoptimized until something else touches it. WordPress is in the same position, since the sub sizes never arrive either, and it exposes a resume path of its own for that case. Optimizing a partial media instead would be the worse outcome.

The flag is stored per attachment, only for uploads WordPress flagged as browser processed, and it is deleted as soon as the sub sizes arrive, so nothing accumulates.

`maybe_store_generate_step()` now takes a third parameter. It is optional and defaults to null, which is what WordPress versions before 7.1 pass, so third party code calling it directly keeps working.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Nothing unticked.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

The flow is observable through the existing `imagify_before_auto_optimization` hook, whose `$is_new_upload` argument now reports true on the finalize pass, and through the `imagify_awaiting_subsizes_<id>` transient which exists between the two. No filesystem or HTTP calls were added.
