### PR TITLE
Fix #1073: resolve Strauss-prefixed classes on a Composer dependency install

### DIFF
--- a/Tests/Fixtures/inc/functions/dependenciesFallback.php
+++ b/Tests/Fixtures/inc/functions/dependenciesFallback.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Stand-ins for unprefixed Composer dependencies.
+ *
+ * These stand in for unprefixed Composer dependencies: the fallback autoloader
+ * should alias `Imagify\Dependencies\<name>` onto them.
+ *
+ * @package Imagify\Tests
+ */
+
+if ( ! interface_exists( 'Imagify_Test_Fallback_Contract' ) ) {
+	interface Imagify_Test_Fallback_Contract {}
+}
+
+if ( ! class_exists( 'Imagify_Test_Fallback_Dep' ) ) {
+	class Imagify_Test_Fallback_Dep {
+	/**
+	 * Marker so the test can prove the alias points at this implementation.
+	 *
+	 * @return string
+	 */
+		public function value() {
+			return 'fallback-ok';
+		}
+	}
+}
+
+/**
+ * Stands in for a third-party class that a greedy `Imagify_` strip could wrongly
+ * bind one of Imagify's own global class names onto.
+ */
+if ( ! class_exists( 'Test_Foreign_Victim' ) ) {
+	class Test_Foreign_Victim {}
+}

--- a/Tests/Unit/inc/functions/imagifyRegisterDependenciesFallbackAutoloader.php
+++ b/Tests/Unit/inc/functions/imagifyRegisterDependenciesFallbackAutoloader.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Imagify\Tests\Unit\Functions;
+
+use Imagify\Tests\Unit\TestCase;
+
+/**
+ * @group Functions
+ * @group Composer
+ */
+class Test_ImagifyRegisterDependenciesFallbackAutoloader extends TestCase {
+	/**
+	 * Load the fallback functions, which are required at runtime rather than autoloaded.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		if ( ! function_exists( 'imagify_register_dependencies_fallback_autoloader' ) ) {
+			require_once IMAGIFY_PLUGIN_ROOT . 'inc/functions/dependencies.php';
+		}
+
+		// Stand-ins for the unprefixed Composer dependencies.
+		require_once IMAGIFY_PLUGIN_ROOT . 'Tests/Fixtures/inc/functions/dependenciesFallback.php';
+
+		static $registered = false;
+
+		if ( ! $registered ) {
+			imagify_register_dependencies_fallback_autoloader();
+			$registered = true;
+		}
+	}
+
+	/**
+	 * A prefixed name resolves to the existing unprefixed class.
+	 *
+	 * This is what actually breaks on a Composer dependency install: the code says
+	 * `Imagify\Dependencies\Foo` while only `Foo` exists on disk.
+	 */
+	public function testShouldAliasAPrefixedClassToTheExistingOriginal() {
+		$this->assertTrue(
+			class_exists( 'Imagify\Dependencies\Imagify_Test_Fallback_Dep' ),
+			'The prefixed name should resolve to the unprefixed class.'
+		);
+
+		$this->assertSame(
+			'fallback-ok',
+			( new \Imagify\Dependencies\Imagify_Test_Fallback_Dep() )->value(),
+			'The alias should point at the real implementation.'
+		);
+	}
+
+	/**
+	 * Interfaces are aliased too - AbstractServiceProvider's contract is one.
+	 */
+	public function testShouldAliasAPrefixedInterface() {
+		$this->assertTrue( interface_exists( 'Imagify\Dependencies\Imagify_Test_Fallback_Contract' ) );
+	}
+
+	/**
+	 * A prefixed name with no original must stay unresolved rather than blow up.
+	 */
+	public function testShouldNotResolveAPrefixedClassWithNoOriginal() {
+		$this->assertFalse( class_exists( 'Imagify\Dependencies\Totally\Absent\Klass' ) );
+	}
+
+	/**
+	 * Imagify's own global classes must not be aliased to a same-named third-party
+	 * class. `Imagify_Test_Foreign_Victim` exists unprefixed here, so a greedy
+	 * `Imagify_` strip would wrongly bind to it.
+	 */
+	public function testShouldNotAliasImagifyOwnGlobalClasses() {
+		$this->assertFalse(
+			class_exists( 'Imagify_Test_Foreign_Victim' ),
+			'A non-allowlisted Imagify_ class must not be aliased.'
+		);
+	}
+}

