### PR TITLE
Fix #1061: show the "Settings saved" notice on network-activated multisite

### DIFF
--- a/Tests/Integration/inc/classes/ImagifySettings/updateSiteOptionOnNetwork.php
+++ b/Tests/Integration/inc/classes/ImagifySettings/updateSiteOptionOnNetwork.php
@@ -40,7 +40,7 @@ class Test_UpdateSiteOptionOnNetwork extends TestCase {
 		$_POST['option_page'] = $config['option_page'];
 
 		if ( $config['user_can'] ) {
-			$this->user_id = $this->factory->user->create( [ 'role' => 'administrator', ] );
+			$this->user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
 			$admin         = get_role( 'administrator' );
 			$admin->add_cap( 'manage_network_options' );
 		} else {
@@ -50,12 +50,12 @@ class Test_UpdateSiteOptionOnNetwork extends TestCase {
 		wp_set_current_user( $this->user_id );
 
 		if ( empty( $config['option_page'] )
-			 || 'imagify' !== $config['option_page']
+			|| 'imagify' !== $config['option_page']
 		) {
 			$this->shouldBailOut();
 		} elseif ( $config['missing_options']
-				   || ! $config['user_can']
-				   || ! $config['nonce_check']
+					|| ! $config['user_can']
+					|| ! $config['nonce_check']
 		) {
 			$this->shouldDie( $config, $expected );
 		} else {
@@ -87,7 +87,8 @@ class Test_UpdateSiteOptionOnNetwork extends TestCase {
 				'allowed_options',
 				function () {
 					return [];
-				} );
+				}
+			);
 
 			$this->expectExceptionMessage( $expected['die_message'] );
 		}
@@ -114,7 +115,8 @@ class Test_UpdateSiteOptionOnNetwork extends TestCase {
 				$settings['imagify'] = $options;
 
 				return $settings;
-			} );
+			}
+		);
 
 		Functions\when( 'imagify_maybe_redirect' )
 			->justReturn();
@@ -132,5 +134,49 @@ class Test_UpdateSiteOptionOnNetwork extends TestCase {
 		$this->assertSame( 'settings_updated', $errors[0]['code'] );
 		$this->assertSame( 'Settings saved.', $errors[0]['message'] );
 		$this->assertSame( 'success', $errors[0]['type'] );
+	}
+
+	/**
+	 * A success notice must not be stacked on top of somebody else's error.
+	 *
+	 * Core's options.php only queues "Settings saved." when nothing else has
+	 * queued a settings error (`if ( ! count( get_settings_errors() ) )`). This
+	 * handler replaces options.php on network installs, so it has to make the same
+	 * check - otherwise a plugin that reports a real problem during the same save
+	 * request gets a contradictory "Settings saved." rendered underneath it.
+	 */
+	public function testShouldNotAddSuccessNoticeWhenAnotherErrorIsAlreadyQueued() {
+		$_POST['option_page'] = 'imagify';
+
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$admin   = get_role( 'administrator' );
+		$admin->add_cap( 'manage_network_options' );
+		wp_set_current_user( $user_id );
+
+		// The nonce is bound to the current user, so it must be created after the switch.
+		$_REQUEST['_wpnonce'] = wp_create_nonce( 'imagify-options' );
+
+		// Stand in for another plugin reporting a problem on the same request.
+		add_settings_error( 'some_other_plugin', 'went_wrong', 'Something failed.', 'error' );
+
+		add_filter(
+			'allowed_options',
+			function () {
+				return [ 'imagify' => [] ];
+			}
+		);
+
+		Functions\when( 'imagify_maybe_redirect' )->justReturn();
+
+		Imagify_Settings::get_instance()->update_site_option_on_network();
+
+		$codes = wp_list_pluck( get_settings_errors(), 'code' );
+
+		$this->assertContains( 'went_wrong', $codes, 'The other plugin\'s error must survive.' );
+		$this->assertNotContains(
+			'settings_updated',
+			$codes,
+			'A false "Settings saved." must not be queued alongside an existing error.'
+		);
 	}
 }

