### PR TITLE
Fix #1244: interpret the settings info text as HTML

### DIFF
--- a/Tests/Fixtures/inc/classes/ImagifySettings/printInfo.php
+++ b/Tests/Fixtures/inc/classes/ImagifySettings/printInfo.php
@@ -1,0 +1,68 @@
+<?php
+
+return [
+	'test_data' => [
+		'shouldKeepLineBreaks' => [
+			'config'   => [
+				'info' => 'First sentence.<br><br>Second sentence.',
+			],
+			'expected' => 'First sentence.<br><br>Second sentence.',
+		],
+
+		'shouldKeepSelfClosingLineBreaks' => [
+			'config'   => [
+				'info' => 'First sentence.<br />Second sentence.',
+			],
+			'expected' => 'First sentence.<br />Second sentence.',
+		],
+
+		'shouldKeepCodeTags' => [
+			'config'   => [
+				'info' => 'Defined by the <code>imagify_nextgen_images_format</code> filter.',
+			],
+			'expected' => 'Defined by the <code>imagify_nextgen_images_format</code> filter.',
+		],
+
+		'shouldKeepDocumentationLink' => [
+			'config'   => [
+				'info' => 'See <a href="https://imagify.io/documentation/" target="_blank">Read more</a>.',
+			],
+			'expected' => 'See <a href="https://imagify.io/documentation/" target="_blank">Read more</a>.',
+		],
+
+		'shouldKeepInlineEmphasis' => [
+			'config'   => [
+				'info' => 'This is <strong>important</strong> and <em>subtle</em>.',
+			],
+			'expected' => 'This is <strong>important</strong> and <em>subtle</em>.',
+		],
+
+		'shouldStripScriptTag' => [
+			'config'   => [
+				'info' => 'Harmless.<script>alert(1)</script>',
+			],
+			'expected' => 'Harmless.alert(1)',
+		],
+
+		'shouldStripEventHandlerAttribute' => [
+			'config'   => [
+				'info' => '<a href="https://imagify.io/" onclick="alert(1)">Link</a>',
+			],
+			'expected' => '<a href="https://imagify.io/">Link</a>',
+		],
+
+		'shouldStripDisallowedTagButKeepItsText' => [
+			'config'   => [
+				'info' => 'Before <iframe src="https://evil.test/"></iframe>after.',
+			],
+			'expected' => 'Before after.',
+		],
+
+		'shouldPrintNothingForAnEmptyMessage' => [
+			'config'   => [
+				'info' => '',
+			],
+			'expected' => '',
+		],
+	],
+];

--- a/Tests/Integration/inc/classes/ImagifySettings/printInfo.php
+++ b/Tests/Integration/inc/classes/ImagifySettings/printInfo.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Imagify\Tests\Integration\inc\classes\ImagifySettings;
+
+use Imagify_Settings;
+use Imagify\Tests\Integration\TestCase;
+
+/**
+ * @covers Imagify_Settings::print_info
+ *
+ * @group  ImagifySettings
+ */
+class Test_PrintInfo extends TestCase {
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldPrintTheExpectedMarkup( $config, $expected ) {
+		ob_start();
+		Imagify_Settings::print_info( $config['info'] );
+		$output = ob_get_clean();
+
+		$this->assertSame( $expected, $output );
+	}
+}

--- a/inc/classes/class-imagify-settings.php
+++ b/inc/classes/class-imagify-settings.php
@@ -483,7 +483,7 @@ class Imagify_Settings {
 		?>
 		<span id="<?php echo esc_attr( $attributes['aria-describedby'] ); ?>" class="imagify-info">
 			<span class="dashicons dashicons-info"></span>
-			<?php echo esc_html( $args['info'] ); ?>
+			<?php self::print_info( $args['info'] ); ?>
 		</span>
 		<?php
 	}
@@ -698,7 +698,7 @@ class Imagify_Settings {
 		?>
 		<span id="<?php echo esc_attr( $attributes['aria-describedby'] ); ?>" class="imagify-info">
 			<span class="dashicons dashicons-info"></span>
-			<?php echo esc_html( $args['info'] ); ?>
+			<?php self::print_info( $args['info'] ); ?>
 		</span>
 		<?php
 	}
@@ -764,7 +764,7 @@ class Imagify_Settings {
 			</p>
 			<span id="<?php echo esc_attr( $attributes['aria-describedby'] ); ?>" class="imagify-<?php echo esc_attr( $args['info_class'] ); ?>">
 				<span class="dashicons dashicons-info"></span>
-				<?php echo esc_html( $args['info'] ); ?>
+				<?php self::print_info( $args['info'] ); ?>
 			</span>
 		</div>
 		<?php
@@ -832,7 +832,7 @@ class Imagify_Settings {
 		?>
 		<span id="<?php echo esc_attr( $attributes['aria-describedby'] ); ?>" class="imagify-info">
 			<span class="dashicons dashicons-info"></span>
-			<?php echo esc_html( $args['info'] ); ?>
+			<?php self::print_info( $args['info'] ); ?>
 		</span>
 		<?php
 	}
@@ -936,5 +936,40 @@ class Imagify_Settings {
 		}
 
 		return $out;
+	}
+
+	/**
+	 * Print an informative message, keeping the inline formatting it carries.
+	 *
+	 * The `info` argument of the field renderers is written as markup by its
+	 * callers: a `<br>` separating two sentences, a `<code>` naming a filter, a
+	 * link to the documentation. Passing it through `esc_html()` printed those
+	 * tags to the user instead of applying them, so it goes through a narrow
+	 * allow-list of inline tags.
+	 *
+	 * The message is already translated by the time it arrives, which is exactly
+	 * why the filtering happens here: whatever a translation introduces is held
+	 * to the same allow-list as the original string.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param string $info The message to print.
+	 * @return void
+	 */
+	public static function print_info( $info ) {
+		echo wp_kses(
+			$info,
+			[
+				'a'      => [
+					'href'   => true,
+					'rel'    => true,
+					'target' => true,
+				],
+				'br'     => [],
+				'code'   => [],
+				'em'     => [],
+				'strong' => [],
+			]
+		);
 	}
 }