--- a/Tests/Unit/inc/functions/imagifyUnprefixDependencyClass.php
+++ b/Tests/Unit/inc/functions/imagifyUnprefixDependencyClass.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Imagify\Tests\Unit\Functions;
+
+use Imagify\Tests\Unit\TestCase;
+
+/**
+ * @group Functions
+ * @group Composer
+ */
+class Test_ImagifyUnprefixDependencyClass extends TestCase {
+	/**
+	 * Load the fallback functions, which are required at runtime rather than autoloaded.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		if ( ! function_exists( 'imagify_unprefix_dependency_class' ) ) {
+			require_once IMAGIFY_PLUGIN_ROOT . 'inc/functions/dependencies.php';
+		}
+	}
+
+	/**
+	 * Anything under the Imagify\Dependencies\ namespace maps generically, so
+	 * dependencies added to the Strauss config later keep working untouched.
+	 */
+	public function testShouldMapAnyPrefixedNamespaceToItsOriginal() {
+		$cases = [
+			'Imagify\Dependencies\League\Container\Container' => 'League\Container\Container',
+			'Imagify\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider' => 'League\Container\ServiceProvider\AbstractServiceProvider',
+			'Imagify\Dependencies\WPMedia\PluginFamily\Controller\PluginFamily' => 'WPMedia\PluginFamily\Controller\PluginFamily',
+			'Imagify\Dependencies\WPMedia\Mixpanel\Optin' => 'WPMedia\Mixpanel\Optin',
+			'Imagify\Dependencies\Something\Added\Later'  => 'Something\Added\Later',
+		];
+
+		foreach ( $cases as $prefixed => $expected ) {
+			$this->assertSame( $expected, imagify_unprefix_dependency_class( $prefixed ) );
+		}
+	}
+
+	/**
+	 * Global classes come from an explicit allowlist.
+	 */
+	public function testShouldMapAllowlistedGlobalClasses() {
+		$this->assertSame( 'WP_Background_Process', imagify_unprefix_dependency_class( 'Imagify_WP_Background_Process' ) );
+		$this->assertSame( 'WP_Async_Request', imagify_unprefix_dependency_class( 'Imagify_WP_Async_Request' ) );
+	}
+
+	/**
+	 * The important negative case.
+	 *
+	 * Imagify uses the `Imagify_` prefix for its own global classes too. Stripping
+	 * it blindly would let an unrelated third-party class be aliased in their
+	 * place - `Imagify_WP_Retina_2x` must never resolve to some other plugin's
+	 * `WP_Retina_2x`.
+	 */
+	public function testShouldNotTouchImagifyOwnGlobalClasses() {
+		$own = [
+			'Imagify_Settings',
+			'Imagify_Views',
+			'Imagify_Options',
+			'Imagify_WP_Retina_2x',
+			'Imagify_WP_Time_Capsule',
+			'Imagify_Abstract_Background_Process',
+		];
+
+		foreach ( $own as $class_name ) {
+			$this->assertSame( '', imagify_unprefix_dependency_class( $class_name ), $class_name . ' must not be unprefixed.' );
+		}
+	}
+
+	/**
+	 * Unrelated names are ignored.
+	 */
+	public function testShouldIgnoreUnrelatedClassNames() {
+		foreach ( [ 'League\Container\Container', 'WP_Background_Process', 'stdClass', '' ] as $class_name ) {
+			$this->assertSame( '', imagify_unprefix_dependency_class( $class_name ) );
+		}
+	}
+}