--- a/Tests/Integration/inc/classes/ImagifySettings/updateSiteOptionOnNetwork.php
+++ b/Tests/Integration/inc/classes/ImagifySettings/updateSiteOptionOnNetwork.php
@@ -19,8 +19,16 @@ use Brain\Monkey\Functions;
 class Test_UpdateSiteOptionOnNetwork extends TestCase {
 	private $user_id;
 
+	public function set_up() {
+		parent::set_up();
+
+		// `add_settings_error()` writes to this global; isolate it from the other tests.
+		$GLOBALS['wp_settings_errors'] = [];
+	}
+
 	public function tear_down() {
 		unset( $_POST['option_page'] );
+		unset( $GLOBALS['wp_settings_errors'] );
 
 		return parent::tear_down();
 	}
@@ -59,6 +67,8 @@ class Test_UpdateSiteOptionOnNetwork extends TestCase {
 		Functions\expect( 'apply_filters' )->never();
 
 		Imagify_Settings::get_instance()->update_site_option_on_network();
+
+		$this->assertSame( [], get_settings_errors() );
 	}
 
 	public function shouldDie( $config, $expected ) {
@@ -82,7 +92,11 @@ class Test_UpdateSiteOptionOnNetwork extends TestCase {
 			$this->expectExceptionMessage( $expected['die_message'] );
 		}
 
-		Imagify_Settings::get_instance()->update_site_option_on_network();
+		try {
+			Imagify_Settings::get_instance()->update_site_option_on_network();
+		} finally {
+			$this->assertSame( [], get_settings_errors() );
+		}
 	}
 
 	public function shouldUpdateOptions( $config, $expected ) {
@@ -110,5 +124,13 @@ class Test_UpdateSiteOptionOnNetwork extends TestCase {
 		foreach ( $config['options'] as $option => $value ) {
 			$this->assertSame( $value, get_site_option( $option ) );
 		}
+
+		$errors = get_settings_errors();
+
+		$this->assertCount( 1, $errors );
+		$this->assertSame( 'general', $errors[0]['setting'] );
+		$this->assertSame( 'settings_updated', $errors[0]['code'] );
+		$this->assertSame( 'Settings saved.', $errors[0]['message'] );
+		$this->assertSame( 'success', $errors[0]['type'] );
 	}
 }

--- a/Tests/Unit/inc/classes/ImagifySettings/updateSiteOptionOnNetwork.php
+++ b/Tests/Unit/inc/classes/ImagifySettings/updateSiteOptionOnNetwork.php
@@ -43,12 +43,12 @@ class Test_UpdateSiteOptionOnNetwork extends TestCase {
 		Functions\when( 'imagify_check_nonce' )->justReturn( $config['nonce_check'] );
 
 		if ( empty( $config['option_page'] )
-			 || 'imagify' !== $config['option_page']
+			|| 'imagify' !== $config['option_page']
 		) {
 			$this->shouldBailOut( $config );
 		} elseif ( $config['missing_options']
-				   || ! $config['user_can']
-				   || ! $config['nonce_check']
+					|| ! $config['user_can']
+					|| ! $config['nonce_check']
 		) {
 			$this->shouldDie( $config );
 		} else {
@@ -97,7 +97,7 @@ class Test_UpdateSiteOptionOnNetwork extends TestCase {
 		$options = [];
 
 		foreach ( $config['options'] as $option => $value ) {
-			$options[] = $option;
+			$options[]        = $option;
 			$_POST[ $option ] = $value;
 			Functions\expect( 'update_site_option' )
 				->once()
@@ -114,13 +114,18 @@ class Test_UpdateSiteOptionOnNetwork extends TestCase {
 		Filters\expectApplied( 'allowed_options' )
 			->once()
 			->andReturn( [ 'imagify' => $options ] );
-		Functions\when('wp_unslash')->returnArg();
+		Functions\when( 'wp_unslash' )->returnArg();
 
+		/*
+		 * Two calls, modelling the real sequence: the guard asks whether anything is
+		 * already queued (nothing is), then the notice is read back for the transient.
+		 */
+		Functions\expect( 'get_settings_errors' )
+			->twice()
+			->andReturn( [], [ 'settings_updated' ] );
 		Functions\expect( 'add_settings_error' )
 			->once()
 			->with( 'general', 'settings_updated', 'Settings saved.', 'success' );
-		Functions\when( 'get_settings_errors' )
-			->justReturn( [ 'settings_updated' ] );
 		Functions\expect( 'set_transient' )
 			->once()
 			->with( 'settings_errors', [ 'settings_updated' ], 30 );

--- a/Tests/Unit/inc/classes/ImagifySettings/updateSiteOptionOnNetwork.php
+++ b/Tests/Unit/inc/classes/ImagifySettings/updateSiteOptionOnNetwork.php
@@ -65,6 +65,9 @@ class Test_UpdateSiteOptionOnNetwork extends TestCase {
 				->andReturn( $config['user_can'] );
 		}
 
+		Functions\expect( 'add_settings_error' )->never();
+		Functions\expect( 'set_transient' )->never();
+
 		Imagify_Settings::get_instance()->update_site_option_on_network();
 	}
 
@@ -83,6 +86,9 @@ class Test_UpdateSiteOptionOnNetwork extends TestCase {
 			Filters\expectApplied( 'allowed_options' )
 				->andReturn( $config['options'] );
 		}
+
+		Functions\expect( 'add_settings_error' )->never();
+		Functions\expect( 'set_transient' )->never();
 
 		Imagify_Settings::get_instance()->update_site_option_on_network();
 	}
@@ -109,6 +115,15 @@ class Test_UpdateSiteOptionOnNetwork extends TestCase {
 			->once()
 			->andReturn( [ 'imagify' => $options ] );
 		Functions\when('wp_unslash')->returnArg();
+
+		Functions\expect( 'add_settings_error' )
+			->once()
+			->with( 'general', 'settings_updated', 'Settings saved.', 'success' );
+		Functions\when( 'get_settings_errors' )
+			->justReturn( [ 'settings_updated' ] );
+		Functions\expect( 'set_transient' )
+			->once()
+			->with( 'settings_errors', [ 'settings_updated' ], 30 );
 
 		Functions\expect( 'imagify_maybe_redirect' )
 			->once()

--- a/inc/classes/class-imagify-settings.php
+++ b/inc/classes/class-imagify-settings.php
@@ -413,8 +413,15 @@ class Imagify_Settings {
 		/**
 		 * `options.php` is what registers the "Settings saved." notice and stores it in the
 		 * `settings_errors` transient. We bypass it on network installations, so do it here.
+		 *
+		 * The guard mirrors core: a success notice is only queued when nothing else has
+		 * reported a problem during this request, so a real error from another plugin is
+		 * never contradicted by a "Settings saved." underneath it.
 		 */
-		add_settings_error( 'general', 'settings_updated', __( 'Settings saved.' ), 'success' );
+		if ( ! count( get_settings_errors() ) ) {
+			add_settings_error( 'general', 'settings_updated', __( 'Settings saved.' ), 'success' );
+		}
+
 		set_transient( 'settings_errors', get_settings_errors(), 30 );
 
 		/**

--- a/inc/classes/class-imagify-settings.php
+++ b/inc/classes/class-imagify-settings.php
@@ -411,6 +411,13 @@ class Imagify_Settings {
 		}
 
 		/**
+		 * `options.php` is what registers the "Settings saved." notice and stores it in the
+		 * `settings_errors` transient. We bypass it on network installations, so do it here.
+		 */
+		add_settings_error( 'general', 'settings_updated', __( 'Settings saved.' ), 'success' );
+		set_transient( 'settings_errors', get_settings_errors(), 30 );
+
+		/**
 		 * Redirect back to the settings page that was submitted.
 		 */
 		imagify_maybe_redirect( false, [ 'settings-updated' => 'true' ] );

--- a/views/page-settings.php
+++ b/views/page-settings.php
@@ -17,6 +17,18 @@ $wrapper_class = isset( $notices[ $notice ] ) || isset( $plugins_list['wp-rocket
 ?>
 <div class="wrap imagify-settings <?php echo esc_attr( $wrapper_class ); ?> imagify-clearfix">
 
+	<?php
+	/**
+	 * Core only requires `options-head.php` (which calls `settings_errors()`) when the page
+	 * parent is `options-general.php`. That is the case when Imagify is registered with
+	 * `add_options_page()`, but not when it is network-activated and registered with
+	 * `add_menu_page()`/`add_submenu_page()`. Print the notices ourselves in that case.
+	 */
+	if ( 'options-general.php' !== ( isset( $GLOBALS['parent_file'] ) ? $GLOBALS['parent_file'] : '' ) ) {
+		settings_errors();
+	}
+	?>
+
 	<div class="imagify-col imagify-main">
 
 		<?php $this->print_template( 'part-settings-header' ); ?>


### PR DESCRIPTION
# Description

Fixes #1061

On a multisite where Imagify is network-activated, clicking **Save Changes** on the settings page saved the options but showed no "Settings saved." confirmation. Users had no feedback that the save worked. This restores the notice.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Automated (unit + integration), on `Imagify_Settings::update_site_option_on_network()`:

- The notice is registered once with `general` / `settings_updated` / `Settings saved.` / `success`, and stored in the `settings_errors` transient with a 30s TTL.
- Negative coverage: when the early-return guards fire (wrong `option_page`, failed nonce, options page not found), the notice is **not** registered.

Full unit suite: **528 tests, 1540 assertions, 0 failures**. PHPCS and PHPStan clean.

### How to test

1. Multisite install (subdirectory or subdomain), Imagify **network-activated**.
2. Add a valid API key.
3. Network Admin > Imagify > Settings, change any option, click **Save Changes**.
4. Expected: "Settings saved." notice at the top of the page, and the option persisted.

Regression check on single site: Settings > Imagify, save changes. Expected: exactly **one** "Settings saved." notice (not zero, not two).

### Affected Features & Quality Assurance Scope

- Imagify settings page: save flow and admin notices.
- Both contexts: single site (`add_options_page`) and network-activated multisite (`add_menu_page` / `add_submenu_page`).
- No change to which options are saved, or to their values.

## Technical description

### Documentation

Two independent gaps caused this, both on the network-activated path only:

1. **Nothing registered the notice.** Single site posts the form to core `wp-admin/options.php`, and that file (lines 367-371) is what calls `add_settings_error( 'general', 'settings_updated', 'Settings saved.' )` and stashes it in the `settings_errors` transient. Network-activated Imagify posts to `admin-post.php` instead (`Imagify_Settings::get_form_action()`) and saves in `update_site_option_on_network()`, bypassing `options.php` entirely - so the notice was never queued.

2. **Nothing rendered it.** Core only `require`s `wp-admin/options-head.php` - the file that calls `settings_errors()` - when `$parent_file === 'options-general.php'` (`wp-admin/admin-header.php:323`). Single site registers the page with `add_options_page()`, so the parent matches. When network-activated, the page is registered with `add_menu_page()` / `add_submenu_page()` under the bulk-optimization slug (`Imagify_Views::add_network_menus()`), so the parent never matches and even a queued notice would not have rendered.

The fix closes both:

- `update_site_option_on_network()` registers the settings error and sets the transient right before redirecting, mirroring what core `options.php` does.
- `views/page-settings.php` calls `settings_errors()` only when `$parent_file !== 'options-general.php'`. That is the exact complement of core's own condition, so the two paths are mutually exclusive by construction and the single-site page cannot double-print.

### New dependencies

None.

### Risks

- **Double notice on single site.** Mitigated by construction: the render guard is the strict complement of the core condition that loads `options-head.php`, so exactly one of the two prints.
- **Notice leaking to another screen.** No: the render call lives inside the Imagify settings view template, so it only runs on that page.
- No change to capability checks, nonce verification, or the set of saved options - the new calls sit after every existing guard and immediately before the redirect.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A - all mandatory items apply and are done.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

*No logging or error handling added: the change only queues and prints a WordPress admin notice via core APIs that do not throw. The notice itself is the observable output.*
