### PR TITLE
Closes #1250: Fix publish_mcp_abilities workflow after CI migration

### DIFF
--- a/.github/workflows/publish_mcp_abilities.yml
+++ b/.github/workflows/publish_mcp_abilities.yml
@@ -11,49 +11,45 @@ jobs:
 
     name: Dump Imagify abilities catalog (WP latest, PHP 8.2)
 
-    env:
-      WP_TESTS_DIR: "/tmp/tests/phpunit"
-      WP_CORE_DIR: "/tmp/wordpress-develop"
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
 
     steps:
     - name: Checkout
       uses: actions/checkout@v7
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+    - name: Setup PHP + Composer
+      uses: wp-media/workflows/.github/actions/setup-php-composer@main
       with:
         php-version: '8.2'
-        coverage: none
-        tools: composer:v2, phpunit
+        # Empty overrides the action's `--no-scripts` default so Composer runs
+        # post-install/update scripts, i.e. Strauss namespace prefixing, which the
+        # integration tests need to autoload the Imagify\Dependencies\* classes.
+        composer-options: ''
 
-    - name: Install SVN
-      run: sudo apt-get install subversion
-
-    - name: Start mysql service
-      run: sudo /etc/init.d/mysql start
-
-    - name: Get composer cache directory
-      id: composercache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-    - name: Cache dependencies
-      uses: actions/cache@v6
+    - name: Setup WordPress test suite
+      uses: wp-media/workflows/.github/actions/setup-wp-tests@main
       with:
-        path: ${{ steps.composercache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-        restore-keys: ${{ runner.os }}-composer-
+        wp-version: latest
 
-    - name: Install Strauss
-      run: sh -c 'test -f ./bin/strauss.phar || curl -o bin/strauss.phar -L -C - https://github.com/BrianHenryIE/strauss/releases/latest/download/strauss.phar'
+    # Registered here, not in the composite action: GitHub removes problem
+    # matchers added inside a composite action when it finishes, so they must
+    # be added in the caller to stay active for the test steps below.
+    - name: Setup problem matchers for PHP
+      run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
 
-    - name: Install dependencies
-      run: composer install --no-interaction
-
-    - name: Install tests
-      run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 latest
-
-    - name: Mysql8 auth plugin workaround
-      run: sudo mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
+    - name: Setup problem matchers for PHPUnit
+      run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Dump abilities catalog as JSON
       env:


### PR DESCRIPTION
> 🤖 AI-generated — created by an automated pipeline. Review before acting on this.

# Description

Fixes #1250

The `Publish MCP Abilities to ARD Service` workflow failed on every tag push because its `Dump Imagify abilities catalog (WP latest, PHP 8.2)` job still called `bin/install-wp-tests.sh`, a script deleted in #1229 during the CI migration to the `wp-media/workflows` composite actions. `publish_mcp_abilities.yml` was missed in that migration, so the abilities catalog was never published on release. Users are not directly impacted, but the release pipeline was broken.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

- **Automated:** Validated the workflow YAML parses cleanly.
- **Manual (static):** Diffed the changed job structure against the already-migrated, CI-passing `test.yml` and `test_legacy.yml` to confirm it uses the same composite actions, `composer-options: ''`, mysql service container, and problem matchers.
- The end-to-end run was **not** exercised: the workflow only triggers on a tag push, and publishing a tag during development is out of scope for this fix. First real validation will be the next tag publish after merge.

### How to test

- Confirm `.github/workflows/publish_mcp_abilities.yml` no longer references `bin/install-wp-tests.sh` and that the removed script is not needed elsewhere.
- Compare the `Dump Imagify abilities catalog` job against `test.yml` / `test_legacy.yml` — setup should be the `setup-php-composer@main` + `setup-wp-tests@main` composite actions plus the mysql service container.
- After merge, on the next tag push, verify the `Dump Imagify abilities catalog (WP latest, PHP 8.2)` job installs the WP test suite and proceeds to dump and upload the abilities catalog without exit code 127.

### Affected Features & Quality Assurance Scope

- CI/CD only: the `publish_mcp_abilities.yml` release workflow.
- No plugin code, features, or user-facing behavior are changed.

## Technical description

### Documentation

`publish_mcp_abilities.yml` was aligned with the workflows migrated in #1229. The obsolete manual setup steps — `Install SVN`, `Start mysql service`, composer cache directory steps, `Install Strauss`, `Install dependencies`, `Install tests`, and the `Mysql8 auth plugin workaround` — were removed and replaced with the shared composite actions:

- `wp-media/workflows/.github/actions/setup-php-composer@main` (with `composer-options: ''` so the Strauss post-install script runs)
- `wp-media/workflows/.github/actions/setup-wp-tests@main` (`wp-version: latest`)

A `mysql:8.0` service container was added, matching `test.yml`, since `setup-wp-tests` expects the DB to be available (the old manual mysql start / auth workaround are no longer needed).

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

This is a CI-workflow YAML change with no PHP code:

- **Acceptance Criteria / triggering changed lines:** the workflow only runs on a tag push, which is deliberately not performed during development; validation was done statically against the equivalent, CI-passing test workflows.
- **Built-in tests:** not applicable to a GitHub Actions workflow definition.
- **Entry points / output messages:** no runtime code, inputs, or user-facing messages are involved.