--- a/inc/functions/dependencies.php
+++ b/inc/functions/dependencies.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Fallback autoloading for Strauss-prefixed dependencies.
+ *
+ * Imagify's dependencies are namespace-prefixed into `Imagify\Dependencies\` (and
+ * class-prefixed with `Imagify_` for global classes) by Strauss, which runs from
+ * this package's own Composer install scripts. When Imagify is installed as a
+ * Composer *dependency* of another project - Bedrock, for instance - Composer
+ * does not run a dependency's scripts, so Strauss never runs and the prefixed
+ * symbols are never generated. The unprefixed originals are present, because they
+ * are declared in `require` and land in the root project's vendor directory.
+ *
+ * Rather than fail with "Class Imagify\Dependencies\League\Container\Container
+ * not found", alias each prefixed symbol to its unprefixed original on demand.
+ *
+ * @package Imagify
+ * @since   2.3.4
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Global classes Strauss prefixes with `Imagify_`, mapped to their originals.
+ *
+ * This must stay an explicit allowlist. The `Imagify_` prefix is also used by
+ * Imagify's own global classes (`Imagify_Settings`, `Imagify_WP_Retina_*`, ...),
+ * and blindly stripping it would let an unrelated third-party class be aliased in
+ * their place.
+ *
+ * @since 2.3.4
+ *
+ * @return array<string, string>
+ */
+function imagify_get_prefixed_global_classes() {
+	return [
+		'Imagify_WP_Async_Request'      => 'WP_Async_Request',
+		'Imagify_WP_Background_Process' => 'WP_Background_Process',
+	];
+}
+
+/**
+ * Resolve a prefixed class name back to the original it was generated from.
+ *
+ * @since 2.3.4
+ *
+ * @param  string $class_name The class name being autoloaded.
+ * @return string             The unprefixed original, or '' when the name is not
+ *                            one Strauss would have produced.
+ */
+function imagify_unprefix_dependency_class( $class_name ) {
+	$namespace_prefix = 'Imagify\\Dependencies\\';
+
+	/**
+	 * The `Imagify\Dependencies\` namespace is exclusively Strauss output, so
+	 * anything under it can be mapped generically. That keeps this working for
+	 * dependencies added later without touching this file.
+	 */
+	if ( 0 === strpos( $class_name, $namespace_prefix ) ) {
+		return substr( $class_name, strlen( $namespace_prefix ) );
+	}
+
+	$global_classes = imagify_get_prefixed_global_classes();
+
+	return isset( $global_classes[ $class_name ] ) ? $global_classes[ $class_name ] : '';
+}
+
+/**
+ * Register the fallback autoloader.
+ *
+ * Registered last, so Composer's own autoloader always wins. On a normal install
+ * the prefixed classes resolve there and this closure is never reached.
+ *
+ * @since 2.3.4
+ *
+ * @return void
+ */
+function imagify_register_dependencies_fallback_autoloader() {
+	spl_autoload_register(
+		function ( $class_name ) {
+			$original = imagify_unprefix_dependency_class( $class_name );
+
+			if ( '' === $original || $original === $class_name ) {
+				return;
+			}
+
+			/**
+			 * Only alias when the original genuinely exists. Passing true here lets
+			 * other registered autoloaders resolve it; this autoloader itself bails
+			 * out on unprefixed names, so there is no recursion.
+			 */
+			if (
+				! class_exists( $original, true )
+				&& ! interface_exists( $original, true )
+				&& ! trait_exists( $original, true )
+			) {
+				return;
+			}
+
+			class_alias( $original, $class_name );
+		}
+	);
+}

--- a/inc/main.php
+++ b/inc/main.php
@@ -8,6 +8,16 @@ if ( file_exists( IMAGIFY_PATH . 'vendor/autoload.php' ) ) {
 	require_once IMAGIFY_PATH . 'vendor/autoload.php';
 }
 
