### PR TITLE
Fix #1255: guard against an empty next-gen destination path

### DIFF
--- a/Tests/Unit/classes/Optimization/File/OptimizeTest.php
+++ b/Tests/Unit/classes/Optimization/File/OptimizeTest.php
@@ -161,4 +161,62 @@ class OptimizeTest extends TestCase {
 			}
 		}
 	}
+
+	/**
+	 * A next-gen request on a source that is already in a next-gen format must return a
+	 * WP_Error instead of handing an empty destination path to the filesystem.
+	 *
+	 * The get_path_to_nextgen() method returns false in that case. Before the guard, that false was
+	 * passed straight to Imagify_Filesystem::move(), which throws an uncaught ValueError on
+	 * PHP 8 ("Path must not be empty"), killing the background process mid-batch.
+	 */
+	public function testShouldReturnErrorWhenNextGenDestinationIsUnavailable(): void {
+		$webp_path = '/uploads/thumbnail.webp';
+
+		Functions\when( 'wp_check_filetype' )->justReturn(
+			[
+				'ext'  => 'webp',
+				'type' => 'image/webp',
+			]
+		);
+
+		$response = (object) [
+			'image'         => 'https://api.imagify.io/dl/xyz',
+			'original_size' => 1000,
+			'new_size'      => 900,
+			'percent'       => 10,
+		];
+
+		Functions\when( 'upload_imagify_image' )->justReturn( $response );
+		Functions\when( 'download_url' )->justReturn( $this->temp_file );
+
+		$filesystem         = Mockery::mock( \stdClass::class );
+		$filesystem->errors = (object) [ 'errors' => [] ];
+		$filesystem->shouldReceive( 'exists' )->with( $webp_path )->andReturn( true );
+		$filesystem->shouldReceive( 'is_file' )->with( $webp_path )->andReturn( true );
+		$filesystem->shouldReceive( 'is_writable' )->andReturn( true );
+		$filesystem->shouldReceive( 'dir_path' )->andReturn( '/uploads/' );
+
+		// The downloaded temp file must be cleaned up rather than left behind.
+		$filesystem->shouldReceive( 'delete' )->once()->with( $this->temp_file );
+
+		// The empty destination must never reach the filesystem.
+		$filesystem->shouldNotReceive( 'move' );
+
+		$file = $this->make_file( $filesystem );
+		$this->setPropertyValue( 'path', $file, $webp_path );
+
+		$result = $file->optimize(
+			[
+				'backup'  => false,
+				'convert' => 'avif',
+			]
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'no_nextgen_destination', $result->get_error_code() );
+
+		// The source path must be left untouched.
+		$this->assertSame( $webp_path, $file->get_path() );
+	}
 }

--- a/classes/Optimization/File.php
+++ b/classes/Optimization/File.php
@@ -659,9 +659,25 @@ class File {
 
 		if ( $is_nextgen_request ) {
 			$destination_path = $this->get_path_to_nextgen( $args['convert'] );
-			$this->path       = $destination_path;
-			$this->file_type  = null;
-			$this->editor     = null;
+
+			/*
+			 * get_path_to_nextgen() returns false when the file is not an image, or when it
+			 * already is in a next-gen format. Passing that along would hand an empty path to
+			 * the filesystem, which throws an uncaught ValueError on PHP 8 and kills the
+			 * background process mid-batch, leaving its lock behind and stalling the queue.
+			 */
+			if ( empty( $destination_path ) ) {
+				$this->filesystem->delete( $temp_file );
+
+				return new \WP_Error(
+					'no_nextgen_destination',
+					__( 'Could not determine the destination path for the next-gen file.', 'imagify' )
+				);
+			}
+
+			$this->path      = $destination_path;
+			$this->file_type = null;
+			$this->editor    = null;
 		} else {
 			$destination_path = $this->path;
 		}


### PR DESCRIPTION
# Description

Fixes #1255

Optimization no longer dies with a PHP fatal when a next-gen conversion is requested for a file that is already WebP or AVIF.

`File::get_path_to_nextgen()` returns `false` in that case, and that value was passed unchecked to `Imagify_Filesystem::move()`. On PHP 8 an empty path in `copy()` raises a `ValueError`, which is fatal. The fatal happened inside the background process handler running over `admin-ajax.php`, so `unlock_process()` never ran, the process lock was left behind, and the whole queue stalled. Users saw optimization spinning forever in bulk and in the media library, with no error surfaced anywhere in the UI.

The empty destination is now caught and returned as a `WP_Error`. The item fails cleanly, the background process moves on to the next one, and the lock is released as usual.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Automated. Added `testShouldReturnErrorWhenNextGenDestinationIsUnavailable` to `Tests/Unit/classes/Optimization/File/OptimizeTest.php`, covering a next-gen request on an already WebP source. It asserts that a `WP_Error` with the code `no_nextgen_destination` is returned, that `move()` is never reached, that the downloaded temp file is deleted, and that the source path is left untouched.

Verified the test actually catches the regression: with the guard removed it fails, reporting `move_error` instead of `no_nextgen_destination`, which confirms the empty path reached the filesystem.

Full unit suite passes: 528 tests, 1528 assertions. The 2 risky results are pre-existing and unrelated (`version_compare()` deprecation in `class-imagify-settings.php`).

PHPCS is clean on both changed files.

### How to test

1. Enable WebP or AVIF conversion in the Imagify settings.
2. Add a media file whose filename ends in `.webp` to the library.
3. Run optimization on it.
4. Before this change: a `ValueError` fatal is written to `debug.log`, the `imagify_optimize_media_process_lock` site transient stays set, and the queue stops advancing. After this change: the item is marked in error, no fatal is logged, and the rest of the queue keeps processing.

Note that `is_webp()` and `is_avif()` match on the path only, so the filename extension is what matters for reproduction.

### Affected Features & Quality Assurance Scope

Media optimization and next-gen conversion, both single and bulk, in the media library and on the bulk optimization page. Worth checking a mixed library containing regular images alongside `.webp` and `.avif` files, to confirm the run completes end to end rather than stopping at the first already next-gen file.

## Technical description

### Documentation

In `File::optimize()`, the next-gen branch now validates the destination before using it:

```php
if ( $is_nextgen_request ) {
	$destination_path = $this->get_path_to_nextgen( $args['convert'] );

	if ( empty( $destination_path ) ) {
		$this->filesystem->delete( $temp_file );

		return new \WP_Error(
			'no_nextgen_destination',
			__( 'Could not determine the destination path for the next-gen file.', 'imagify' )
		);
	}

	$this->path      = $destination_path;
	...
}
```

Two details worth noting. The guard returns before `$this->path` is reassigned, so the source path is never clobbered with `false`, which also keeps the error path readable for the caller. And the temp file downloaded from the API is deleted on the way out, so a failing item does not leave an orphan behind in the temp directory on every attempt.

### New dependencies

None.

### Risks

Low. The change only adds an early return on a path that previously always ended in a fatal, so there is no behaviour to preserve on that branch. Every other branch of `optimize()` is untouched.

Items that used to kill the request now surface as a regular optimization error, which means already next-gen media will be reported in error on the bulk page rather than silently freezing the queue. That is the intended outcome here, though deciding whether these files should be skipped earlier in the process, before the API call, is a separate discussion worth having.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable, all items are covered.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