### PR DESCRIPTION
> This pull request was written with AI assistance.

# Description

Fixes #1244

The settings page showed `<br><br>` as literal text in the middle of the "Lossless compression"
description. The four field renderers print their `info` argument through `esc_html()`, but the views
deliberately build that argument as markup, so the tags were escaped instead of applied. The same bug
hid the documentation link in the Next-Gen image format message.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

**The two real occurrences, by reading the rendered output:**

- `views/page-settings.php:83` builds the lossless description as two translated sentences joined by
  `'<br><br>'`. It reached `field_checkbox()`, which escaped it. Now it line-breaks.
- `views/part-settings-webp.php:20-27` builds the filter-active message with `<code>` and an
  `<a href>` to the documentation, and reached `field_inline_radio_list()`. The link is now clickable
  instead of being printed as raw HTML.

**Automated — integration (`--group ImagifySettings`, 9 data sets):** `br` and self-closing `<br />`
survive, as do `code`, `a` with `href`/`target`, `strong` and `em`. The negative cases matter more:
`<script>alert(1)</script>` loses its tags, an `onclick` attribute on an otherwise-allowed `<a>` is
dropped while the `href` is kept, an `<iframe>` is removed entirely, and an empty message prints
nothing at all.

**Automated — unit:** 527 tests pass (2 pre-existing risky results in
`ImagifySettings/updateSiteOptionOnNetwork`, from a `version_compare()` deprecation at
`class-imagify-settings.php:374` — untouched by this branch and present on `develop`).

**Verified against real `wp_kses()`:** the integration suite needs a WordPress test install that is
not provisioned on this machine, so before committing I ran all nine inputs through WordPress core's
own `wp_kses()` with this branch's allow-list, in a standalone harness loading
`wp-includes/kses.php`. All nine outputs matched the fixture expectations byte for byte. The
integration test itself has therefore not been executed by a runner yet — CI will be its first real
run, and that is the one gap in this PR's verification.

```
IN : First sentence.<br><br>Second sentence.
OUT: First sentence.<br><br>Second sentence.
IN : Harmless.<script>alert(1)</script>
OUT: Harmless.alert(1)
IN : <a href="https://imagify.io/" onclick="alert(1)">Link</a>
OUT: <a href="https://imagify.io/">Link</a>
```

`composer phpcs` and `composer run-stan` are clean.

### How to test

1. Go to **Settings → Imagify** and read the info text under **Lossless compression**. The two
   sentences must be separated by a blank line, with no `<br>` visible anywhere.
2. Add `add_filter( 'imagify_nextgen_images_formats', '__return_empty_array' );` in a mu-plugin,
   reload the settings page, and check the Next-Gen image format message: `imagify_nextgen_images_format`
   must render as inline code and "Read more" must be a working link to the documentation.
3. Confirm the remaining info texts (Auto-Optimize, Backup, and the text boxes) are unchanged — they
   contain no markup, so they must look exactly as before.

### Affected Features & Quality Assurance Scope

The info text of every settings field, via `field_checkbox()`, `field_radio_list()`,
`field_inline_radio_list()` and `field_text_box()`. No option value, form submission or sanitization
path is touched — only how the help text beside a field is printed. `field_hidden()` has no info text
and is untouched.

## Technical description

### Documentation

`Imagify_Settings::print_info( string $info )` prints an info message through `wp_kses()` with an
allow-list of `a` (`href`, `rel`, `target`), `br`, `code`, `em` and `strong`. The four renderers call
it in place of `echo esc_html( $args['info'] )`; the surrounding `<span class="imagify-info">` markup
and the existing empty-info guards are unchanged, so the only behavioural difference is which
characters survive.

Filtering happens at print time, after translation, on purpose: the strings are wrapped in `__()`,
so a translation is just as capable of introducing markup as the source string, and `wp_kses()`
holds both to the same allow-list.

The helper prints rather than returns. Returning it would put a non-core function inside an `echo`
at four call sites, which `WordPress.Security.EscapeOutput` flags and which would have meant four
`phpcs:ignore` comments; keeping the `echo` inside the helper leaves the escaping sniff satisfied
with `wp_kses()` and needs no suppression.

### New dependencies

None. `wp_kses()` is WordPress core.

### Risks

Switching from `esc_html()` to `wp_kses()` widens what can be printed, so it is worth being precise
about the trust boundary. Every `info` value in the plugin is a hard-coded, translated literal
assembled in a view — none is user input, an option value, or anything that crosses a request. The
allow-list carries no `style`, no `on*` handler and no `script`/`iframe`, and `wp_kses()` applies
`wp_allowed_protocols()` to `href`, so a `javascript:` URL is stripped even if one were introduced by
a translation. The realistic worst case is a malicious translation adding a link, which the
allow-list already permits and which `wp_kses()` protocol-checks.

Nothing else reads or reuses `print_info()`, and the escaping of every other rendered value
(`label`, `legend`, attributes, option values) is untouched.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

All mandatory items apply and are done. Note the verification caveat above: the new integration test
was validated against core's `wp_kses()` in a standalone harness rather than by the PHPUnit
integration runner, which is not provisioned locally.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

Observability is not applicable: the change is a single rendering helper with no state, no failure
mode and no branch worth logging.
