### PR TITLE
Fix #1044: update the WP Rocket banner copy on the bulk page

### DIFF
--- a/views/notice-wp-rocket.php
+++ b/views/notice-wp-rocket.php
@@ -1,8 +1,9 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin’ uh?' );
 
-$dismiss_url  = get_imagify_admin_url( 'dismiss-notice', 'wp-rocket' );
-$wprocket_url = imagify_get_wp_rocket_url();
+$dismiss_url      = get_imagify_admin_url( 'dismiss-notice', 'wp-rocket' );
+$wprocket_url     = imagify_get_wp_rocket_url();
+$discount_percent = '20%';
 ?>
 <div class="updated imagify-rkt-notice">
 	<a href="<?php echo esc_url( $dismiss_url ); ?>" class="imagify-notice-dismiss imagify-cross"><span class="dashicons dashicons-no"></span></a>
@@ -12,10 +13,11 @@ $wprocket_url = imagify_get_wp_rocket_url();
 	</p>
 	<p class="imagify-rkt-msg">
 		<?php
-		esc_html_e( 'Discover the best caching plugin to speed up your website.', 'imagify' );
+		/* translators: %s is a percentage, e.g. "20%". */
+		printf( esc_html__( 'Discover the best performance optimization plugin at %s off. Make your site even faster.', 'imagify' ), esc_html( $discount_percent ) );
 		?>
 	</p>
 	<p class="imagify-rkt-cta">
-		<a target="_blank" href="<?php echo esc_url( $wprocket_url ); ?>" class="button button-primary tgm-plugin-update-modal"><?php esc_html_e( 'Get WP Rocket now', 'imagify' ); ?></a>
+		<a target="_blank" href="<?php echo esc_url( $wprocket_url ); ?>" class="button button-primary tgm-plugin-update-modal"><?php esc_html_e( 'Get WP Rocket Now', 'imagify' ); ?></a>
 	</p>
 </div>

--- a/views/part-rocket-ad.php
+++ b/views/part-rocket-ad.php
@@ -23,7 +23,7 @@ $dismiss_url      = wp_nonce_url( admin_url( 'admin-post.php?action=imagify_dism
 <div class="imagify-col imagify-sidebar">
 	<div class="imagify-sidebar-section">
 		<p class="imagify-sidebar-title">
-			<?php esc_html_e( 'We recommend for you', 'corporate' ); ?>
+			<?php esc_html_e( 'We recommend for you', 'imagify' ); ?>
 		</p>
 
 		<img src="<?php echo esc_url( IMAGIFY_ASSETS_IMG_URL ); ?>logo-wprocket.png" srcset="<?php echo esc_url( IMAGIFY_ASSETS_IMG_URL ); ?>logo-wprocket.svg 1x, <?php echo esc_url( IMAGIFY_ASSETS_IMG_URL ); ?>logo-wprocket.svg 2x" alt="WP Rocket" width="232" height="63">


### PR DESCRIPTION
# Description

Fixes #1044

Updates the WP Rocket banner copy on the bulk optimization page to the wording @raahulbasu confirmed with Marketing:

> **Main copy:** "Discover the best performance optimization plugin at 20% off. Make your site even faster."
> **CTA:** "Get WP Rocket Now"

Copy only. No logic, no display conditions changed.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Verified in the browser on the real bulk optimization page, not by reading the diff. Read back from the rendered DOM:

```
.imagify-rkt-msg     -> "Discover the best performance optimization plugin at 20% off. Make your site even faster."
.imagify-rkt-cta a   -> "Get WP Rocket Now"
```

Rendered banner measures **1593x92**, against the **1656x95** in the issue screenshot, which confirms this is the element the ticket is about.

Screenshot of the rendered banner is attached in a comment below.

Integration suite: 149 tests / 403 assertions. PHPCS clean.

### How to test

1. A site **without** WP Rocket installed (the notice returns early if it is present).
2. The `wp-rocket` notice must not be dismissed for your user. If you have dismissed it, clear it from the `_imagify_ignore_notices` user meta.
3. Go to **Media > Bulk Optimization**.
4. The full-width WP Rocket notice at the top should read the new copy, with a **Get WP Rocket Now** button.

### Affected Features & Quality Assurance Scope

- The WP Rocket promo notice on the bulk optimization page (`views/notice-wp-rocket.php`).
- The settings-page sidebar heading text domain (`views/part-rocket-ad.php`), see below.
- **Three translatable strings change**, so translations for them need refreshing.
- No change to when the banner shows, to its dismissal behaviour, or to the WP Rocket URL.

## Technical description

### Documentation

The banner is `views/notice-wp-rocket.php`, the full-width admin notice rendered on the bulk page. `Notices.php:91` maps `'wp-rocket'` to the `'bulk-optimize'` screen.

Worth recording, since it is an easy trap: there is a **second** WP Rocket block, `views/part-rocket-ad.php`, in the settings-page sidebar. I initially changed that one. It is a different placement with different copy, and the ticket is not about it, so it is untouched here apart from the text-domain fix below.

The percentage is interpolated from a `$discount_percent` variable rather than written into the sentence, mirroring what `part-rocket-ad.php` already does. That keeps one place to change the figure, and a future offer change does not require rewriting a translated string.

### Second commit: text domain fix

`views/part-rocket-ad.php:26` passed `'corporate'` as the text domain instead of `'imagify'`, so "We recommend for you" never matched a translation and always rendered in English regardless of locale.

Unrelated to the copy change and in the other file, but it is a one-word defect found while tracing which banner the ticket meant, and folding it in was agreed rather than opening a separate ticket for it.

### New dependencies

None.

### Risks

- **Translations.** Three strings change, so those fall back to English until retranslated. Unavoidable for a copy change.
- The `20%` figure is now stated in the message rather than the button. If the offer changes, update `$discount_percent` in `views/notice-wp-rocket.php`; the sentence adapts automatically.
- No conditional logic touched, so there is no change to who sees the banner or when.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No automated test added: the change is static translatable text in a view, with no branching to cover. It was verified by rendering the real page and reading the strings back from the DOM, which is stronger evidence here than asserting a string constant against itself.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

*Not applicable: static copy in a view template, no I/O and nothing that can throw.*