+/**
+ * When Imagify is installed as a Composer dependency, Strauss never runs and the
+ * prefixed dependency classes do not exist. Alias them to their unprefixed
+ * originals on demand. Registered after Composer's autoloader, so a normal
+ * install never reaches it.
+ */
+require_once IMAGIFY_PATH . 'inc/functions/dependencies.php';
+
+imagify_register_dependencies_fallback_autoloader();
+
 require_once IMAGIFY_PATH . 'inc/Dependencies/ActionScheduler/action-scheduler.php';
 
 /**

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -23,6 +23,7 @@ parameters:
 		- inc/functions/api.php
 		- inc/functions/attachments.php
 		- inc/functions/common.php
+		- inc/functions/dependencies.php
 		- inc/functions/formatting.php
 		- inc/3rd-party/nextgen-gallery/inc/functions/common.php
 		- inc/functions/options.php


### PR DESCRIPTION
# Description

Fixes #1073

Installing Imagify with Composer (Bedrock and similar) and activating it killed the site with `Class "Imagify\Dependencies\League\Container\Container" not found`. It now activates and runs.

Supersedes #1074 by @faisalahammad, who identified the cause correctly. Opened separately because that PR's branch is on a fork with `maintainerCanModify: false`, and because the fix needed to cover more than the three `League\Container` classes - see the last section.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

**Reproduced the real scenario**, since CI cannot: a throwaway root project with a path repository pointing at the plugin source *with no `vendor/`*, so Strauss cannot run - exactly a dependency-mode install.

| Symbol the bootstrap needs | Before | After |
|---|---|---|
| `Imagify\Dependencies\League\Container\Container` | MISSING | OK |
| `Imagify\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider` | MISSING | OK |
| `Imagify\Dependencies\WPMedia\PluginFamily\Controller\PluginFamily` | MISSING | OK |
| `Imagify\Dependencies\WPMedia\Mixpanel\Optin` | MISSING | OK |
| `Imagify\Dependencies\WPMedia\Mixpanel\TrackingPlugin` | MISSING | OK |
| `Imagify_WP_Background_Process` | MISSING | OK |

**6/6 missing before, 0/6 after.** The same probe asserts the over-reach guard: `Imagify_WP_Retina_2x`, `Imagify_WP_Time_Capsule` and `Imagify_Settings` are confirmed *not* aliased.

Automated - 4 unit tests on the mapping function, including the negative case that matters: Imagify's own `Imagify_`-prefixed global classes must not be unprefixed.

Suites: **532 unit / 1545 assertions**, **148 integration / 391 assertions**, 0 failures. PHPCS and PHPStan clean.

### How to test

```bash
mkdir -p /tmp/dep/root && cd /tmp/dep/root
cat > composer.json <<'JSON'
{
  "repositories": [ { "type": "path", "url": "../pkg", "options": { "symlink": false } } ],
  "require": { "wp-media/imagify-plugin": "*" },
  "config": { "allow-plugins": true },
  "minimum-stability": "dev", "prefer-stable": true
}
JSON
# ../pkg = a copy of this branch WITHOUT vendor/, so Strauss cannot run.
composer install
```

Then load `vendor/autoload.php`, require the plugin's `inc/functions/dependencies.php`, call `imagify_register_dependencies_fallback_autoloader()`, and check `class_exists( 'Imagify\Dependencies\League\Container\Container' )`. It is false without the call and true with it.

Or, end to end: install into a real Bedrock site with `composer require` and activate the plugin.

Regression check on a normal install: `composer install` in the plugin directory (Strauss runs), then activate. Everything must behave exactly as before - the fallback autoloader is registered last and only fires for symbols nothing else resolved.

### Affected Features & Quality Assurance Scope

- Plugin bootstrap (`inc/main.php`) - the fallback is registered right after Composer's autoloader.
- Composer-based installs only. A normal install (zip from WordPress.org, or `composer install` in the plugin directory) never reaches the new code path.
- No behaviour change to any feature, setting, or endpoint.

## Technical description

### Documentation

`composer.json`'s `extra.strauss` prefixes four packages into `Imagify\Dependencies\`, with `classmap_prefix: "Imagify_"` for global classes. That runs from `post-install-cmd` / `post-update-cmd` - **this** package's scripts. Composer never runs a dependency's scripts, so in dependency mode the prefixing simply does not happen, while `inc/main.php` and `classes/Plugin.php` still `use` the prefixed names.

The originals *are* available, since all four packages are in `require` and install into the root project's vendor directory. So the fix maps prefixed to unprefixed lazily:

```php
spl_autoload_register( function ( $class_name ) {
    $original = imagify_unprefix_dependency_class( $class_name );
    // ... alias only when the original really exists
} );
```

The two mapping rules are deliberately asymmetric:

- **Namespaces: generic.** `Imagify\Dependencies\` is exclusively Strauss output, so stripping the prefix is always correct - and a package added to the Strauss config later needs no change here.
- **Global classes: explicit allowlist** (`Imagify_WP_Async_Request`, `Imagify_WP_Background_Process`). This is the important asymmetry. Imagify uses the `Imagify_` prefix for its own global classes as well, and blindly stripping it would make `Imagify_WP_Retina_2x` resolve to another plugin's `WP_Retina_2x`. Silently binding to an unrelated class is worse than the fatal we are fixing, so this side stays a list.

Registered after Composer's autoloader and gated on the original existing, so normal installs are untouched.

### New dependencies

None.

### Risks

- **Version skew.** In dependency mode Imagify now binds to whatever `league/container` the root project resolved, rather than a prefixed copy it controls. That is inherent to installing this way - the alternative is the current fatal - and Composer still honours the `^4.2` constraint from `require`.
- **Aliasing the wrong class.** Mitigated by the allowlist above and covered by a unit test plus the live probe.
- **CI does not cover this scenario.** Every workflow job runs a root-package `composer install`, where Strauss runs normally, so CI green says nothing about this bug either way. That is why the reproduction above was done by hand. A dependency-mode CI job would be the proper long-term guard and is worth a follow-up.

### Why the three-class version is not enough

Strauss prefixes **four** packages, not one. `wp-media/plugin-family` and `wp-media/wp-mixpanel` are used unprefixed in `classes/Admin/ServiceProvider.php`, `classes/Admin/PluginFamilySubscriber.php`, `classes/Tracking/ServiceProvider.php`, `classes/Tracking/BaseTracking.php`, `classes/Tracking/Notices.php` and `inc/classes/class-imagify-views.php` - all wired into `Plugin::init()`. Aliasing only `League\Container` clears the fatal in the issue and then hits the identical one on `Imagify\Dependencies\WPMedia\PluginFamily\Controller\PluginFamily` moments later. The "before" table above shows all six symbols missing, which is why the generic namespace mapping is the right shape.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
